### PR TITLE
Lock dependencies per gem source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,50 +1,53 @@
-source 'https://rubygems.org'
-
 ruby IO.read('.ruby-version').strip
 
-gem 'rails', '~> 5.0.0', '>= 5.0.0.1'
-gem 'pg', '~> 0.18'
-gem 'puma', '~> 3.0'
-gem 'sass-rails', '~> 5.0'
-gem 'uglifier', '>= 1.3.0'
-gem 'govuk_admin_template'
-gem 'turbolinks', '~> 5'
-gem 'sprockets-es6'
-gem 'gds-sso'
-gem 'plek'
-gem 'fullcalendar-rails'
-gem 'momentjs-rails'
-gem 'rails-assets-listjs', source: 'https://rails-assets.org'
-gem 'rails-assets-zloirock--core-js', source: 'https://rails-assets.org'
-gem 'bootstrap-daterangepicker-rails'
-gem 'active_link_to'
-gem 'foreman'
-
-group :development, :test do
-  gem 'pry-byebug'
-  gem 'rspec-rails'
-  gem 'factory_girl_rails', '~> 4.0'
-  gem 'capybara'
-  gem 'faker'
-  gem 'launchy'
-  gem 'site_prism'
-  gem 'rubocop'
+source 'https://rails-assets.org' do
+  gem 'rails-assets-listjs'
+  gem 'rails-assets-zloirock--core-js'
 end
 
-group :test do
-  gem 'poltergeist'
-  gem 'phantomjs-binaries'
-  gem 'database_cleaner'
-end
+source 'https://rubygems.org' do
+  gem 'rails', '~> 5.0.0', '>= 5.0.0.1'
+  gem 'pg', '~> 0.18'
+  gem 'puma', '~> 3.0'
+  gem 'sass-rails', '~> 5.0'
+  gem 'uglifier', '>= 1.3.0'
+  gem 'govuk_admin_template'
+  gem 'turbolinks', '~> 5'
+  gem 'sprockets-es6'
+  gem 'gds-sso'
+  gem 'plek'
+  gem 'fullcalendar-rails'
+  gem 'momentjs-rails'
+  gem 'bootstrap-daterangepicker-rails'
+  gem 'active_link_to'
+  gem 'foreman'
 
-group :development do
-  gem 'web-console'
-  gem 'listen', '~> 3.0.5'
-  gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
-end
+  group :development, :test do
+    gem 'pry-byebug'
+    gem 'rspec-rails'
+    gem 'factory_girl_rails', '~> 4.0'
+    gem 'capybara'
+    gem 'faker'
+    gem 'launchy'
+    gem 'site_prism'
+    gem 'rubocop'
+  end
 
-group :staging, :production do
-  gem 'bugsnag'
-  gem 'rails_12factor'
+  group :test do
+    gem 'poltergeist'
+    gem 'phantomjs-binaries'
+    gem 'database_cleaner'
+  end
+
+  group :development do
+    gem 'web-console'
+    gem 'listen', '~> 3.0.5'
+    gem 'spring'
+    gem 'spring-watcher-listen', '~> 2.0.0'
+  end
+
+  group :staging, :production do
+    gem 'bugsnag'
+    gem 'rails_12factor'
+  end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GEM
-  remote: https://rubygems.org/
   remote: https://rails-assets.org/
+  remote: https://rubygems.org/
   specs:
     actioncable (5.0.0.1)
       actionpack (= 5.0.0.1)
@@ -291,40 +291,40 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  active_link_to
-  bootstrap-daterangepicker-rails
-  bugsnag
-  capybara
-  database_cleaner
-  factory_girl_rails (~> 4.0)
-  faker
-  foreman
-  fullcalendar-rails
-  gds-sso
-  govuk_admin_template
-  launchy
-  listen (~> 3.0.5)
-  momentjs-rails
-  pg (~> 0.18)
-  phantomjs-binaries
-  plek
-  poltergeist
-  pry-byebug
-  puma (~> 3.0)
-  rails (~> 5.0.0, >= 5.0.0.1)
+  active_link_to!
+  bootstrap-daterangepicker-rails!
+  bugsnag!
+  capybara!
+  database_cleaner!
+  factory_girl_rails (~> 4.0)!
+  faker!
+  foreman!
+  fullcalendar-rails!
+  gds-sso!
+  govuk_admin_template!
+  launchy!
+  listen (~> 3.0.5)!
+  momentjs-rails!
+  pg (~> 0.18)!
+  phantomjs-binaries!
+  plek!
+  poltergeist!
+  pry-byebug!
+  puma (~> 3.0)!
+  rails (~> 5.0.0, >= 5.0.0.1)!
   rails-assets-listjs!
   rails-assets-zloirock--core-js!
-  rails_12factor
-  rspec-rails
-  rubocop
-  sass-rails (~> 5.0)
-  site_prism
-  spring
-  spring-watcher-listen (~> 2.0.0)
-  sprockets-es6
-  turbolinks (~> 5)
-  uglifier (>= 1.3.0)
-  web-console
+  rails_12factor!
+  rspec-rails!
+  rubocop!
+  sass-rails (~> 5.0)!
+  site_prism!
+  spring!
+  spring-watcher-listen (~> 2.0.0)!
+  sprockets-es6!
+  turbolinks (~> 5)!
+  uglifier (>= 1.3.0)!
+  web-console!
 
 RUBY VERSION
    ruby 2.3.1p112


### PR DESCRIPTION
This works around a particularly nasty CVE in bundler that means source
resolution is non-deterministic when multiple gem sources exist.

See:

http://collectiveidea.com/blog/archives/2016/10/06/bundlers-multiple-source-security-vulnerability/