### PR TITLE
Remove old unused style

### DIFF
--- a/app/assets/stylesheets/components/_calendars.scss
+++ b/app/assets/stylesheets/components/_calendars.scss
@@ -1,9 +1,5 @@
 $calendar-today-background: $color-white;
 
-.calendar {
-  clear: both;
-}
-
 .fc-unthemed {
   .fc-today {
     background: $calendar-today-background;


### PR DESCRIPTION
This was causing date range pickers to show on two lines, which means
the display area calculation was showing the range picker outside of the
scroll area.

![https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-20-10-2016-19-20-29-uD9su2to.png](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-20-10-2016-19-20-29-uD9su2to.png)

![https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-20-10-2016-19-21-59-mie2Cie2.png](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-20-10-2016-19-21-59-mie2Cie2.png)