### PR TITLE
Update date range picker to latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source 'https://rails-assets.org' do
   gem 'rails-assets-fullcalendar'
   gem 'rails-assets-fullcalendar-scheduler'
   gem 'rails-assets-qTip2'
+  gem 'rails-assets-bootstrap-daterangepicker'
 end
 
 source 'https://rubygems.org' do
@@ -19,7 +20,6 @@ source 'https://rubygems.org' do
   gem 'gds-sso'
   gem 'plek'
   gem 'momentjs-rails'
-  gem 'bootstrap-daterangepicker-rails'
   gem 'active_link_to'
   gem 'foreman'
   gem 'bh'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,8 +58,6 @@ GEM
     bh (1.3.6)
       actionpack
       activesupport
-    bootstrap-daterangepicker-rails (0.1.5)
-      railties (>= 4.0, < 5.1)
     bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)
@@ -196,6 +194,9 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 5.0.0.1)
       sprockets-rails (>= 2.0.0)
+    rails-assets-bootstrap-daterangepicker (2.1.21)
+      rails-assets-jquery (>= 1.10)
+      rails-assets-moment (>= 2.9.0)
     rails-assets-ev-emitter (1.0.3)
     rails-assets-fullcalendar (3.0.1)
       rails-assets-jquery (>= 2.0.0)
@@ -323,7 +324,6 @@ DEPENDENCIES
   active_link_to!
   active_model_serializers!
   bh!
-  bootstrap-daterangepicker-rails!
   bugsnag!
   capybara!
   chronic!
@@ -344,6 +344,7 @@ DEPENDENCIES
   pry-byebug!
   puma (~> 3.0)!
   rails (~> 5.0.0, >= 5.0.0.1)!
+  rails-assets-bootstrap-daterangepicker!
   rails-assets-fullcalendar!
   rails-assets-fullcalendar-scheduler!
   rails-assets-listjs!

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,7 +15,7 @@
 //= require fullcalendar-scheduler
 //= require qTip2
 //= require listjs
-//= require daterangepicker
+//= require bootstrap-daterangepicker
 //= require core.js/core.js
 //= require calendar
 //= require customer-age

--- a/app/assets/javascripts/date-range-picker.es6
+++ b/app/assets/javascripts/date-range-picker.es6
@@ -9,8 +9,7 @@
         timePicker24Hour: true,
         locale: {
           format: 'D MMM YYYY'
-        },
-        maxDate: moment().add(10, 'years')
+        }
       };
 
       this.config = $.extend(true, defaultConfig, config);

--- a/app/assets/stylesheets/vendor/_vendor.scss
+++ b/app/assets/stylesheets/vendor/_vendor.scss
@@ -3,6 +3,6 @@
 @import "select2-bootstrap";
 @import "fullcalendar";
 @import "fullcalendar-scheduler";
-@import "daterangepicker-bs3";
+@import "bootstrap-daterangepicker";
 @import "qTip2";
 @import "font-awesome";


### PR DESCRIPTION
- fixes issue where a maxDate attribute had to be specified
- now removed maxDate, now that it's no longer required