### PR TITLE
Fix error where rails could not load on production

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,16 @@ require_relative 'config/application'
 
 Rails.application.load_tasks
 
-task default:  [:spec, :rubocop, :"js:lint"]
+default_tasks = [:spec]
+
+begin
+  # Rubocop is not available in envs other than development and test.
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new
+  default_tasks << :rubocop
+rescue LoadError
+end
+
+default_tasks << :'js:lint'
+
+task default: default_tasks

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,2 +1,0 @@
-require 'rubocop/rake_task'
-RuboCop::RakeTask.new


### PR DESCRIPTION
Rubocop is not loaded in environments other than development or test, so
we can't load the rake task.