### PR TITLE
Make date of birth readonly after eligiblity check

### DIFF
--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -25,7 +25,7 @@
       <%= f.email_field :email, class: 't-email' %>
       <%= f.telephone_field :phone, class: 't-phone', label: required_label(:phone) %>
       <%= f.telephone_field :mobile, class: 't-mobile' %>
-      <%= render 'shared/date_of_birth_form_field', form: f %>
+      <%= render 'shared/date_of_birth_form_field', form: f, readonly: true %>
     </div>
     <div class="col-md-6">
       <%= f.text_field :memorable_word, class: 't-memorable-word', placeholder: 'Pension Wise will use this each time the customer is called', label: required_label(:memorable_word) %>

--- a/app/views/shared/_date_of_birth_form_field.html.erb
+++ b/app/views/shared/_date_of_birth_form_field.html.erb
@@ -1,4 +1,5 @@
 <% start_year = 120.years.ago %>
+<% readonly = local_assigns[:readonly] || false %>
 
 <div class="form-dob" data-module="CustomerAge" data-output-id="js-customer-age">
   <%= field_with_errors_wrapper(form, :date_of_birth) do %>
@@ -16,7 +17,8 @@
           pattern: '[0-9]*',
           min: 1,
           max: 31,
-          'aria-describedby': 'dob-hint'
+          'aria-describedby': 'dob-hint',
+          readonly: readonly
         )
       %>
     </label>
@@ -32,7 +34,8 @@
           class: 'js-dob-month t-date-of-birth-month',
           pattern: '[0-9]*',
           min: 1,
-          max: 12
+          max: 12,
+          readonly: readonly
         )
       %>
     </label>
@@ -48,7 +51,8 @@
           class: 'js-dob-year t-date-of-birth-year',
           pattern: '[0-9]*',
           min: start_year.year,
-          max: Date.today.year
+          max: Date.today.year,
+          readonly: readonly
         )
       %>
     </label>


### PR DESCRIPTION
Before this, it was possible to provide an eligible date of birth
on the first page of the 'Book Appointment' journey, which is the
point at which the eligibility checks take place. However you
could then edit the date of birth to an ineligible age on the
second screen – resulting in an ineligible appointment being
successfully booked.

An unlikely scenario to occur, but this just prevents that from
happening.