### PR TITLE
Ensure that calendar stays on current view/date across page impressions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ source 'https://rails-assets.org' do
   gem 'rails-assets-fullcalendar-scheduler'
   gem 'rails-assets-qTip2'
   gem 'rails-assets-bootstrap-daterangepicker'
+  gem 'rails-assets-cookie'
 end
 
 source 'https://rubygems.org' do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,6 +217,7 @@ GEM
     rails-assets-bootstrap-daterangepicker (2.1.21)
       rails-assets-jquery (>= 1.10)
       rails-assets-moment (>= 2.9.0)
+    rails-assets-cookie (1.2.1)
     rails-assets-ev-emitter (1.0.3)
     rails-assets-fullcalendar (3.0.1)
       rails-assets-jquery (>= 2.0.0)
@@ -369,6 +370,7 @@ DEPENDENCIES
   puma (~> 3.0)!
   rails (~> 5.0.0, >= 5.0.0.1)!
   rails-assets-bootstrap-daterangepicker!
+  rails-assets-cookie!
   rails-assets-fullcalendar!
   rails-assets-fullcalendar-scheduler!
   rails-assets-listjs!

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -27,4 +27,5 @@
 //= require activity-feed-poller
 //= require select2
 //= require advanced-select
+//= require cookie
 //= require_tree .

--- a/app/assets/javascripts/calendar.es6
+++ b/app/assets/javascripts/calendar.es6
@@ -1,27 +1,58 @@
-/* global moment */
+/* global moment, cookie */
 
 'use strict';
 
+window.PWTAP = window.PWTAP || {};
+
 class Calendar {
   constructor(el, config = {}) {
+    this.$el = el;
+
     const defaultConfig = {
-      schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
-      weekends: false,
-      timeFormat: 'H:mm',
-      slotLabelFormat: 'H:mm',
+      allDaySlot: false,
+      cookieName: this.$el.attr('id') || 'calendar',
+      defaultDate: moment(this.$el.data('default-date')),
+      firstDay: 1,
+      height: 'auto',
       maxTime: '19:00:00',
       minTime: '08:30:00',
-      height: 'auto',
-      allDaySlot: false,
-      firstDay: 1,
-      defaultDate: moment(el.data('default-date'))
+      schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
+      slotLabelFormat: 'H:mm',
+      timeFormat: 'H:mm',
+      viewRender: (view, element) => this.viewRender(view, element),
+      weekends: false
     };
 
-    this.config = $.extend(true, defaultConfig, config);
-    this.$el = el;
+    this.config = $.extend(
+      true,
+      defaultConfig,
+      config,
+      this.getCookieConfig(defaultConfig.cookieName)
+    );
 
     this.$el.fullCalendar(this.config);
   }
-}
 
-window.PWTAP = window.PWTAP || {};
+  viewRender(view) {
+    cookie.set(
+      this.config.cookieName,
+      JSON.stringify({
+        defaultView: view.name,
+        defaultDate: view.calendar.getDate()
+      }),
+      {
+        expires: 7
+      }
+    );
+  }
+
+  getCookieConfig(cookieName) {
+    const cookieValue = cookie(cookieName);
+
+    if (cookieValue) {
+      return JSON.parse(cookieValue);
+    }
+
+    return {};
+  }
+}

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -13,6 +13,7 @@
       <h2>Choose available slot <%= required_label %></h2>
       <p class="text-danger hide" id="slot-error">Please choose a slot</p>
       <div
+          id="AppointmentAvailabilityCalendar"
           class="appointment-availability-calendar"
           data-module="AppointmentAvailabilityCalendar"
           data-error-id="slot-error"

--- a/app/views/appointments/reschedule.html.erb
+++ b/app/views/appointments/reschedule.html.erb
@@ -15,6 +15,7 @@
       <h2>Choose available slot <%= required_label %></h2>
       <p class="text-danger hide" id="slot-error">Please choose a slot</p>
       <div
+        id="AppointmentAvailabilityCalendar"
         class="appointment-availability-calendar"
         data-module="AppointmentAvailabilityCalendar"
         data-error-id="slot-error"

--- a/app/views/calendars/show.html.erb
+++ b/app/views/calendars/show.html.erb
@@ -7,4 +7,4 @@
   <h1>My appointments</h1>
 </div>
 
-<div data-module="GuiderAppointmentsCalendar" data-default-date="<%= Time.zone.now %>"></div>
+<div id="GuiderAppointmentsCalendar" data-module="GuiderAppointmentsCalendar" data-default-date="<%= Time.zone.now %>"></div>

--- a/app/views/holidays/index.html.erb
+++ b/app/views/holidays/index.html.erb
@@ -15,6 +15,7 @@
   </div>
 </div>
 <div
+  id="HolidaysCalendar"
   class="holiday-calendar"
   data-module="HolidaysCalendar"
   data-holidays-path="<%= holidays_path %>"

--- a/app/views/resource_calendars/show.html.erb
+++ b/app/views/resource_calendars/show.html.erb
@@ -8,6 +8,7 @@
 </div>
 
 <div
+  id="GuidersAppointmentsCalendar"
   class="guiders-appointments-calendar js-calendar"
   data-config='{"editable": true, "eventDurationEditable": true, "slotDuration": "00:10:00"}'
   data-module="GuidersAppointmentsCalendar"

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -58,7 +58,7 @@
     </div>
   </div>
   <div class="form-group">
-    <div data-module="GuiderSlotPickerCalendar" data-events=".slots-data" data-events-common="calendar-common" data-config='{"slotDurationMinutes": 70}'></div>
+    <div id="GuiderSlotPickerCalendar" data-module="GuiderSlotPickerCalendar" data-events=".slots-data" data-events-common="calendar-common" data-config='{"slotDurationMinutes": 70}'></div>
   </div>
 
   <%= f.hidden_field :slots, class: 'slots-data', value: @slots_as_json %>


### PR DESCRIPTION
- Storing a cookie of the current view and date of each calendar
- Config for fullcalendar on initialisation gets overriden with values from cookie
- Remembers current defaultView/defaultDate settings for a year (across browser sessions)
