### PR TITLE
Fix bug where guider availability > 30 caused an error

### DIFF
--- a/app/assets/javascripts/calendars/appointment-availability.es6
+++ b/app/assets/javascripts/calendars/appointment-availability.es6
@@ -60,11 +60,11 @@
       super(el, calendarConfig);
 
       this.coloursConfig = [
-        { count: 30, colour: 'hsl(200, 50%, 25%)' },
-        { count: 20, colour: 'hsl(200, 50%, 35%)' },
-        { count: 10, colour: 'hsl(200, 50%, 45%)' },
+        { count: 1,  colour: 'hsl(200, 50%, 65%)' },
         { count: 5,  colour: 'hsl(200, 50%, 55%)' },
-        { count: 1,  colour: 'hsl(200, 50%, 65%)' }
+        { count: 10, colour: 'hsl(200, 50%, 45%)' },
+        { count: 20, colour: 'hsl(200, 50%, 35%)' },
+        { count: 30, colour: 'hsl(200, 50%, 25%)' },
       ];
 
       this.init();
@@ -77,7 +77,7 @@
       }
 
       const colours = $.grep(this.coloursConfig, (configItem) => {
-        if (configItem.count >= event.guiders) {
+        if (configItem.count <= event.guiders) {
           return configItem.colour;
         }
       });


### PR DESCRIPTION
- any guider availability count over 30 caused a JS error
  and the event failed to render on the availibility calendar