### PR TITLE
Change strategy for auto-generating test user

### DIFF
--- a/config/initializers/gds_sso.rb
+++ b/config/initializers/gds_sso.rb
@@ -9,7 +9,7 @@ GDS::SSO.config do |config|
 end
 
 if Rails.env.development?
-  GDS::SSO.test_user = User.find_or_create_by(name: 'Test User') do |user|
-    user.permissions << User::RESOURCE_MANAGER_PERMISSION
-  end
+  test_user = User.first_or_initialize(name: 'Test User')
+  test_user.permissions << User::RESOURCE_MANAGER_PERMISSION
+  test_user.save!
 end


### PR DESCRIPTION
We need to ensure that the FIRST user always has the resource_manager
permission, not just the user with the name "Test User".