### PR TITLE
Precompile when running in Travis CI

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,6 +1,6 @@
 # Default application configuration that all configurations inherit from.
 
-scss_files: 'app/assets/stylesheets/**/.scss'
+scss_files: 'app/assets/stylesheets/**/*.scss'
 
 exclude:
   - 'node_modules/**/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
   bundler: true
   directories:
   - tmp/cache/assets/test
+  - tmp/cache/assets/sprockets
 node_js:
 - '0.10'
 before_install:
@@ -16,7 +17,8 @@ before_install:
 before_script:
 - npm install
 - gem update --system
-- bundle exec rake db:create db:migrate RAILS_ENV=test
+- bundle exec rails assets:precompile RAILS_ENV=test
+- bundle exec rails db:create db:migrate RAILS_ENV=test
 notifications:
   slack:
     secure: izFI8CV1BAc5Sk08/q84YijolWAY2Zm3JA4RPyilwjzfrro5v2lOM9rEX32W1fgPDu7hWq1bmqYcgxhVI+ecu2RFkI0iQklgNSe256HN7AKqRtSgtVx+3L6w8B9tBCJJ9wfj0lur/8x6oh8UwH8jExJmqtJbL3rxIq+O9N0/nJdf4jXR9vPHfFtprZwExQQTDQccqXkfyE+BqYRsFjoa/jL0utZlLt5kn8ErQPW/lDiSFvOA9OKk5o2ihQrndxkhAhZX6GbKp2aBP3xkom37aQZRyXsKIMXCz16+0IGOsTrW32j3lwLjsesb308Bp01e4q4ssp3a+2k5Hs2CKs0++b9Bb4GLpEl6Q63TGewUqK9/TXjvp7IWx5SOTQbktB5YLL6WmfR+j7MfD52VrEIHahEgJUwQQ+2+EG9MP0O8Qbs4Gek1FgGtpN7+rUS9WpOUIiGEjN7+uGd+PHTgSL7gf0kqrhtQcDHkP8KfI7KOrB1O0gO4DmdHNfJ184MXKEFlh7ULKtX08i8iB5GMVGQqsCuI7lfgR/P+u/SlIbPVu/aRoXpzo4e18UVpjBl9fR5mk6vroXqiR/5v4sHByFp5wn/QwvGszXjZcgmqTtZ7tyGGoq1IS6QdPr1Y0D/mBZT/O4N7QzG7fugPXwKOIfiktPooGt6CSVca5SHa13OkBrk=

--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ source 'https://rubygems.org' do
     gem 'phantomjs-binaries'
     gem 'database_cleaner'
     gem 'chronic'
-    gem 'scss-lint', '~> 0.30'
+    gem 'scss_lint', require: false
   end
 
   group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,9 +266,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    scss-lint (0.38.0)
-      rainbow (~> 2.0)
-      sass (~> 3.4.1)
+    scss_lint (0.50.2)
+      rake (>= 0.9, < 12)
+      sass (~> 3.4.20)
     select2-rails (4.0.3)
       thor (~> 0.14)
     sidekiq (4.2.2)
@@ -353,7 +353,7 @@ DEPENDENCIES
   rspec-rails!
   rubocop!
   sass-rails (~> 5.0)!
-  scss-lint (~> 0.30)!
+  scss_lint!
   select2-rails!
   sidekiq!
   sinatra!

--- a/app/assets/stylesheets/components/_guider-schedules.scss
+++ b/app/assets/stylesheets/components/_guider-schedules.scss
@@ -65,7 +65,7 @@ $guider-schedules-read-only-border-color: $color-silver;
     display: inline-block;
     margin-right: 5px;
 
-    &:before {
+    &::before {
       content: "";
       display: inline-block;
       height: 25px;
@@ -77,20 +77,20 @@ $guider-schedules-read-only-border-color: $color-silver;
 }
 
 .guider-schedules-swatch--readonly-window {
-  &:before {
+  &::before {
     background: $guider-schedule-read-only-window-color;
     border: 1px dashed $guider-schedules-read-only-border-color;
   }
 }
 
 .guider-schedules-swatch--readonly {
-  &:before {
+  &::before {
     background: schedule-repeating-gradient($guider-schedules-read-only-color);
   }
 }
 
 .guider-schedules-swatch--editable {
-  &:before {
+  &::before {
     background: schedule-repeating-gradient($guider-schedules-editable-color);
   }
 }

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,6 +37,9 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  # Precompile in travis to resolve poltergeist timeouts
+  config.assets.compile = ENV['TRAVIS'] ? false : true
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end


### PR DESCRIPTION
This stops the intermittent timeouts caused when assets are compiled
upon request, during the first or subsequent JS spec runs.