### PR TITLE
Resource managers can view holidays

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,6 +23,7 @@
 //= require calendars/appointment-availability
 //= require calendars/guider-slot-picker
 //= require calendars/guider-appointments
+//= require calendars/holidays
 //= require select2
 //= require advanced-select
 //= require_tree .

--- a/app/assets/javascripts/calendars/holidays.es6
+++ b/app/assets/javascripts/calendars/holidays.es6
@@ -10,6 +10,7 @@
         columnFormat: 'ddd D/M',
         slotDuration: '00:30:00',
         eventBorderColor: '#000',
+        events: '/holidays',
         header: {
           'right': 'agendaWeek agendaThreeDay agendaDay today prev,next'
         },
@@ -22,16 +23,6 @@
       }, config);
 
       super(el, calendarConfig);
-
-      this.init();
-    }
-
-    handleEventData(data) {
-      this.$el.fullCalendar('addEventSource', data);
-    }
-
-    init() {
-      $.getJSON('/holidays', this.handleEventData.bind(this));
     }
   }
 

--- a/app/assets/javascripts/calendars/holidays.es6
+++ b/app/assets/javascripts/calendars/holidays.es6
@@ -1,0 +1,40 @@
+/* global Calendar */
+{
+  'use strict';
+
+  class HolidaysCalendar extends Calendar {
+    constructor(el, config = {}) {
+      const calendarConfig = $.extend(true, {
+        defaultView: 'agendaWeek',
+        weekends: false,
+        columnFormat: 'ddd D/M',
+        slotDuration: '00:30:00',
+        eventBorderColor: '#000',
+        header: {
+          'right': 'agendaWeek agendaThreeDay agendaDay today prev,next'
+        },
+        views: {
+          agendaThreeDay: {
+            type: 'agenda',
+            duration: { days: 3 }
+          }
+        }
+      }, config);
+
+      super(el, calendarConfig);
+
+      this.init();
+    }
+
+    handleEventData(data) {
+      this.$el.fullCalendar('addEventSource', data);
+    }
+
+    init() {
+      $.getJSON('/holidays', this.handleEventData.bind(this));
+    }
+  }
+
+  window.PWTAP = window.PWTAP || {};
+  window.PWTAP.HolidaysCalendar = HolidaysCalendar;
+}

--- a/app/controllers/holidays_controller.rb
+++ b/app/controllers/holidays_controller.rb
@@ -1,0 +1,12 @@
+class HolidaysController < ApplicationController
+  before_action :authorise_for_managing_resources!
+
+  def index
+  end
+
+  private
+
+  def authorise_for_managing_resources!
+    authorise_user!(User::RESOURCE_MANAGER_PERMISSION)
+  end
+end

--- a/app/controllers/holidays_controller.rb
+++ b/app/controllers/holidays_controller.rb
@@ -2,6 +2,12 @@ class HolidaysController < ApplicationController
   before_action :authorise_for_managing_resources!
 
   def index
+    respond_to do |format|
+      format.html
+      format.json do
+        render json: Holiday.merged_for_calendar_view
+      end
+    end
   end
 
   private

--- a/app/jobs/generate_bank_holidays_job.rb
+++ b/app/jobs/generate_bank_holidays_job.rb
@@ -1,0 +1,19 @@
+class GenerateBankHolidaysJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    require 'open-uri'
+    response = open('https://www.gov.uk/bank-holidays.json').read
+    holidays = JSON.parse(response).with_indifferent_access
+    events = holidays['england-and-wales'][:events]
+    events.each do |event|
+      date = Date.parse(event[:date])
+      logger.info "Adding holiday '#{event[:title]}' on '#{date}'"
+      Holiday.find_or_create_by!(
+        title: event[:title],
+        start_at: date.beginning_of_day,
+        end_at: date.end_of_day
+      )
+    end
+  end
+end

--- a/app/jobs/generate_bank_holidays_job.rb
+++ b/app/jobs/generate_bank_holidays_job.rb
@@ -2,18 +2,23 @@ class GenerateBankHolidaysJob < ApplicationJob
   queue_as :default
 
   def perform
-    require 'open-uri'
-    response = open('https://www.gov.uk/bank-holidays.json').read
-    holidays = JSON.parse(response).with_indifferent_access
-    events = holidays['england-and-wales'][:events]
-    events.each do |event|
-      date = Date.parse(event[:date])
-      logger.info "Adding holiday '#{event[:title]}' on '#{date}'"
+    retrieve_holidays.each do |holiday|
+      date = Date.parse(holiday[:date])
+      logger.info "Adding holiday '#{holiday[:title]}' on '#{date}'"
       Holiday.find_or_create_by!(
-        title: event[:title],
+        title: holiday[:title],
         start_at: date.beginning_of_day,
         end_at: date.end_of_day
       )
     end
+  end
+
+  private
+
+  def retrieve_holidays
+    require 'open-uri'
+    response = open('https://www.gov.uk/bank-holidays.json').read
+    holidays = JSON.parse(response).with_indifferent_access
+    holidays['england-and-wales'][:events]
   end
 end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -15,6 +15,7 @@ class Appointment < ApplicationRecord
   def assign_to_guider
     slot = BookableSlot
            .without_appointments
+           .without_holidays
            .where(start_at: start_at, end_at: end_at)
            .sample(1)
            .first

--- a/app/models/holiday.rb
+++ b/app/models/holiday.rb
@@ -4,7 +4,7 @@ class Holiday < ApplicationRecord
   def self.merged_for_calendar_view
     select(<<-SQL
       DISTINCT ON(holidays.start_at, holidays.end_at, holidays.title)
-        holidays.title, holidays.start_at, holidays.end_at, holidays.title || ' - ' || string_agg(users.name, ', ') AS title
+        holidays.title, holidays.start_at, holidays.end_at, holidays.title || COALESCE(' - ' || string_agg(users.name, ', '), '') AS title
     SQL
           )
       .joins('LEFT JOIN users ON users.id = holidays.user_id')

--- a/app/models/holiday.rb
+++ b/app/models/holiday.rb
@@ -1,0 +1,14 @@
+class Holiday < ApplicationRecord
+  belongs_to :user, required: false
+
+  def self.merged_for_calendar_view
+    select(<<-SQL
+      DISTINCT ON(holidays.start_at, holidays.end_at, holidays.title)
+        holidays.title, holidays.start_at, holidays.end_at, holidays.title || ' - ' || string_agg(users.name, ', ') AS title
+    SQL
+          )
+      .joins('LEFT JOIN users ON users.id = holidays.user_id')
+      .group(:start_at, :end_at, :title)
+      .order(:start_at)
+  end
+end

--- a/app/models/holiday.rb
+++ b/app/models/holiday.rb
@@ -2,11 +2,13 @@ class Holiday < ApplicationRecord
   belongs_to :user, required: false
 
   def self.merged_for_calendar_view
-    select(<<-SQL
-      DISTINCT ON(holidays.start_at, holidays.end_at, holidays.title)
-        holidays.title, holidays.start_at, holidays.end_at, holidays.title || COALESCE(' - ' || string_agg(users.name, ', '), '') AS title
-    SQL
-          )
+    select(
+      <<-SQL
+        DISTINCT ON(holidays.start_at, holidays.end_at, holidays.title)
+        holidays.title, holidays.start_at, holidays.end_at,
+        holidays.title || COALESCE(' - ' || string_agg(users.name, ', '), '') AS title
+      SQL
+    )
       .joins('LEFT JOIN users ON users.id = holidays.user_id')
       .group(:start_at, :end_at, :title)
       .order(:start_at)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord
   has_many :schedules, dependent: :destroy
   has_many :bookable_slots
   has_many :appointments, foreign_key: :guider_id
+  has_many :holidays
 
   has_many :group_assignments
   has_many :groups, through: :group_assignments

--- a/app/serializers/holiday_serializer.rb
+++ b/app/serializers/holiday_serializer.rb
@@ -1,0 +1,9 @@
+class HolidaySerializer < ActiveModel::Serializer
+  attribute :title
+  attribute :start do
+    object.start_at
+  end
+  attribute :end do
+    object.end_at
+  end
+end

--- a/app/serializers/holiday_serializer.rb
+++ b/app/serializers/holiday_serializer.rb
@@ -1,9 +1,5 @@
 class HolidaySerializer < ActiveModel::Serializer
   attribute :title
-  attribute :start do
-    object.start_at
-  end
-  attribute :end do
-    object.end_at
-  end
+  attribute :start_at, key: :start
+  attribute :end_at, key: :end
 end

--- a/app/views/holidays/index.html.erb
+++ b/app/views/holidays/index.html.erb
@@ -1,0 +1,5 @@
+<h1>Holidays</h1>
+
+<div class="calendar">
+  <div data-module="HolidaysCalendar"></div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
 <% content_for :navbar_items do %>
   <% if current_user.resource_manager? %>
     <%= active_link_to 'Manage guiders', users_path, wrap_tag: :li %>
+    <%= active_link_to 'Holidays', holidays_path, wrap_tag: :li %>
   <% end %>
   <% if current_user.agent? %>
     <%= active_link_to 'Book appointment', new_appointment_attempt_path, wrap_tag: :li %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   resources :customers
   resource :calendar, only: :show
   resources :appointments, only: %i(index show edit)
+  resources :holidays, only: %i(index)
 
   resources :groups, only: %i(index destroy)
 

--- a/db/migrate/20161017130509_create_holidays.rb
+++ b/db/migrate/20161017130509_create_holidays.rb
@@ -1,0 +1,11 @@
+class CreateHolidays < ActiveRecord::Migration[5.0]
+  def change
+    create_table :holidays do |t|
+      t.integer  :user_id, index: true
+      t.string   :title
+      t.datetime :start_at
+      t.datetime :end_at
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161014111858) do
+ActiveRecord::Schema.define(version: 20161017130509) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,16 @@ ActiveRecord::Schema.define(version: 20161014111858) do
     t.string   "name",       default: "", null: false
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
+  end
+
+  create_table "holidays", force: :cascade do |t|
+    t.integer  "user_id"
+    t.string   "title"
+    t.datetime "start_at"
+    t.datetime "end_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_holidays_on_user_id", using: :btree
   end
 
   create_table "schedules", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,6 +35,8 @@ if Rails.env.development?
     )
   end
 
+  GenerateBankHolidaysJob.new.perform_now
+
   BookableSlot.generate_for_six_weeks
 
   User.first.tap do |user|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,6 +24,17 @@ if Rails.env.development?
     schedule.save!(validate: false)
   end
 
+  fake_holiday_title = Faker::Book.title
+  User.guiders.each do |guider|
+    date = Faker::Date.between(Date.today, 1.month.from_now)
+    Holiday.create!(
+      user: guider,
+      title: fake_holiday_title,
+      end_at: date.end_of_day,
+      start_at: date.beginning_of_day
+    )
+  end
+
   BookableSlot.generate_for_six_weeks
 
   User.first.tap do |user|

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -5,4 +5,11 @@ namespace :jobs do
       GenerateBookableSlotsJob.perform_now
     end
   end
+
+  namespace :bank_holidays do
+    desc 'generate bank holidays'
+    task generate: :environment do
+      GenerateBankHolidaysJob.perform_now
+    end
+  end
 end

--- a/spec/factories/holidays.rb
+++ b/spec/factories/holidays.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :holiday do
+    title { Faker::Book.title }
+  end
+end

--- a/spec/features/holidays_spec.rb
+++ b/spec/features/holidays_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+RSpec.feature 'Holidays' do
+  describe 'Viewing holidays' do
+    let(:users) do
+      [
+        create(:guider, name: 'First Guider'),
+        create(:guider, name: 'Second Guider')
+      ]
+    end
+
+    let(:today) { BusinessDays.from_now(0).change(hour: 9, min: 0) }
+    let(:next_week) { BusinessDays.from_now(6).change(hour: 9, min: 0) }
+
+    scenario 'displays all holidays', js: true do
+      given_the_user_is_a_resource_manager do
+        and_there_are_some_holidays
+        when_they_view_holidays
+        then_they_can_see_the_holidays_for_this_week
+        and_they_can_see_the_holidays_for_next_week
+      end
+    end
+
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength
+    def and_there_are_some_holidays
+      create(
+        :holiday,
+        user: users.first,
+        title: 'First user holiday',
+        start_at: today,
+        end_at: today + 2.hours
+      )
+      create(
+        :holiday,
+        user: users.second,
+        title: 'Second user holiday',
+        start_at: next_week,
+        end_at: next_week + 5.hours
+      )
+      users.each do |user|
+        create(
+          :holiday,
+          user: user,
+          title: 'Merged Holiday',
+          start_at: today + 4.hours,
+          end_at: today + 5.hours
+        )
+      end
+      create(
+        :holiday,
+        title: 'Christmas',
+        start_at: next_week,
+        end_at: next_week.end_of_day
+      )
+    end
+
+    def when_they_view_holidays
+      @page = Pages::Holidays.new.tap(&:load)
+    end
+
+    def then_they_can_see_the_holidays_for_this_week
+      expect(@page.all_appointments).to eq [
+        {
+          title: 'First user holiday - First Guider',
+          time: '9:00 - 11:00'
+        },
+        {
+          title: 'Merged Holiday - First Guider, Second Guider',
+          time: '1:00 - 2:00'
+        }
+      ]
+    end
+
+    def and_they_can_see_the_holidays_for_next_week
+      @page.next_week.click
+      expect(@page.all_appointments).to eq [
+        {
+          title: 'Christmas',
+          time: '9:00 - 11:59'
+        },
+        {
+          title: 'Second user holiday - Second Guider',
+          time: '9:00 - 2:00'
+        }
+      ]
+    end
+  end
+end

--- a/spec/features/roles_spec.rb
+++ b/spec/features/roles_spec.rb
@@ -24,6 +24,13 @@ RSpec.feature 'Roles' do
         then_they_are_allowed
       end
     end
+
+    scenario 'Can manage holidays' do
+      given_the_user_is_a_resource_manager do
+        when_they_try_to_manage_holidays
+        then_they_are_allowed
+      end
+    end
   end
 
   context 'Agents' do
@@ -81,6 +88,13 @@ RSpec.feature 'Roles' do
         then_they_are_locked_out
       end
     end
+
+    scenario 'Can not manage holidays' do
+      given_the_user_has_no_permissions do
+        when_they_try_to_manage_holidays
+        then_they_are_locked_out
+      end
+    end
   end
 
   def when_they_try_to_manager_guiders
@@ -91,6 +105,11 @@ RSpec.feature 'Roles' do
   def when_they_try_to_manage_guiders_slots
     @page = Pages::EditSchedule.new
     @page.load(user_id: @guider.id, id: @schedule.id)
+  end
+
+  def when_they_try_to_manage_holidays
+    @page = Pages::Holidays.new
+    @page.load
   end
 
   def and_a_guider_with_a_schedule_exists

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -105,6 +105,39 @@ RSpec.describe Appointment, type: :model do
           expect { subject.assign_to_guider }.to_not change { subject.guider }
         end
       end
+
+      context 'and the guider already has a holiday at that time' do
+        before do
+          create(
+            :holiday,
+            user: guider_with_slot,
+            start_at: appointment_start_time.beginning_of_day,
+            end_at: appointment_end_time.end_of_day
+          )
+        end
+
+        it 'does not assign to a guider' do
+          subject.start_at = appointment_start_time
+          subject.end_at = appointment_end_time
+          expect { subject.assign_to_guider }.to_not change { subject.guider }
+        end
+      end
+
+      context 'and there is a bank holiday at that time' do
+        before do
+          create(
+            :holiday,
+            start_at: appointment_start_time.beginning_of_day,
+            end_at: appointment_end_time.end_of_day
+          )
+        end
+
+        it 'does not assign to a guider' do
+          subject.start_at = appointment_start_time
+          subject.end_at = appointment_end_time
+          expect { subject.assign_to_guider }.to_not change { subject.guider }
+        end
+      end
     end
   end
 end

--- a/spec/models/bookable_slot_spec.rb
+++ b/spec/models/bookable_slot_spec.rb
@@ -38,10 +38,12 @@ RSpec.describe BookableSlot, type: :model do
 
   describe '#with_guider_count' do
     context 'three guiders with bookable slots' do
-      before do
-        1.upto(3) do
-          guider = create(:guider)
+      let(:guiders) do
+        create_list(:guider, 3)
+      end
 
+      before do
+        guiders.each do |guider|
           create(
             :bookable_slot,
             guider: guider,
@@ -84,6 +86,38 @@ RSpec.describe BookableSlot, type: :model do
             guider: User.guiders.first,
             start_at: make_time(10, 30),
             end_at: make_time(11, 30)
+          )
+
+          expect(result).to eq(
+            [
+              guiders: 2,
+              start: make_time(10, 30),
+              end: make_time(11, 30)
+            ]
+          )
+        end
+      end
+
+      context 'there is a holiday obscuring a bookable slot' do
+        it 'excludes the slots' do
+          create(
+            :holiday,
+            start_at: make_time(6, 30),
+            end_at: make_time(18, 30)
+          )
+
+          expect(result).to eq([])
+        end
+      end
+
+      context 'there is a holiday for a single user' do
+        it 'excludes the slot' do
+          guider = guiders.first
+          create(
+            :holiday,
+            user: guider,
+            start_at: make_time(6, 30),
+            end_at: make_time(18, 30)
           )
 
           expect(result).to eq(

--- a/spec/models/holiday_spec.rb
+++ b/spec/models/holiday_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 
 RSpec.describe Holiday, type: :model do
   describe '#merge_for_calendar_view' do
+    let(:results) do
+      subject.class.merged_for_calendar_view
+    end
+
     it 'merges holidays for calendar view' do
       user1 = create(:user)
       user2 = create(:user)
@@ -19,8 +23,6 @@ RSpec.describe Holiday, type: :model do
       create(:holiday, user: user2, title: same_title, start_at: same_start, end_at: same_end)
       create(:holiday, user: user3, title: different_title, start_at: different_start, end_at: different_end)
 
-      results = Holiday.merged_for_calendar_view
-
       expect(results.first.title).to eq "#{same_title} - #{user1.name}, #{user2.name}"
       expect(results.first.start_at.to_s).to eq same_start.to_s
       expect(results.first.end_at.to_s).to eq same_end.to_s
@@ -28,6 +30,26 @@ RSpec.describe Holiday, type: :model do
       expect(results.second.title).to eq "#{different_title} - #{user3.name}"
       expect(results.second.start_at.to_s).to eq different_start.to_s
       expect(results.second.end_at.to_s).to eq different_end.to_s
+    end
+
+    it 'lists bank holidays' do
+      create(
+        :holiday,
+        user: create(:user),
+        title: 'some other holiday',
+        start_at: Date.new(2014, 12, 25).beginning_of_day,
+        end_at: Date.new(2014, 12, 25).end_of_day
+      )
+      christmas = create(
+        :holiday,
+        title: 'christmas',
+        start_at: Date.new(2010, 12, 25).beginning_of_day,
+        end_at: Date.new(2010, 12, 25).end_of_day
+      )
+
+      expect(results.first.title).to eq christmas.title
+      expect(results.first.start_at.to_s).to eq christmas.start_at.to_s
+      expect(results.first.end_at.to_s).to eq christmas.end_at.to_s
     end
   end
 end

--- a/spec/models/holiday_spec.rb
+++ b/spec/models/holiday_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Holiday, type: :model do
+  describe '#merge_for_calendar_view' do
+    it 'merges holidays for calendar view' do
+      user1 = create(:user)
+      user2 = create(:user)
+      user3 = create(:user)
+
+      same_start = Time.zone.now
+      same_end = 1.hour.from_now
+      same_title = 'Same Title'
+
+      different_start = 5.hours.from_now
+      different_end = 6.hours.from_now
+      different_title = 'Different Title'
+
+      create(:holiday, user: user1, title: same_title, start_at: same_start, end_at: same_end)
+      create(:holiday, user: user2, title: same_title, start_at: same_start, end_at: same_end)
+      create(:holiday, user: user3, title: different_title, start_at: different_start, end_at: different_end)
+
+      results = Holiday.merged_for_calendar_view
+
+      expect(results.first.title).to eq "#{same_title} - #{user1.name}, #{user2.name}"
+      expect(results.first.start_at.to_s).to eq same_start.to_s
+      expect(results.first.end_at.to_s).to eq same_end.to_s
+
+      expect(results.second.title).to eq "#{different_title} - #{user3.name}"
+      expect(results.second.start_at.to_s).to eq different_start.to_s
+      expect(results.second.end_at.to_s).to eq different_end.to_s
+    end
+  end
+end

--- a/spec/support/pages/holidays.rb
+++ b/spec/support/pages/holidays.rb
@@ -6,5 +6,22 @@ module Pages
       'h1',
       text: 'Sorry, you don\'t seem to have the resource_manager permission for this app.'
     )
+
+    element :next_week, '.fc-next-button'
+
+    sections :appointments, '.fc-event' do
+      element :title, '.fc-title'
+      element :time, '.fc-time'
+    end
+
+    def all_appointments
+      wait_for_appointments
+      appointments.map do |a|
+        {
+          title: a.title.text,
+          time: a.time.text
+        }
+      end
+    end
   end
 end

--- a/spec/support/pages/holidays.rb
+++ b/spec/support/pages/holidays.rb
@@ -1,0 +1,10 @@
+module Pages
+  class Holidays < SitePrism::Page
+    set_url 'holidays'
+    element(
+      :permission_error_message,
+      'h1',
+      text: 'Sorry, you don\'t seem to have the resource_manager permission for this app.'
+    )
+  end
+end


### PR DESCRIPTION
- Add a link to /holidays in the nav
- Appointments don't get assigned to guiders on a holiday
- Don't show bookable slots if there's a holiday
- Seed bank holidays with ActiveJob

![https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-18-10-2016-16-17-42-ahY4lah6.png](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-18-10-2016-16-17-42-ahY4lah6.png)