### PR TITLE
Toggle javascript 'ready' event based on Turbolinks support

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,9 @@
 <% content_for :body_end do %>
   <script>
   var loadedModules = [];
-  $(document).on('turbolinks:load', function() {
+  var readyEvent = Turbolinks.supported ? 'turbolinks:load' : 'ready';
+
+  $(document).on(readyEvent, function() {
     var modules = $('[data-module]');
 
     if (loadedModules.length) {


### PR DESCRIPTION
The HTML5 History API is required for Turbolinks. This change checks if Turbolinks is being run in a supported browser and toggles the event we wait to boot the javascript with accordingly.