### PR TITLE
Remove six week restriction on schedules

### DIFF
--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -54,13 +54,13 @@ class BookableSlot < ApplicationRecord
   end
 
   def self.generate_for_guider(guider)
-    (Time.zone.now.to_date..6.weeks.from_now.to_date).each do |day|
+    where(guider: guider).delete_all
+
+    generation_range.each do |day|
       active_schedule = guider.schedules.active(day)
       next unless active_schedule
 
-      available_slots = active_schedule
-                        .slots
-                        .where(day_of_week: day.wday)
+      available_slots = active_schedule.slots.where(day_of_week: day.wday)
 
       available_slots.each do |available_slot|
         create_from_slot!(guider, day, available_slot)
@@ -77,6 +77,10 @@ class BookableSlot < ApplicationRecord
       hour: slot.end_hour,
       min: slot.end_minute
     )
-    find_or_create_by!(guider: guider, start_at: start_at, end_at: end_at)
+    create!(guider: guider, start_at: start_at, end_at: end_at)
+  end
+
+  def self.generation_range
+    Time.zone.now.to_date..6.weeks.from_now.to_date
   end
 end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -6,7 +6,6 @@ class Schedule < ApplicationRecord
 
   validates :start_at, presence: true
   validates :start_at, uniqueness: { scope: :user_id }
-  validate :start_at_must_be_more_than_six_weeks_in_the_future, unless: :first_schedule?
 
   def self.active(day)
     order(:start_at)
@@ -28,7 +27,8 @@ class Schedule < ApplicationRecord
   end
 
   def modifiable?
-    start_at > 6.weeks.from_now
+    return true unless end_at
+    end_at > Time.zone.now.end_of_day
   end
 
   private
@@ -37,11 +37,5 @@ class Schedule < ApplicationRecord
     user
       .schedules
       .none?(&:persisted?)
-  end
-
-  def start_at_must_be_more_than_six_weeks_in_the_future
-    maximum_age = 6.weeks.from_now.beginning_of_day
-    older_than_six_weeks = start_at && start_at >= maximum_age
-    errors.add(:start_at, 'must be more than six weeks from now') unless older_than_six_weeks
   end
 end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -49,7 +49,7 @@
   </thead>
   <tbody>
   <% @schedules.each do |schedule| %>
-    <tr data-schedule-start="<%= schedule.start_at %>" data-schedule-end="<%= schedule.end_at %>">
+    <tr class='t-schedule' data-schedule-start="<%= schedule.start_at %>" data-schedule-end="<%= schedule.end_at %>">
       <td>
         <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span> <%= schedule.title %>
         <% unless schedule.modifiable? %>

--- a/spec/factories/schedules.rb
+++ b/spec/factories/schedules.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :schedule do
     user { build(:user) }
-    start_at 6.weeks.from_now
+    start_at { Time.zone.now.beginning_of_day }
 
     days = 1.upto(6)
 

--- a/spec/features/resource_manager_manages_schedules_spec.rb
+++ b/spec/features/resource_manager_manages_schedules_spec.rb
@@ -39,19 +39,12 @@ RSpec.feature 'Resource manager manages schedules' do
     end
   end
 
-  scenario 'Fails to delete a schedule' do
-    given_the_user_is_a_resource_manager do
-      and_there_is_a_guider
-      and_the_guider_has_a_schedule_that_can_not_be_modified
-      then_they_cant_delete_the_schedule
-    end
-  end
-
-  scenario 'Fails to edit a schedule' do
+  scenario 'Fails to modify an old schedule' do
     given_the_user_is_a_resource_manager do
       and_there_is_a_guider
       and_the_guider_has_a_schedule_that_can_not_be_modified
       then_they_cant_edit_the_schedule
+      and_they_cant_delete_the_schedule
     end
   end
 
@@ -66,10 +59,8 @@ RSpec.feature 'Resource manager manages schedules' do
   end
 
   def and_the_guider_has_a_schedule_that_can_not_be_modified
-    @schedule = @guider.schedules.create!(
-      start_at: 7.weeks.from_now
-    )
-    @schedule.update_attribute(:start_at, 1.week.from_now)
+    @schedule = @guider.schedules.create!(start_at: 5.days.ago)
+    @guider.schedules.create!(start_at: 3.days.ago)
   end
 
   def click_on_day_and_time(day, time)
@@ -179,22 +170,22 @@ RSpec.feature 'Resource manager manages schedules' do
   def and_they_delete_the_schedule
     @page = Pages::EditUser.new
     @page.load(id: @guider.id)
-    @page.delete.click
+    @page.schedules.first.delete.click
   end
 
   def and_the_schedule_is_deleted
     expect(@guider.reload.schedules).to be_empty
   end
 
-  def then_they_cant_delete_the_schedule
-    @page = Pages::EditUser.new
-    @page.load(id: @guider.id)
-    expect(@page.delete).to be_disabled
-  end
-
   def then_they_cant_edit_the_schedule
     @page = Pages::EditUser.new
     @page.load(id: @guider.id)
-    expect(@page).to_not have_edit
+    expect(@page.schedules.first).to have_no_edit
+  end
+
+  def and_they_cant_delete_the_schedule
+    @page = Pages::EditUser.new
+    @page.load(id: @guider.id)
+    expect(@page.schedules.first.delete).to be_disabled
   end
 end

--- a/spec/support/pages/edit_user.rb
+++ b/spec/support/pages/edit_user.rb
@@ -1,13 +1,16 @@
 module Pages
   class EditUser < SitePrism::Page
-    set_url 'users/{id}/edit'
+    set_url '/users/{id}/edit'
     element(
       :permission_error_message,
       'h1',
       text: 'Sorry, you don\'t seem to have the resource_manager permission for this app.'
     )
     element :flash_of_success, '.alert-success'
-    element :delete, '.t-delete'
-    element :edit, '.t-edit'
+
+    sections :schedules, '.t-schedule' do
+      element :delete, '.t-delete'
+      element :edit, '.t-edit'
+    end
   end
 end

--- a/spec/support/pages/new_holiday.rb
+++ b/spec/support/pages/new_holiday.rb
@@ -1,6 +1,6 @@
 module Pages
   class NewHoliday < SitePrism::Page
-    set_url 'holidays/new'
+    set_url '/holidays/new'
 
     element :title, '.t-title'
     element :date_range, '.t-date-range'


### PR DESCRIPTION
- Schedules have no six week restrictions anymore
- Destroy all bookable slots when regenerating
- Bookable slots are still generated for six weeks