### PR TITLE
Ensure Schedule#start_at is unique per user

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -5,6 +5,7 @@ class Schedule < ApplicationRecord
   scope :by_start_at, -> { order(:start_at) }
 
   validates :start_at, presence: true
+  validates :start_at, uniqueness: { scope: :user_id }
   validate :start_at_must_be_more_than_six_weeks_in_the_future, unless: :first_schedule?
 
   def end_at

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -3,6 +3,26 @@ require 'rails_helper'
 RSpec.describe Schedule, type: :model do
   describe 'validation' do
     context '#start_at' do
+      it 'is unique per user' do
+        same_time = Time.zone.now
+        same_user = create(:guider)
+        create(
+          :schedule,
+          user: same_user,
+          start_at: same_time
+        )
+
+        schedule = build(
+          :schedule,
+          user: same_user,
+          start_at: same_time
+        )
+        expect(schedule).to_not be_valid
+
+        schedule.user = create(:guider)
+        expect(schedule).to be_valid
+      end
+
       context 'first schedule' do
         let(:user) do
           create(:user)

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -47,20 +47,20 @@ RSpec.describe Schedule, type: :model do
         end
       end
     end
+  end
 
-    describe '#modifiable?' do
-      context 'schedule starts less than six weeks from now' do
-        it 'is false' do
-          schedule = build_stubbed(:schedule, start_at: 5.weeks.from_now)
-          expect(schedule).to_not be_modifiable
-        end
+  describe '#modifiable?' do
+    context 'schedule starts less than six weeks from now' do
+      it 'is false' do
+        schedule = build_stubbed(:schedule, start_at: 5.weeks.from_now)
+        expect(schedule).to_not be_modifiable
       end
+    end
 
-      context 'schedule starts more than six weeks from now' do
-        it 'is true' do
-          schedule = build_stubbed(:schedule, start_at: 7.weeks.from_now)
-          expect(schedule).to be_modifiable
-        end
+    context 'schedule starts more than six weeks from now' do
+      it 'is true' do
+        schedule = build_stubbed(:schedule, start_at: 7.weeks.from_now)
+        expect(schedule).to be_modifiable
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/GRqNIx44/116-guiders-cannot-have-more-than-one-schedule-starting-on-the-same-date

Also, slight refactor of schedules spec. Only review the second commit.