### PR TITLE
Adding a status to appointments

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -79,7 +79,8 @@ class AppointmentsController < ApplicationController
       :notes,
       :opt_out_of_market_research,
       :where_did_you_hear_about_pension_wise,
-      :who_is_your_pension_provider
+      :who_is_your_pension_provider,
+      :status
     )
   end
 

--- a/app/helpers/appointment_helper.rb
+++ b/app/helpers/appointment_helper.rb
@@ -53,6 +53,10 @@ module AppointmentHelper
     )
   end
 
+  def friendly_options(statuses)
+    statuses.map { |k, _| [k.titleize, k] }.to_h
+  end
+
   private
 
   def select_options(current_value, options)

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -1,4 +1,14 @@
 class Appointment < ApplicationRecord
+  enum status: %i(
+    pending
+    completed
+    no_show
+    ineligible_age
+    ineligible_pension_type
+    cancelled_by_customer
+    cancelled_by_pension_wise
+  )
+
   belongs_to :guider, class_name: 'User'
 
   validates :start_at, presence: true
@@ -8,6 +18,7 @@ class Appointment < ApplicationRecord
   validates :phone, presence: true
   validates :memorable_word, presence: true
   validates :where_did_you_hear_about_pension_wise, presence: true
+  validates :status, presence: true
 
   validate :not_within_two_business_days
   validate :not_more_than_thirty_business_days_in_future

--- a/app/views/appointments/_personal_details_form.html.erb
+++ b/app/views/appointments/_personal_details_form.html.erb
@@ -54,5 +54,14 @@
         }
       )
     %>
+
+    <%=
+      f.select(
+        :status,
+        friendly_options(Appointment.statuses),
+        options = {},
+        { class: 't-status' }
+      ) if defined?(edit) && edit
+    %>
   </div>
 </div>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -10,7 +10,7 @@
 
 <%= render 'shared/required_fields_note' %>
 <%= form_for @appointment, layout: :basic do |f| %>
-  <%= render partial: 'personal_details_form', locals: { f: f } %>
+  <%= render partial: 'personal_details_form', locals: { f: f, edit: true } %>
   <div class="row form-group">
     <div class="col-md-12">
       <%= f.submit "Update appointment", class: 't-save' %>

--- a/db/migrate/20161021120409_add_status_to_appointments.rb
+++ b/db/migrate/20161021120409_add_status_to_appointments.rb
@@ -1,0 +1,5 @@
+class AddStatusToAppointments < ActiveRecord::Migration[5.0]
+  def change
+    add_column :appointments, :status, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161017130509) do
+ActiveRecord::Schema.define(version: 20161021120409) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 20161017130509) do
     t.string   "where_did_you_hear_about_pension_wise", default: "",    null: false
     t.string   "who_is_your_pension_provider",          default: "",    null: false
     t.date     "date_of_birth"
+    t.integer  "status",                                default: 0,     null: false
   end
 
   create_table "bookable_slots", force: :cascade do |t|

--- a/spec/features/contact_centre_agent_creates_appointments_spec.rb
+++ b/spec/features/contact_centre_agent_creates_appointments_spec.rb
@@ -78,6 +78,7 @@ RSpec.feature 'Agent creates appointments' do
     expect(appointment.where_did_you_hear_about_pension_wise).to eq 'Radio advert'
     expect(appointment.who_is_your_pension_provider).to eq 'Scottish Widows'
     expect(appointment.start_at).to eq day.change(hour: 9, min: 30).to_s
+    expect(appointment.status).to eq 'pending'
     expect(appointment.end_at).to eq day.change(hour: 10, min: 40).to_s
   end
 

--- a/spec/features/guider_edits_an_appointment_spec.rb
+++ b/spec/features/guider_edits_an_appointment_spec.rb
@@ -1,4 +1,5 @@
 # rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/MethodLength
 require 'rails_helper'
 
 RSpec.feature 'Guider edits an appointment' do
@@ -32,6 +33,7 @@ RSpec.feature 'Guider edits an appointment' do
     expect(@page.opt_out_of_market_research.value).to eq('1')
     expect(@page.where_did_you_hear_about_pension_wise.value).to eq(@appointment.where_did_you_hear_about_pension_wise)
     expect(@page.who_is_your_pension_provider.value).to eq(@appointment.who_is_your_pension_provider)
+    expect(@page.status.value).to eq(@appointment.status)
   end
 
   def when_they_modify_the_appointment

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe Appointment, type: :model do
       build_stubbed(:appointment)
     end
 
+    it 'defaults #status to `pending`' do
+      expect(described_class.new).to be_pending
+    end
+
     it 'is valid with valid parameters' do
       expect(subject).to be_valid
     end

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -12,6 +12,7 @@ module Pages
     element :opt_out_of_market_research,            '.t-opt-out-of-market-research'
     element :where_did_you_hear_about_pension_wise, '.t-where-did-you-hear-about-pension-wise'
     element :who_is_your_pension_provider,          '.t-who-is-your-pension-provider'
+    element :status, '.t-status'
     element :submit, '.t-save'
   end
 end


### PR DESCRIPTION
- only available on edit appointment screen
- defaults to 'pending' on creation of an appointment