### PR TITLE
Use server clock to set current date

### DIFF
--- a/app/views/holidays/index.html.erb
+++ b/app/views/holidays/index.html.erb
@@ -7,4 +7,4 @@
   <h1>Holidays</h1>
 </div>
 
-<div data-module="HolidaysCalendar"></div>
+<div data-module="HolidaysCalendar" data-default-date="<%= Time.zone.now %>"></div>


### PR DESCRIPTION
This allows us to time travel successfully in our feature specs and ends
a whole class of spec bugs caused by @AndrewVos' incompetence.