### PR TITLE
Force a sort on initialisation of sortable list

### DIFF
--- a/app/assets/javascripts/sortable-list.es6
+++ b/app/assets/javascripts/sortable-list.es6
@@ -15,6 +15,7 @@
     init() {
       // using listjs
       this.list = new List(this.$el.attr('id'), this.config);
+      this.orderList();
     }
 
     bindEvents() {
@@ -29,6 +30,14 @@
       this.$el.find('.sort').each(function() {
         $(this).replaceWith($(this)[0].outerHTML.replace('span', 'button'));
       });
+    }
+
+    orderList() {
+      const defaultOrder = this.$el.data('default-order');
+
+      if (defaultOrder) {
+        this.list.sort(defaultOrder.value, { order: defaultOrder.order });
+      }
     }
   }
 

--- a/app/helpers/multi_guider_helper.rb
+++ b/app/helpers/multi_guider_helper.rb
@@ -1,0 +1,11 @@
+module MultiGuiderHelper
+  def sortable_list_config(groups)
+    value_names = ['name']
+
+    groups.each do |group|
+      value_names << dom_id(group)
+    end
+
+    { valueNames: value_names }.to_json
+  end
+end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Manage Guiders</h1>
 
 <div data-module="GuidersMultiAction">
-  <div id="guiders" data-module="SortableList" data-config='{"valueNames": ["name", <%= @groups.map { |group| "\"#{dom_id(group)}\"" }.join(', ') %>]}'>
+  <div id="guiders" data-module="SortableList" data-default-order='{"value": "name", "order": "asc"}' data-config='<%= sortable_list_config(@groups) %>'>
     <form class="form-inline">
       <div class="form-group">
         <label for="user-search">Search</label>


### PR DESCRIPTION
- this fixes an issue when you click the 'name' header for
  the first time and it doesn't sort as the list is already
  sorted A-Z in the DOM when it's initialised
- fixed a bug in the config for the sortable list
  when there is no groups (trailing comma)