### PR TITLE
Customers can attempt an appointment and either be eligible or not

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,6 +17,7 @@
 //= require daterangepicker
 //= require core.js/core.js
 //= require calendar
+//= require customer-age
 //= require calendars/appointment-availability
 //= require calendars/guider-slot-picker
 //= require select2

--- a/app/assets/javascripts/customer-age.es6
+++ b/app/assets/javascripts/customer-age.es6
@@ -1,0 +1,33 @@
+/* global moment */
+{
+  'use strict';
+
+  class CustomerAge {
+    constructor(el, config = {}) {
+      this.$el = el;
+      this.config = config;
+
+      this.bindEvents();
+    }
+
+    renderCustomerAge() {
+      var $output = $(this.$el.data('output'));
+      var val = this.$el.val();
+
+      if (val) {
+        var age = moment(val).month(0).from(moment().month(0));
+        $output.text('Customer was born ' + age);
+      } else {
+        $output.text('');
+      }
+    }
+
+    bindEvents() {
+      this.$el.on('change', this.renderCustomerAge.bind(this));
+      this.renderCustomerAge();
+    }
+  }
+
+  window.PWTAP = window.PWTAP || {};
+  window.PWTAP.CustomerAge = CustomerAge;
+}

--- a/app/controllers/appointment_attempts_controller.rb
+++ b/app/controllers/appointment_attempts_controller.rb
@@ -1,0 +1,40 @@
+class AppointmentAttemptsController < ApplicationController
+  before_action :authorise_for_agents!
+
+  def new
+    @appointment_attempt = AppointmentAttempt.new
+  end
+
+  def create
+    @appointment_attempt = AppointmentAttempt.new(appointment_attempt_params)
+    if @appointment_attempt.save
+      if @appointment_attempt.eligible?
+        redirect_to new_appointment_attempt_appointment_path(@appointment_attempt)
+      else
+        redirect_to ineligible_appointment_attempts_path
+      end
+    else
+      render :new
+    end
+  end
+
+  def ineligible
+  end
+
+  private
+
+  def appointment_attempt_params
+    params
+      .require(:appointment_attempt)
+      .permit(
+        :first_name,
+        :last_name,
+        :date_of_birth,
+        :defined_contribution_pot
+      )
+  end
+
+  def authorise_for_agents!
+    authorise_user!(User::AGENT_PERMISSION)
+  end
+end

--- a/app/models/appointment_attempt.rb
+++ b/app/models/appointment_attempt.rb
@@ -1,0 +1,9 @@
+class AppointmentAttempt < ApplicationRecord
+  validates :first_name, presence: true
+  validates :last_name, presence: true
+  validates :date_of_birth, presence: true
+
+  def eligible?
+    defined_contribution_pot? && ((date_of_birth + 50.years) < Time.zone.today)
+  end
+end

--- a/app/views/appointment_attempts/ineligible.html.erb
+++ b/app/views/appointment_attempts/ineligible.html.erb
@@ -1,0 +1,3 @@
+<div class='t-ineligible-message'>
+  This customer is ineligible for a phone appointment.
+</div>

--- a/app/views/appointment_attempts/new.html.erb
+++ b/app/views/appointment_attempts/new.html.erb
@@ -1,0 +1,9 @@
+<h1>Book an appointment</h1>
+
+<%= form_for @appointment_attempt, layout: :basic do |f| %>
+  <%= f.text_field :first_name, class: 't-first-name' %>
+  <%= f.text_field :last_name, class: 't-last-name' %>
+  <%= f.date_field :date_of_birth, class: 't-date-of-birth' %>
+  <%= f.check_box :defined_contribution_pot, class: 't-defined-contribution-pot' %>
+  <%= f.submit 'Next', class: 't-next' %>
+<% end %>

--- a/app/views/appointment_attempts/new.html.erb
+++ b/app/views/appointment_attempts/new.html.erb
@@ -3,7 +3,9 @@
 <%= form_for @appointment_attempt, layout: :basic do |f| %>
   <%= f.text_field :first_name, class: 't-first-name' %>
   <%= f.text_field :last_name, class: 't-last-name' %>
-  <%= f.date_field :date_of_birth, class: 't-date-of-birth' %>
+  <%= f.date_field :date_of_birth, class: 't-date-of-birth', data: { module: 'CustomerAge', output: '.js-customer-age' } %>
+  <div class="bg-info js-customer-age">
+  </div>
   <%= f.check_box :defined_contribution_pot, class: 't-defined-contribution-pot' %>
   <%= f.submit 'Next', class: 't-next' %>
 <% end %>

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -1,6 +1,6 @@
-<h1>Create new appointment</h1>
+<h1>Book an appointment</h1>
 
-<%= form_for @appointment, layout: :basic do |f| %>
+<%= form_for [@appointment_attempt, @appointment], layout: :basic do |f| %>
   <div class="row form-group">
     <div class="col-md-12">
       <h2>Choose available slot</h2>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,7 @@
     <%= active_link_to 'Manage guiders', users_path, wrap_tag: :li %>
   <% end %>
   <% if current_user.agent? %>
-    <%= active_link_to 'Create appointments', new_appointment_path, wrap_tag: :li %>
+    <%= active_link_to 'Book appointment', new_appointment_attempt_path, wrap_tag: :li %>
   <% end %>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,10 @@ Rails.application.routes.draw do
   end
 
   resources :groups, only: %i(index create destroy)
-  resources :appointments
+  resources :appointment_attempts do
+    get 'ineligible', on: :collection
+    resources :appointments
+  end
   resources :customers
 
   resources :groups, only: %i(index destroy)

--- a/db/migrate/20161014111858_create_appointment_attempts.rb
+++ b/db/migrate/20161014111858_create_appointment_attempts.rb
@@ -1,0 +1,11 @@
+class CreateAppointmentAttempts < ActiveRecord::Migration[5.0]
+  def change
+    create_table :appointment_attempts do |t|
+      t.string :first_name, null: false
+      t.string :last_name, null: false
+      t.date :date_of_birth, null: false
+      t.boolean :defined_contribution_pot, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161012143328) do
+ActiveRecord::Schema.define(version: 20161014111858) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "appointment_attempts", force: :cascade do |t|
+    t.string   "first_name",               null: false
+    t.string   "last_name",                null: false
+    t.date     "date_of_birth",            null: false
+    t.boolean  "defined_contribution_pot", null: false
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+  end
 
   create_table "appointments", force: :cascade do |t|
     t.integer  "guider_id",                                             null: false

--- a/spec/factories/appointment_attempts.rb
+++ b/spec/factories/appointment_attempts.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :appointment_attempt do
+    first_name { Faker::Name.name }
+    last_name { Faker::Name.name }
+    date_of_birth { 50.years.ago }
+    defined_contribution_pot true
+  end
+end

--- a/spec/features/roles_spec.rb
+++ b/spec/features/roles_spec.rb
@@ -27,6 +27,13 @@ RSpec.feature 'Roles' do
   end
 
   context 'Agents' do
+    scenario 'Can attempt appointments' do
+      given_the_user_is_an_agent do
+        when_they_try_to_attempt_an_appointment
+        then_they_are_allowed
+      end
+    end
+
     scenario 'Can book appointments' do
       given_the_user_is_an_agent do
         when_they_try_to_book_an_appointment
@@ -36,6 +43,13 @@ RSpec.feature 'Roles' do
   end
 
   context 'Users who are not Agents' do
+    scenario 'Can not attempt appointments' do
+      given_the_user_has_no_permissions do
+        when_they_try_to_attempt_an_appointment
+        then_they_are_locked_out
+      end
+    end
+
     scenario 'Can not book appointments' do
       given_the_user_has_no_permissions do
         when_they_try_to_book_an_appointment
@@ -109,8 +123,14 @@ RSpec.feature 'Roles' do
     expect(@page).to_not have_permission_error_message
   end
 
-  def when_they_try_to_book_an_appointment
-    @page = Pages::NewAppointment.new
+  def when_they_try_to_attempt_an_appointment
+    @page = Pages::NewAppointmentAttempt.new
     @page.load
+  end
+
+  def when_they_try_to_book_an_appointment
+    appointment_attempt = create(:appointment_attempt)
+    @page = Pages::NewAppointment.new
+    @page.load(appointment_attempt_id: appointment_attempt.id)
   end
 end

--- a/spec/models/appointment_attempt_spec.rb
+++ b/spec/models/appointment_attempt_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe AppointmentAttempt, type: :model do
+  describe 'validations' do
+    let(:subject) do
+      build_stubbed(:appointment_attempt)
+    end
+
+    it 'is valid with valid parameters' do
+      expect(subject).to be_valid
+    end
+
+    required = [
+      :first_name,
+      :last_name,
+      :date_of_birth
+    ]
+    required.each do |field|
+      it "validate presence of #{field}" do
+        subject.public_send("#{field}=", nil)
+        subject.validate
+        expect(subject.errors[field]).to_not be_empty
+      end
+    end
+  end
+
+  describe '#eligible?' do
+    context 'customers that are 50 or older' do
+      before { subject.date_of_birth = 60.years.ago }
+
+      context 'that have a defined contribution pot' do
+        before { subject.defined_contribution_pot = true }
+
+        it 'is true' do
+          expect(subject).to be_eligible
+        end
+      end
+      context 'that do not have a defined contribution pot' do
+        before { subject.defined_contribution_pot = false }
+
+        it 'is false' do
+          expect(subject).to_not be_eligible
+        end
+      end
+    end
+
+    context 'customers that are younger than 50' do
+      before { subject.date_of_birth = 10.years.ago }
+
+      context 'that have a defined contribution pot' do
+        before { subject.defined_contribution_pot = true }
+
+        it 'is false' do
+          expect(subject).to_not be_eligible
+        end
+      end
+      context 'that do not have a defined contribution pot' do
+        before { subject.defined_contribution_pot = false }
+
+        it 'is false' do
+          expect(subject).to_not be_eligible
+        end
+      end
+    end
+  end
+end

--- a/spec/support/pages/new_appointment.rb
+++ b/spec/support/pages/new_appointment.rb
@@ -1,6 +1,6 @@
 module Pages
   class NewAppointment < SitePrism::Page
-    set_url '/appointments/new'
+    set_url '/appointment_attempts/{appointment_attempt_id}/appointments/new'
 
     element(
       :permission_error_message,

--- a/spec/support/pages/new_appointment_attempt.rb
+++ b/spec/support/pages/new_appointment_attempt.rb
@@ -1,0 +1,18 @@
+module Pages
+  class NewAppointmentAttempt < SitePrism::Page
+    set_url '/appointment_attempts/new'
+
+    element(
+      :permission_error_message,
+      'h1',
+      text: 'Sorry, you don\'t seem to have the agent permission for this app.'
+    )
+    element :ineligible_message,       '.t-ineligible-message'
+
+    element :first_name,               '.t-first-name'
+    element :last_name,                '.t-last-name'
+    element :date_of_birth,            '.t-date-of-birth'
+    element :defined_contribution_pot, '.t-defined-contribution-pot'
+    element :next,                     '.t-next'
+  end
+end


### PR DESCRIPTION
- Seperate page to take first_name, last_name, date_of_birth, and
defined_contribution_pension.
- If they are not eligible the agent is told.
- If they are then they can continue to book an appointment as usual.

![https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-14-10-2016-17-06-48-thefahph.png](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-14-10-2016-17-06-48-thefahph.png)

![https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-14-10-2016-16-46-11-eekuiqui.png](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-14-10-2016-16-46-11-eekuiqui.png)

(note that those fields are prefilled)

![https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-14-10-2016-16-46-41-iengahke.png](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-14-10-2016-16-46-41-iengahke.png)