### PR TITLE
Fix orphaned bookable slots

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
   default_scope { order(:name) }
 
   has_many :schedules, dependent: :destroy
-  has_many :bookable_slots
+  has_many :bookable_slots, dependent: :destroy, foreign_key: :guider_id
   has_many :appointments, foreign_key: :guider_id
   has_many :holidays
 

--- a/spec/factories/bookable_slots.rb
+++ b/spec/factories/bookable_slots.rb
@@ -1,4 +1,6 @@
 FactoryGirl.define do
   factory :bookable_slot do
+    start_at Time.zone.now
+    end_at { start_at + 1.hour }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -61,4 +61,13 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe '#bookable_slots' do
+    it 'destroys them when the user is destroyed' do
+      guider = create(:user)
+      create(:bookable_slot, guider: guider)
+      create(:bookable_slot, guider: guider)
+      expect { guider.destroy }.to change { BookableSlot.count }.by(-2)
+    end
+  end
 end


### PR DESCRIPTION
There was a really irritating issue where sometimes we just couldn't
book appointments, randomly. This was because the bookable slot that
matched didn't have an existing user anymore, because we deleted that
user in db:seed.

The fix is to ensure we delete any child bookable slots when we delete
users.