### PR TITLE
Install `phantomjs` this way instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
   bundler: true
   directories:
   - tmp/cache/assets/test
-  - .phantomjs
 node_js:
 - '0.10'
 before_install:

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ end
 
 group :test do
   gem 'poltergeist'
-  gem 'phantomjs', require: 'phantomjs/poltergeist'
+  gem 'phantomjs-binaries'
   gem 'database_cleaner'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,7 +154,8 @@ GEM
     parser (2.3.1.4)
       ast (~> 2.2)
     pg (0.19.0)
-    phantomjs (2.1.1.0)
+    phantomjs-binaries (2.1.1.1)
+      sys-uname (= 0.9.0)
     pkg-config (1.1.7)
     plek (1.12.0)
     poltergeist (1.10.0)
@@ -257,6 +258,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sys-uname (0.9.0)
+      ffi (>= 1.0.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -302,7 +305,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   momentjs-rails
   pg (~> 0.18)
-  phantomjs
+  phantomjs-binaries
   plek
   poltergeist
   pry-byebug


### PR DESCRIPTION
The other gem uses bitbucket for its CDN and hits the rate limits pretty
quickly and intermittently which is really nice when we're trying to get
our builds to run in CI.