### PR TITLE
Allow guiders to edit their own appointments

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -1,6 +1,6 @@
 class AppointmentsController < ApplicationController
-  before_action :authorise_for_agents!, except: %i(index edit)
-  before_action :authorise_for_guiders!, only: %i(index edit)
+  before_action :authorise_for_agents!, except: %i(index edit update)
+  before_action :authorise_for_guiders!, only: %i(index edit update)
 
   def index
     @appointments = current_user.appointments.where(start_at: date_range_params)
@@ -9,7 +9,17 @@ class AppointmentsController < ApplicationController
   end
 
   def edit
-    render nothing: true
+    @appointment = current_user.appointments.find(params[:id])
+  end
+
+  def update
+    @appointment = current_user.appointments.find(params[:id])
+
+    if @appointment.update(edit_params)
+      redirect_to calendar_path
+    else
+      render :edit
+    end
   end
 
   def new
@@ -49,6 +59,10 @@ class AppointmentsController < ApplicationController
     ends   = params[:end].to_date.beginning_of_day
 
     starts..ends
+  end
+
+  def edit_params
+    appointment_params.except(:start_at, :end_at)
   end
 
   def appointment_params

--- a/app/views/appointments/_personal_details_form.html.erb
+++ b/app/views/appointments/_personal_details_form.html.erb
@@ -1,0 +1,58 @@
+<div class="row form-group">
+  <div class="col-md-12">
+    <h2>Personal Details</h2>
+  </div>
+  <div class="col-md-6">
+    <%= f.text_field :first_name, class: 't-first-name', label: required_label(:first_name) %>
+    <%= f.text_field :last_name, class: 't-last-name', label: required_label(:last_name) %>
+    <%= f.email_field :email, class: 't-email' %>
+    <%= f.telephone_field :phone, class: 't-phone', label: required_label(:phone) %>
+    <%= f.telephone_field :mobile, class: 't-mobile' %>
+    <%= render 'shared/date_of_birth_form_field', form: f, readonly: true %>
+  </div>
+  <div class="col-md-6">
+    <%= f.text_field :memorable_word, class: 't-memorable-word', placeholder: 'Pension Wise will use this each time the customer is called', label: required_label(:memorable_word) %>
+    <%= f.text_area :notes, class: 't-notes', rows: 6, placeholder: 'Is the customer hard of hearing? Is English their first language? etc.' %>
+    <%= f.check_box :opt_out_of_market_research, class: 't-opt-out-of-market-research' %>
+    <%=
+      f.select(
+        :where_did_you_hear_about_pension_wise,
+        where_did_you_hear_about_pension_wise_options(@appointment),
+        {
+          label: required_label('Where did you hear about Pension Wise?'),
+          include_blank: true
+        },
+        {
+          class: 't-where-did-you-hear-about-pension-wise',
+          data: {
+            module: 'AdvancedSelect',
+            config: {
+              tags: true,
+              placeholder: 'Type a value in here if it is not included in the list'
+            }
+          }
+        }
+      )
+    %>
+    <%=
+      f.select(
+        :who_is_your_pension_provider,
+        who_is_your_pension_provider_options(@appointment),
+        {
+          label: 'Who is your pension provider?',
+          include_blank: true
+        },
+        {
+          class: 't-who-is-your-pension-provider',
+          data: {
+            module: 'AdvancedSelect',
+            config: {
+              tags: true,
+              placeholder: 'Type a value in here if it is not included in the list'
+            }
+          }
+        }
+      )
+    %>
+  </div>
+</div>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -1,0 +1,10 @@
+<h1>Edit appointment</h1>
+<%= render 'shared/required_fields_note' %>
+<%= form_for @appointment, layout: :basic do |f| %>
+  <%= render partial: 'personal_details_form', locals: { f: f } %>
+  <div class="row form-group">
+    <div class="col-md-12">
+      <%= f.submit "Update appointment", class: 't-save' %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -15,64 +15,7 @@
       </div>
     </div>
   </div>
-  <div class="row form-group">
-    <div class="col-md-12">
-      <h2>Personal Details</h2>
-    </div>
-    <div class="col-md-6">
-      <%= f.text_field :first_name, class: 't-first-name', label: required_label(:first_name) %>
-      <%= f.text_field :last_name, class: 't-last-name', label: required_label(:last_name) %>
-      <%= f.email_field :email, class: 't-email' %>
-      <%= f.telephone_field :phone, class: 't-phone', label: required_label(:phone) %>
-      <%= f.telephone_field :mobile, class: 't-mobile' %>
-      <%= render 'shared/date_of_birth_form_field', form: f, readonly: true %>
-    </div>
-    <div class="col-md-6">
-      <%= f.text_field :memorable_word, class: 't-memorable-word', placeholder: 'Pension Wise will use this each time the customer is called', label: required_label(:memorable_word) %>
-      <%= f.text_area :notes, class: 't-notes', rows: 6, placeholder: 'Is the customer hard of hearing? Is English their first language? etc.' %>
-      <%= f.check_box :opt_out_of_market_research, class: 't-opt-out-of-market-research' %>
-      <%=
-        f.select(
-          :where_did_you_hear_about_pension_wise,
-          where_did_you_hear_about_pension_wise_options(@appointment),
-          {
-            label: required_label('Where did you hear about Pension Wise?'),
-            include_blank: true
-          },
-          {
-            class: 't-where-did-you-hear-about-pension-wise',
-            data: {
-              module: 'AdvancedSelect',
-              config: {
-                tags: true,
-                placeholder: 'Type a value in here if it is not included in the list'
-              }
-            }
-          }
-        )
-      %>
-      <%=
-        f.select(
-          :who_is_your_pension_provider,
-          who_is_your_pension_provider_options(@appointment),
-          {
-            label: 'Who is your pension provider?',
-            include_blank: true
-          },
-          {
-            class: 't-who-is-your-pension-provider',
-            data: {
-              module: 'AdvancedSelect',
-              config: {
-                tags: true,
-                placeholder: 'Type a value in here if it is not included in the list'
-              }
-            }
-          }
-        )
-      %>
-    </div>
-  </div>
+  <%= render partial: 'personal_details_form', locals: { f: f } %>
   <div class="row form-group">
     <div class="col-md-12">
       <%= f.submit "Confirm appointment", class: 't-save' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,8 +16,8 @@ Rails.application.routes.draw do
   end
   resources :customers
   resource :calendar, only: :show
-  resources :appointments, only: %i(index show edit)
   resources :holidays, only: %i(index)
+  resources :appointments, only: %i(index show edit update)
 
   resources :groups, only: %i(index destroy)
 

--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -4,9 +4,15 @@ FactoryGirl.define do
     end_at { start_at + 1.hour }
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
-    phone '932009320'
+    email 'someone@example.com'
+    phone '0208 252 4758'
+    mobile '07715 930 444'
+    notes 'This customer is very nice.'
+    opt_out_of_market_research true
     memorable_word 'lozenge'
+    date_of_birth '1945-01-01'
     guider { build(:user) }
     where_did_you_hear_about_pension_wise 'Somewhere'
+    who_is_your_pension_provider 'Someone'
   end
 end

--- a/spec/features/guider_edits_an_appointment_spec.rb
+++ b/spec/features/guider_edits_an_appointment_spec.rb
@@ -1,0 +1,45 @@
+# rubocop:disable Metrics/AbcSize
+require 'rails_helper'
+
+RSpec.feature 'Guider edits an appointment' do
+  scenario 'Successfully editing an appointment' do
+    given_the_user_is_a_guider do
+      and_they_have_an_appointment
+      when_they_attempt_to_edit_the_appointment
+      then_they_see_the_existing_details
+      when_they_modify_the_appointment
+      then_the_appointment_is_changed
+    end
+  end
+
+  def and_they_have_an_appointment
+    @appointment = create(:appointment, guider: current_user)
+  end
+
+  def when_they_attempt_to_edit_the_appointment
+    @page = Pages::EditAppointment.new
+    @page.load(id: @appointment.id)
+  end
+
+  def then_they_see_the_existing_details
+    expect(@page.first_name.value).to eq(@appointment.first_name)
+    expect(@page.last_name.value).to eq(@appointment.last_name)
+    expect(@page.email.value).to eq(@appointment.email)
+    expect(@page.phone.value).to eq(@appointment.phone)
+    expect(@page.mobile.value).to eq(@appointment.mobile)
+    expect(@page.memorable_word.value).to eq(@appointment.memorable_word)
+    expect(@page.notes.value).to eq(@appointment.notes)
+    expect(@page.opt_out_of_market_research.value).to eq('1')
+    expect(@page.where_did_you_hear_about_pension_wise.value).to eq(@appointment.where_did_you_hear_about_pension_wise)
+    expect(@page.who_is_your_pension_provider.value).to eq(@appointment.who_is_your_pension_provider)
+  end
+
+  def when_they_modify_the_appointment
+    @page.first_name.set 'Rick'
+    @page.submit.click
+  end
+
+  def then_the_appointment_is_changed
+    expect(@appointment.reload.first_name).to eq('Rick')
+  end
+end

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -1,0 +1,17 @@
+module Pages
+  class EditAppointment < SitePrism::Page
+    set_url '/appointments/{id}/edit'
+
+    element :first_name,                            '.t-first-name'
+    element :last_name,                             '.t-last-name'
+    element :email,                                 '.t-email'
+    element :phone,                                 '.t-phone'
+    element :mobile,                                '.t-mobile'
+    element :memorable_word,                        '.t-memorable-word'
+    element :notes,                                 '.t-notes'
+    element :opt_out_of_market_research,            '.t-opt-out-of-market-research'
+    element :where_did_you_hear_about_pension_wise, '.t-where-did-you-hear-about-pension-wise'
+    element :who_is_your_pension_provider,          '.t-who-is-your-pension-provider'
+    element :submit, '.t-save'
+  end
+end


### PR DESCRIPTION
The guider can modify the personal details stored against appointments
assigned to them.

I extracted the common fields from new / edit into a partial to be
reused across both actions.