### PR TITLE
Fix BookableSlots#with_holidays negating valid slots

### DIFF
--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -29,7 +29,7 @@ class BookableSlot < ApplicationRecord
   def self.without_holidays
     joins(<<-SQL
           LEFT JOIN holidays ON
-            holidays.user_id = #{quoted_table_name}.guider_id OR holidays.user_id IS NULL AND
+            (holidays.user_id = #{quoted_table_name}.guider_id OR holidays.user_id IS NULL) AND
             holidays.start_at < #{quoted_table_name}.start_at AND
             holidays.end_at > #{quoted_table_name}.end_at
             SQL

--- a/spec/models/bookable_slot_spec.rb
+++ b/spec/models/bookable_slot_spec.rb
@@ -102,11 +102,29 @@ RSpec.describe BookableSlot, type: :model do
         it 'excludes the slots' do
           create(
             :holiday,
+            user: nil,
             start_at: make_time(6, 30),
             end_at: make_time(18, 30)
           )
 
           expect(result).to eq([])
+        end
+      end
+
+      context 'there is a holiday for a single user that doesn\'t obscure any bookable slots' do
+        it 'does not exclude the slots' do
+          create(
+            :holiday,
+            user: guiders.first,
+            start_at: make_time(19, 30),
+            end_at: make_time(20, 30)
+          )
+
+          expect(result).to eq [
+            guiders: 3,
+            start: make_time(10, 30),
+            end: make_time(11, 30)
+          ]
         end
       end
 


### PR DESCRIPTION
Because of operator precedence we were dropping bookable slots for
users when the slots weren't actually covered by the holiday.