### PR TITLE
Appointments cannot be booked < 2 working days, > 30 working days

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ source 'https://rubygems.org' do
   gem 'sidekiq'
   gem 'sinatra', require: false
   gem 'select2-rails'
+  gem 'business_time'
 
   group :development, :test do
     gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,9 @@ GEM
       sass (>= 3.3.0)
     bugsnag (5.0.1)
     builder (3.2.2)
+    business_time (0.7.6)
+      activesupport (>= 3.1.0)
+      tzinfo
     byebug (9.0.6)
     capybara (2.10.1)
       addressable
@@ -316,6 +319,7 @@ DEPENDENCIES
   bh!
   bootstrap-daterangepicker-rails!
   bugsnag!
+  business_time!
   capybara!
   database_cleaner!
   factory_girl_rails (~> 4.0)!

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -9,6 +9,9 @@ class Appointment < ApplicationRecord
   validates :memorable_word, presence: true
   validates :where_did_you_hear_about_pension_wise, presence: true
 
+  validate :not_within_two_business_days
+  validate :not_more_than_thirty_business_days_in_future
+
   def assign_to_guider
     slot = BookableSlot
            .without_appointments
@@ -16,5 +19,21 @@ class Appointment < ApplicationRecord
            .sample(1)
            .first
     self.guider = slot.guider if slot
+  end
+
+  private
+
+  def not_within_two_business_days
+    return unless start_at
+
+    days_until = Time.zone.now.to_date.business_days_until(start_at)
+    errors.add(:start_at, 'must be more than two business days from now') if days_until <= 2
+  end
+
+  def not_more_than_thirty_business_days_in_future
+    return unless start_at
+
+    days_until = Time.zone.now.to_date.business_days_until(start_at)
+    errors.add(:start_at, 'must be less than thirty business days from now') if days_until >= 30
   end
 end

--- a/config/business_time.yml
+++ b/config/business_time.yml
@@ -1,0 +1,10 @@
+business_time:
+  beginning_of_workday: 8:00 am
+  end_of_workday: 5:30 pm
+  holidays:
+  work_week:
+    - mon
+    - tue
+    - wed
+    - thu
+    - fri

--- a/config/initializers/business_time.rb
+++ b/config/initializers/business_time.rb
@@ -1,0 +1,1 @@
+BusinessTime::Config.load("#{Rails.root}/config/business_time.yml")

--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :appointment do
-    start_at { Time.zone.now }
-    end_at { Time.zone.now + 1.hour }
+    start_at { 5.days.from_now }
+    end_at { 5.days.from_now + 1.hour }
     first_name { Faker::Name.name }
     last_name { Faker::Name.name }
     phone '932009320'

--- a/spec/features/contact_centre_agent_creates_appointments_spec.rb
+++ b/spec/features/contact_centre_agent_creates_appointments_spec.rb
@@ -2,6 +2,8 @@
 require 'rails_helper'
 
 RSpec.feature 'Agent creates appointments' do
+  let(:day) { 5.business_days.from_now }
+
   scenario 'Creates an appointment' do
     given_the_user_is_an_agent do
       and_there_is_a_guider_with_available_slots
@@ -14,14 +16,14 @@ RSpec.feature 'Agent creates appointments' do
     @guider = create(:guider)
     @slot = build(
       :slot,
-      day_of_week: Time.zone.now.wday,
+      day_of_week: day.wday,
       start_hour: 9,
       start_minute: 30,
       end_hour: 10,
       end_minute: 40
     )
     @schedule = @guider.schedules.build(
-      start_at: Time.zone.now.beginning_of_day,
+      start_at: day.beginning_of_day,
       slots: [@slot]
     )
     @schedule.save!
@@ -44,8 +46,8 @@ RSpec.feature 'Agent creates appointments' do
     @page.opt_out_of_market_research.set true
     @page.where_did_you_hear_about_pension_wise.select 'Radio advert'
     @page.who_is_your_pension_provider.select 'Scottish Widows'
-    @page.start_at.set Time.zone.now.change(hour: 9, min: 30).to_s
-    @page.end_at.set Time.zone.now.change(hour: 10, min: 40).to_s
+    @page.start_at.set day.change(hour: 9, min: 30).to_s
+    @page.end_at.set day.change(hour: 10, min: 40).to_s
 
     @page.save.click
   end
@@ -67,7 +69,7 @@ RSpec.feature 'Agent creates appointments' do
     expect(appointment.opt_out_of_market_research).to eq true
     expect(appointment.where_did_you_hear_about_pension_wise).to eq 'Radio advert'
     expect(appointment.who_is_your_pension_provider).to eq 'Scottish Widows'
-    expect(appointment.start_at).to eq Time.zone.now.change(hour: 9, min: 30).to_s
-    expect(appointment.end_at).to eq Time.zone.now.change(hour: 10, min: 40).to_s
+    expect(appointment.start_at).to eq day.change(hour: 9, min: 30).to_s
+    expect(appointment.end_at).to eq day.change(hour: 10, min: 40).to_s
   end
 end

--- a/spec/models/bookable_slot_spec.rb
+++ b/spec/models/bookable_slot_spec.rb
@@ -1,6 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe BookableSlot, type: :model do
+  def make_time(hour, minute)
+    5
+      .business_days
+      .from_now
+      .change(hour: hour, min: minute)
+  end
+
+  def result
+    BookableSlot.with_guider_count(
+      5.business_days.ago,
+      10.business_day.from_now
+    )
+  end
+
   describe '#with_guider_count' do
     context 'three guiders with bookable slots' do
       before do
@@ -10,23 +24,18 @@ RSpec.describe BookableSlot, type: :model do
           create(
             :bookable_slot,
             guider: guider,
-            start_at: DateTime.new(2022, 12, 9, 10, 30, 0).in_time_zone,
-            end_at: DateTime.new(2022, 12, 9, 11, 30, 0).in_time_zone
+            start_at: make_time(10, 30),
+            end_at: make_time(11, 30)
           )
         end
       end
 
       it 'returns bookable slots' do
-        result = BookableSlot.with_guider_count(
-          Date.new(2022, 12, 5),
-          Date.new(2022, 12, 20)
-        )
-
         expect(result).to eq(
           [
             guiders: 3,
-            start: DateTime.new(2022, 12, 9, 10, 30, 0).in_time_zone,
-            end: DateTime.new(2022, 12, 9, 11, 30, 0).in_time_zone
+            start: make_time(10, 30),
+            end: make_time(11, 30)
           ]
         )
       end
@@ -36,20 +45,15 @@ RSpec.describe BookableSlot, type: :model do
           create(
             :appointment,
             guider: User.guiders.first,
-            start_at: DateTime.new(2022, 12, 9, 10, 30, 0).in_time_zone,
-            end_at: DateTime.new(2022, 12, 9, 11, 30, 0).in_time_zone
-          )
-
-          result = BookableSlot.with_guider_count(
-            Date.new(2022, 12, 5),
-            Date.new(2022, 12, 20)
+            start_at: make_time(10, 30),
+            end_at: make_time(11, 30)
           )
 
           expect(result).to eq(
             [
               guiders: 2,
-              start: DateTime.new(2022, 12, 9, 10, 30, 0).in_time_zone,
-              end: DateTime.new(2022, 12, 9, 11, 30, 0).in_time_zone
+              start: make_time(10, 30),
+              end: make_time(11, 30)
             ]
           )
         end


### PR DESCRIPTION
Not taking into account bank holidays at the moment, which should be
worked on when we do the non-working-days feature.

This should abide by the rules mentioned here:
https://trello.com/c/XZoLbCJZ/119-appointment-booking-part-2