### PR TITLE
Schedule default start is (six weeks + one day)

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -3,9 +3,7 @@ class SchedulesController < ApplicationController
   before_action :load_current_guider
 
   def new
-    @schedule = @guider.schedules.build(
-      start_at: 6.weeks.from_now
-    )
+    @schedule = @guider.schedules.build
     @slots_as_json = slots_as_json
   end
 

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -14,6 +14,11 @@ class Schedule < ApplicationRecord
       .last
   end
 
+  after_initialize :set_default_start_at
+  def set_default_start_at
+    self.start_at ||= 6.weeks.from_now + 1.day
+  end
+
   def end_at
     self[:end_at] - 1.second if self[:end_at]
   end

--- a/spec/features/resource_manager_manages_schedules_spec.rb
+++ b/spec/features/resource_manager_manages_schedules_spec.rb
@@ -47,27 +47,6 @@ RSpec.feature 'Resource manager manages schedules' do
     end
   end
 
-  scenario 'Fails to create a schedule with invalid start_at date' do
-    given_the_user_is_a_resource_manager do
-      and_there_is_a_guider
-      and_they_add_a_new_schedule
-      and_they_enter_an_invalid_start_at_date
-      when_they_save_the_users_time_slots
-      then_they_are_shown_an_error
-    end
-  end
-
-  scenario 'Fails to update a schedule with invalid start_at date' do
-    given_the_user_is_a_resource_manager do
-      and_there_is_a_guider
-      and_the_guider_has_a_schedule_that_can_be_modified
-      and_they_edit_the_schedule
-      and_they_enter_an_invalid_start_at_date
-      when_they_save_the_users_time_slots
-      then_they_are_shown_an_error
-    end
-  end
-
   scenario 'Fails to edit a schedule' do
     given_the_user_is_a_resource_manager do
       and_there_is_a_guider
@@ -195,15 +174,6 @@ RSpec.feature 'Resource manager manages schedules' do
       end_hour: 11,
       end_minute: 40
     )
-  end
-
-  def and_they_enter_an_invalid_start_at_date
-    @page.start_at.set 'something not datey'
-  end
-
-  def then_they_are_shown_an_error
-    expect(@page).to have_error_summary
-    expect(@page).to have_errors
   end
 
   def and_they_delete_the_schedule

--- a/spec/support/pages/edit_schedule.rb
+++ b/spec/support/pages/edit_schedule.rb
@@ -2,9 +2,6 @@ module Pages
   class EditSchedule < SitePrism::Page
     set_url '/users/{user_id}/schedules/{id}/edit'
 
-    elements :errors, '.field_with_errors'
-    element :error_summary, '.t-errors'
-
     element(
       :permission_error_message,
       'h1',

--- a/spec/support/pages/new_schedule.rb
+++ b/spec/support/pages/new_schedule.rb
@@ -2,9 +2,6 @@ module Pages
   class NewSchedule < SitePrism::Page
     set_url '/users/{user_id}/schedules/new'
 
-    elements :errors, '.field_with_errors'
-    element :error_summary, '.t-errors'
-
     element :save, '.t-save'
     element :start_at, '.t-start-at'
   end


### PR DESCRIPTION
This is because when we create a new schedule, we still want to be able
to edit that schedule today.

https://trello.com/c/GRqNIx44/116-guiders-cannot-have-more-than-one-schedule-starting-on-the-same-date