### PR TITLE
Bump `active_model_serializers` to avoid depending on yanked gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,10 +114,10 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jsonapi (0.1.1.beta5)
-      jsonapi-parser (= 0.1.1.beta2)
+    jsonapi (0.1.1.beta6)
+      jsonapi-parser (= 0.1.1.beta3)
       jsonapi-renderer (= 0.1.1.beta1)
-    jsonapi-parser (0.1.1.beta2)
+    jsonapi-parser (0.1.1.beta3)
     jsonapi-renderer (0.1.1.beta1)
     jwt (1.5.6)
     launchy (2.4.3)
@@ -367,4 +367,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.5
+   1.13.6


### PR DESCRIPTION
Ref: https://rubygems.org/gems/jsonapi-parser/versions/0.1.1.beta2