### PR TITLE
Fix moment JS warning on new holiday date picker

### DIFF
--- a/app/assets/javascripts/date-range-picker.es6
+++ b/app/assets/javascripts/date-range-picker.es6
@@ -1,3 +1,4 @@
+/* global moment */
 {
   'use strict';
 
@@ -8,7 +9,8 @@
         timePicker24Hour: true,
         locale: {
           format: 'D MMM YYYY'
-        }
+        },
+        maxDate: moment().add(10, 'years')
       };
 
       this.config = $.extend(true, defaultConfig, config);


### PR DESCRIPTION
- appears to be an issue with date range picker where it
  passes 'false' through to moment js when there isn't a maxDate
  specified