### PR TITLE
Remove redundant factory suffix

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,4 +5,4 @@ if Rails.env.development?
   end
 end
 
-FactoryGirl.create_list(:guider_user, 10)
+FactoryGirl.create_list(:guider, 10)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -10,7 +10,7 @@ FactoryGirl.define do
       permissions { Array(User::RESOURCE_MANAGER_PERMISSION) }
     end
 
-    factory :guider_user do
+    factory :guider do
       permissions { Array(User::GUIDER_PERMISSION) }
     end
   end

--- a/spec/features/roles_spec.rb
+++ b/spec/features/roles_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'roles' do
   end
 
   def and_a_guider_with_a_schedule_exists
-    @guider = create(:guider_user)
+    @guider = create(:guider)
     @schedule = @guider.schedules.create!(
       from: 7.weeks.from_now
     )
@@ -24,7 +24,7 @@ RSpec.feature 'roles' do
   end
 
   def and_a_guider_exists
-    @guider = create(:guider_user)
+    @guider = create(:guider)
   end
 
   def then_they_can_manage_guiders_slots

--- a/spec/features/schedules_spec.rb
+++ b/spec/features/schedules_spec.rb
@@ -5,11 +5,11 @@ require 'rails_helper'
 
 RSpec.feature 'schedules' do
   def and_there_is_a_guider
-    @guider = create(:guider_user, name: 'Davey Daverson')
+    @guider = create(:guider, name: 'Davey Daverson')
   end
 
   def and_there_is_a_guider_with_a_schedule
-    @guider = create(:guider_user, name: 'Davey Daverson')
+    @guider = create(:guider, name: 'Davey Daverson')
     @schedule = @guider.schedules.create!(
       from: 7.weeks.from_now
     )

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe User, type: :model do
 
     context 'user with guider permission' do
       it 'is true' do
-        user = build(:guider_user)
+        user = build(:guider)
         expect(user).to be_guider
       end
     end


### PR DESCRIPTION
We know guiders are users so no need for the `_user` suffix.