### PR TITLE
Favour seeds over latent user creation

### DIFF
--- a/config/initializers/gds_sso.rb
+++ b/config/initializers/gds_sso.rb
@@ -7,9 +7,3 @@ GDS::SSO.config do |config|
 
   config.cache = Rails.cache
 end
-
-if Rails.env.development?
-  test_user = User.first_or_initialize(name: 'Test User')
-  test_user.permissions << User::RESOURCE_MANAGER_PERMISSION
-  test_user.save!
-end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,6 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+if Rails.env.development?
+  User.first_or_initialize(name: 'Test User').tap do |user|
+    user.permissions << User::RESOURCE_MANAGER_PERMISSION
+    user.save!
+  end
+end


### PR DESCRIPTION
This causes problems when migrating on a freshly minted database.
GDS-SSO's initializer is loaded thus the `User` creation is attempted
and fails since the schema is not yet in place.