### PR TITLE
Cancelled appointments are not considered for blocking bookable slots

### DIFF
--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -15,6 +15,7 @@ class BookableSlot < ApplicationRecord
     BusinessDays.from_now(3)
   end
 
+  # rubocop:disable Metrics/MethodLength
   def self.without_appointments
     joins(<<-SQL
             LEFT JOIN appointments ON
@@ -23,7 +24,14 @@ class BookableSlot < ApplicationRecord
               appointments.end_at = #{quoted_table_name}.end_at
             SQL
          )
-      .where('appointments.start_at IS NULL')
+      .where(<<-SQL
+              appointments.start_at IS NULL OR
+              appointments.status IN (
+                #{Appointment.statuses['cancelled_by_customer']},
+                #{Appointment.statuses['cancelled_by_pension_wise']}
+              )
+              SQL
+            )
   end
 
   def self.without_holidays

--- a/spec/models/bookable_slot_spec.rb
+++ b/spec/models/bookable_slot_spec.rb
@@ -79,18 +79,47 @@ RSpec.describe BookableSlot, type: :model do
         )
       end
 
-      context 'one guider has a bookable slot obscured by an appointment' do
+      context 'one guider has a bookable slot obscured by a non cancelled appointment' do
         it 'excludes the slot' do
           create(
             :appointment,
             guider: User.guiders.first,
             start_at: make_time(10, 30),
-            end_at: make_time(11, 30)
+            end_at: make_time(11, 30),
+            status: :pending
           )
 
           expect(result).to eq(
             [
               guiders: 2,
+              start: make_time(10, 30),
+              end: make_time(11, 30)
+            ]
+          )
+        end
+      end
+
+      context 'two guiders have bookable slots not obscured by cancelled appointments' do
+        it 'does not exclude the slot' do
+          create(
+            :appointment,
+            guider: User.guiders.first,
+            start_at: make_time(10, 30),
+            end_at: make_time(11, 30),
+            status: :cancelled_by_customer
+          )
+
+          create(
+            :appointment,
+            guider: User.guiders.last,
+            start_at: make_time(10, 30),
+            end_at: make_time(11, 30),
+            status: :cancelled_by_pension_wise
+          )
+
+          expect(result).to eq(
+            [
+              guiders: 3,
               start: make_time(10, 30),
               end: make_time(11, 30)
             ]


### PR DESCRIPTION
- if an appointment is cancelled then the bookable slot should be
  bookable