### PR TITLE
Resource manager appointments calendar

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,6 +22,7 @@
 //= require calendars/appointment-availability
 //= require calendars/guider-slot-picker
 //= require calendars/guider-appointments
+//= require calendars/guiders-appointments
 //= require calendars/holidays
 //= require activity-feed-poller
 //= require select2

--- a/app/assets/javascripts/calendars/guiders-appointments.es6
+++ b/app/assets/javascripts/calendars/guiders-appointments.es6
@@ -1,0 +1,204 @@
+/* global Calendar, moment */
+{
+  'use strict';
+
+  class GuidersAppointmentsCalendar extends Calendar {
+    constructor(el, config = {}) {
+      const calendarConfig = $.extend(true, {
+        columnFormat: 'ddd D/M',
+        defaultView: 'agendaDay',
+        resourceLabelText: 'Guiders',
+        header: {
+            right: 'agendaDay timelineDay today prev,next'
+        },
+        buttonText: {
+          agendaDay: 'Agenda',
+          timelineDay: 'Timeline'
+        },
+        groupByDateAndResource: true,
+        nowIndicator: true,
+        slotDuration: '00:30:00',
+        eventTextColor: '#fff',
+        resourceRender: (resourceObj, labelTds, bodyTds, view) => {
+          if (view.type === 'agendaDay') {
+            labelTds.html('');
+            $(`<div>${resourceObj.name}</div>`).prependTo(labelTds);
+          } else {
+            $('<span aria-hidden="true" class="glyphicon glyphicon-user" style="margin-right: 5px;"></span>').prependTo(
+              labelTds.find('.fc-cell-text')
+            );
+          }
+        },
+        eventRender: (event, element, view) => {
+          if (view.type === 'agendaDay') {
+            element.find('.fc-content').remove();
+          } else {
+            $('<span class="glyphicon glyphicon-phone-alt" aria-hidden="true" style="margin-right: 5px;"></span>').prependTo(
+              element.find('.fc-content')
+            );
+          }
+
+          if (event.hasChanged) {
+            event.backgroundColor = 'red';
+            event.borderColor = '#c00';
+          } else {
+            delete event.backgroundColor;
+            delete event.borderColor;
+          }
+        },
+        eventAfterRender: (event, element) => {
+          if (event.rendering === 'background') {
+            return;
+          }
+
+          var resource = el.fullCalendar('getResourceById', event.guider_id);
+
+          element.qtip({
+            content: {
+              text: `
+              <p>${event.start.format('HH:mm')} - ${event.end.format('HH:mm')}</p>
+              <p><span class="glyphicon glyphicon-phone-alt" aria-hidden="true"></span> ${event.title}</p>
+              <p><span class="glyphicon glyphicon-user" aria-hidden="true"></span> ${resource.title}</p>
+              `
+            }
+          });
+        },
+        eventDrop: (event, delta, revertFunc) => {
+          this.handleEventChange(event, revertFunc);
+        },
+        eventResize: (event, delta, revertFunc) => {
+          this.handleEventChange(event, revertFunc);
+        },
+        resources: '/guiders',
+        events: '/appointments'
+      }, config);
+
+      super(el, calendarConfig);
+
+      this.eventChanges = [];
+      this.actionPanel = $('[data-action-panel]');
+
+      this.setupUndo();
+    }
+
+    setupUndo() {
+      this.actionPanel.find('[data-action-panel-undo-all]').on('click', this.undoAllChanges.bind(this));
+      this.actionPanel.find('[data-action-panel-undo-one]').on('click', this.undoOneChange.bind(this));
+      this.actionPanel.find('[data-action-panel-save]').on('click', this.save.bind(this));
+    }
+
+    handleEventChange(event, revertFunc) {
+      event.hasChanged = true;
+
+      this.eventChanges.push({
+        eventObj: event,
+        revertFunc: revertFunc
+      });
+
+      this.$el.fullCalendar('rerenderEvents');
+
+      this.checkToShowActionPanel();
+    }
+
+    undoOneChange(evt) {
+      const event = this.eventChanges.pop();
+      evt.preventDefault();
+
+      event.revertFunc();
+      event.eventObj.hasChanged = this.hasEventChanged(event.eventObj);
+
+      this.rerenderEvents();
+
+      this.checkToShowActionPanel();
+    }
+
+    hasEventChanged(event) {
+      for (let eventIndex in this.eventChanges) {
+        let currentEvent = this.eventChanges[eventIndex];
+        if (currentEvent.eventObj.id === event.id) {
+          return true;
+        }
+      }
+    }
+
+    undoAllChanges(evt) {
+      evt.preventDefault();
+
+      for (let eventIndex in this.eventChanges.reverse()) {
+        let event = this.eventChanges[eventIndex];
+        event.revertFunc();
+        event.eventObj.hasChanged = false;
+      }
+
+      this.eventChanges = [];
+      this.rerenderEvents();
+
+      this.checkToShowActionPanel();
+    }
+
+    save(evt) {
+      const $hiddenInput = $('#event-changes');
+      evt.preventDefault();
+      $hiddenInput.val(this.getEventChangesForForm());
+      $hiddenInput.parents('form').submit();
+    }
+
+    getEventChangesForForm() {
+      let output = [],
+      outputEventIds = [];
+
+      for (let eventIndex in this.eventChanges) {
+        let event = this.eventChanges[eventIndex],
+        eventObj = event.eventObj;
+
+        if (outputEventIds.indexOf(eventObj.id) === -1) {
+          output.push({
+            id: eventObj.id,
+            guider_id: eventObj.resourceId,
+            start: eventObj.start,
+            end: eventObj.end
+          });
+
+          outputEventIds.push(eventObj.id);
+        }
+      }
+
+      return JSON.stringify(output);
+    }
+
+    rerenderEvents() {
+      // Strange rendering issue where calling this twice seems to fix
+      // events who are left in red after event changes are undone
+      this.$el.fullCalendar('rerenderEvents');
+      this.$el.fullCalendar('rerenderEvents');
+    }
+
+    checkToShowActionPanel() {
+      const eventsChanged = this.uniqueEventsChanged();
+
+      if (eventsChanged > 0) {
+        this.actionPanel.find('[data-action-panel-event-count]').html(
+          `${eventsChanged} event${eventsChanged == 1 ? '':'s'}`
+        );
+
+        this.actionPanel.fadeIn();
+      } else {
+        this.actionPanel.fadeOut();
+      }
+    }
+
+    uniqueEventsChanged() {
+      let unique = {};
+
+      for (let eventIndex in this.eventChanges) {
+        let event = this.eventChanges[eventIndex];
+        unique[event.eventObj.id] = true;
+      }
+
+      return Object.keys(unique).length;
+    }
+  }
+
+  window.PWTAP = window.PWTAP || {};
+  window.PWTAP.GuidersAppointmentsCalendar = GuidersAppointmentsCalendar;
+}

--- a/app/assets/javascripts/calendars/guiders-appointments.es6
+++ b/app/assets/javascripts/calendars/guiders-appointments.es6
@@ -157,8 +157,8 @@
           output.push({
             id: eventObj.id,
             guider_id: eventObj.resourceId,
-            start: eventObj.start,
-            end: eventObj.end
+            start_at: eventObj.start,
+            end_at: eventObj.end
           });
 
           outputEventIds.push(eventObj.id);

--- a/app/assets/javascripts/calendars/guiders-appointments.es6
+++ b/app/assets/javascripts/calendars/guiders-appointments.es6
@@ -1,4 +1,4 @@
-/* global Calendar, moment */
+/* global Calendar */
 {
   'use strict';
 
@@ -22,7 +22,7 @@
         resourceRender: (resourceObj, labelTds, bodyTds, view) => {
           if (view.type === 'agendaDay') {
             labelTds.html('');
-            $(`<div>${resourceObj.name}</div>`).prependTo(labelTds);
+            $(`<div>${resourceObj.title}</div>`).prependTo(labelTds);
           } else {
             $('<span aria-hidden="true" class="glyphicon glyphicon-user" style="margin-right: 5px;"></span>').prependTo(
               labelTds.find('.fc-cell-text')
@@ -30,6 +30,8 @@
           }
         },
         eventRender: (event, element, view) => {
+          $(element).attr('id', event.id);
+
           if (view.type === 'agendaDay') {
             element.find('.fc-content').remove();
           } else {
@@ -51,7 +53,7 @@
             return;
           }
 
-          var resource = el.fullCalendar('getResourceById', event.guider_id);
+          var resource = el.fullCalendar('getResourceById', event.resourceId);
 
           element.qtip({
             content: {
@@ -70,7 +72,7 @@
           this.handleEventChange(event, revertFunc);
         },
         resources: '/guiders',
-        events: '/appointments'
+        events: '/appointments?include_links=false'
       }, config);
 
       super(el, calendarConfig);

--- a/app/assets/stylesheets/components/_action-panel.scss
+++ b/app/assets/stylesheets/components/_action-panel.scss
@@ -13,4 +13,5 @@ $action-panel-border-color: $color-black;
   position: fixed;
   text-align: center;
   width: 100%;
+  z-index: 1;
 }

--- a/app/assets/stylesheets/components/_calendars.scss
+++ b/app/assets/stylesheets/components/_calendars.scss
@@ -4,15 +4,15 @@ $calendar-today-background: $color-white;
   .fc-resource-cell {
     height: 150px;
     white-space: nowrap;
+
+    div {
+      transform: translateY(120px) rotate(-90deg);
+    }
   }
 
   th {
     border-width: 0;
     overflow: hidden;
-  }
-
-  .fc-resource-cell > div {
-    transform: translateY(120px) rotate(-90deg);
   }
 }
 

--- a/app/assets/stylesheets/components/_calendars.scss
+++ b/app/assets/stylesheets/components/_calendars.scss
@@ -4,9 +4,17 @@ $calendar-today-background: $color-white;
   .fc-resource-cell {
     height: 150px;
     white-space: nowrap;
+    position: relative;
 
     div {
-      transform: translateY(120px) rotate(-90deg);
+      box-sizing: border-box;
+      left: 50%;
+      padding-left: 5px;
+      position: absolute;
+      text-align: left;
+      top: 50%;
+      transform: translateX(-50%) translateY(-50%) rotate(-90deg);
+      width: 150px;
     }
   }
 

--- a/app/assets/stylesheets/components/_calendars.scss
+++ b/app/assets/stylesheets/components/_calendars.scss
@@ -1,5 +1,21 @@
 $calendar-today-background: $color-white;
 
+.guiders-appointments-calendar {
+  .fc-resource-cell {
+    height: 150px;
+    white-space: nowrap;
+  }
+
+  th {
+    border-width: 0;
+    overflow: hidden;
+  }
+
+  .fc-resource-cell > div {
+    transform: translateY(120px) rotate(-90deg);
+  }
+}
+
 .fc-unthemed {
   .fc-today {
     background: $calendar-today-background;

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -1,5 +1,12 @@
+# rubocop:disable Metrics/ClassLength
 class AppointmentsController < ApplicationController
   before_action :authenticate_user!
+
+  def batch_update
+    BatchAppointmentUpdate.new(params[:changes]).call
+
+    redirect_to resource_calendar_path
+  end
 
   def index
     scope = if current_user.resource_manager?

--- a/app/controllers/guiders_controller.rb
+++ b/app/controllers/guiders_controller.rb
@@ -1,0 +1,5 @@
+class GuidersController < ApplicationController
+  def index
+    render json: User.guiders
+  end
+end

--- a/app/controllers/resource_calendars_controller.rb
+++ b/app/controllers/resource_calendars_controller.rb
@@ -1,0 +1,4 @@
+class ResourceCalendarsController < ApplicationController
+  def show
+  end
+end

--- a/app/forms/batch_appointment_update.rb
+++ b/app/forms/batch_appointment_update.rb
@@ -1,0 +1,20 @@
+class BatchAppointmentUpdate
+  def initialize(changes)
+    @changes = JSON.parse(changes)
+  end
+
+  def call
+    changes.each do |change|
+      appointment = Appointment.find(change['id'])
+      appointment.update!(permitted_attributes(change))
+    end
+  end
+
+  private
+
+  def permitted_attributes(change)
+    change.slice('guider_id', 'start_at', 'end_at')
+  end
+
+  attr_reader :changes
+end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -60,7 +60,7 @@ class Appointment < ApplicationRecord
   end
 
   def not_within_two_business_days
-    return unless start_at
+    return unless new_record? && start_at?
 
     too_soon = start_at < BusinessDays.from_now(2)
     errors.add(:start_at, 'must be more than two business days from now') if too_soon

--- a/app/serializers/appointment_serializer.rb
+++ b/app/serializers/appointment_serializer.rb
@@ -1,13 +1,15 @@
 class AppointmentSerializer < ActiveModel::Serializer
   include Rails.application.routes.url_helpers
 
+  attribute :id
   attribute :start_at, key: :start
   attribute :end_at, key: :end
   attribute :title
   attribute :memorable_word
   attribute :phone
-  attribute :url
+  attribute :url, if: -> { instance_options[:include_links] }
   attribute :status
+  attribute :guider_id, key: :resourceId
 
   def title
     "#{object.first_name} #{object.last_name}"

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,4 @@
+class UserSerializer < ActiveModel::Serializer
+  attribute :id
+  attribute :name
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,4 +1,4 @@
 class UserSerializer < ActiveModel::Serializer
   attribute :id
-  attribute :name
+  attribute :name, key: :title
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
       type = $el.data('module'),
       config = $el.data('config');
 
-      new PWTAP[type]($el, config);
+      $el.data('loaded-module', new PWTAP[type]($el, config));
       $el.attr('data-module-loaded', true);
     });
   });

--- a/app/views/resource_calendars/show.html.erb
+++ b/app/views/resource_calendars/show.html.erb
@@ -15,7 +15,7 @@
 </div>
 
 <div class="action-panel t-action-panel" data-action-panel>
-  <form method="post">
+  <%= form_tag batch_update_appointments_path, method: :patch do %>
     <button class="btn btn-primary t-save" data-action-panel-save>
       <span class="glyphicon glyphicon-save" aria-hidden="true"></span> Save changes to
       <b>
@@ -30,6 +30,6 @@
     <button class="btn btn-danger" data-action-panel-undo-all>
       <span class="glyphicon glyphicon-erase" aria-hidden="true"></span> Undo <b>all</b> changes
     </button>
-    <input type="hidden" name="event-changes" id="event-changes">
-  </form>
+    <input type="hidden" name="changes" id="event-changes">
+  <% end %>
 </div>

--- a/app/views/resource_calendars/show.html.erb
+++ b/app/views/resource_calendars/show.html.erb
@@ -1,0 +1,15 @@
+<div class="page-header">
+  <ol class="breadcrumb">
+    <li><a href="<%= root_path %>">Home</a></li>
+    <li class="active">Appointments</li>
+  </ol>
+
+  <h1>Appointments</h1>
+</div>
+
+<div
+  class="guiders-appointments-calendar"
+  data-config='{"editable": true, "eventDurationEditable": true, "slotDuration": "00:10:00"}'
+  data-module="GuidersAppointmentsCalendar"
+  data-default-date="<%= Time.zone.now %>">
+</div>

--- a/app/views/resource_calendars/show.html.erb
+++ b/app/views/resource_calendars/show.html.erb
@@ -8,8 +8,28 @@
 </div>
 
 <div
-  class="guiders-appointments-calendar"
+  class="guiders-appointments-calendar js-calendar"
   data-config='{"editable": true, "eventDurationEditable": true, "slotDuration": "00:10:00"}'
   data-module="GuidersAppointmentsCalendar"
   data-default-date="<%= Time.zone.now %>">
+</div>
+
+<div class="action-panel t-action-panel" data-action-panel>
+  <form method="post">
+    <button class="btn btn-primary t-save" data-action-panel-save>
+      <span class="glyphicon glyphicon-save" aria-hidden="true"></span> Save changes to
+      <b>
+        <span data-action-panel-event-count>0 events</span>
+      </b>
+    </button>
+
+    <button class="btn btn-warning" data-action-panel-undo-one>
+      <span class="glyphicon glyphicon-step-backward" aria-hidden="true"></span> Undo last change
+    </button>
+
+    <button class="btn btn-danger" data-action-panel-undo-all>
+      <span class="glyphicon glyphicon-erase" aria-hidden="true"></span> Undo <b>all</b> changes
+    </button>
+    <input type="hidden" name="event-changes" id="event-changes">
+  </form>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
   resources :customers
   resource :calendar, only: :show
   resources :appointments, only: %i(index show edit update) do
+    patch :batch_update, on: :collection
+
     resources :activities, only: %i(index create)
     get '/search', on: :collection, action: :search
     get :reschedule

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 
   root 'home#index'
 
+  resources :guiders, only: :index
   resources :users do
     resources :schedules
   end
@@ -21,6 +22,7 @@ Rails.application.routes.draw do
     get '/search', on: :collection, action: :search
     get :reschedule
   end
+  resource :resource_calendar, only: :show
   resources :holidays, only: %i(index new create) do
     delete '/', on: :collection, action: :destroy
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -136,7 +136,6 @@ ActiveRecord::Schema.define(version: 20161027165515) do
     t.datetime "created_at",                              null: false
     t.datetime "updated_at",                              null: false
     t.jsonb    "permissions",             default: "[]",  null: false
-    t.index ["permissions"], name: "index_users_on_permissions", using: :gin
   end
 
 end

--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :appointment do
-    start_at { BusinessDays.from_now(3) }
+    start_at { BusinessDays.from_now(3).at_midday }
     end_at { start_at + 1.hour }
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }

--- a/spec/features/resource_manager_modifies_appointments_spec.rb
+++ b/spec/features/resource_manager_modifies_appointments_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.feature 'Resource manager modifies appointments' do
+  scenario 'Rescheduling an appointment', js: true do
+    given_the_user_is_a_resource_manager do
+      and_there_are_appointments_for_multiple_guiders
+      travel_to @appointment.start_at do
+        when_they_view_the_appointments
+        then_they_see_appointments_for_multiple_guiders
+        when_they_reschedule_an_appointment
+        then_the_appointment_is_modified
+      end
+    end
+  end
+
+  def and_there_are_appointments_for_multiple_guiders
+    @ben = create(:guider, name: 'Ben Lovell')
+    @jan = create(:guider, name: 'Jan Schwifty')
+
+    @appointment = create(:appointment, guider: @ben)
+    @other_appointment = create(:appointment, guider: @jan)
+  end
+
+  def when_they_view_the_appointments
+    @page = Pages::ResourceCalendar.new.tap(&:load)
+    expect(@page).to be_displayed
+  end
+
+  def then_they_see_appointments_for_multiple_guiders
+    @page.wait_for_guiders
+
+    expect(@page).to have_guiders(count: 2)
+  end
+
+  def when_they_reschedule_an_appointment
+    skip
+  end
+
+  def then_the_appointment_is_modified
+    skip
+  end
+end

--- a/spec/features/resource_manager_modifies_appointments_spec.rb
+++ b/spec/features/resource_manager_modifies_appointments_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature 'Resource manager modifies appointments' do
         when_they_view_the_appointments
         then_they_see_appointments_for_multiple_guiders
         when_they_reschedule_an_appointment
+        and_commit_their_modifications
         then_the_appointment_is_modified
       end
     end
@@ -28,12 +29,19 @@ RSpec.feature 'Resource manager modifies appointments' do
 
   def then_they_see_appointments_for_multiple_guiders
     @page.wait_for_guiders
-
     expect(@page).to have_guiders(count: 2)
+    expect(@page.guiders.first).to have_text('Ben Lovell')
+
+    @page.wait_for_appointments
+    expect(@page).to have_appointments(count: 2)
   end
 
   def when_they_reschedule_an_appointment
-    skip
+    @page.reschedule(@page.appointments.first, hours: 8, minutes: 30)
+  end
+
+  def and_commit_their_modifications
+    @page.wait_for_action_panel
   end
 
   def then_the_appointment_is_modified

--- a/spec/features/resource_manager_modifies_appointments_spec.rb
+++ b/spec/features/resource_manager_modifies_appointments_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/AbcSize
 require 'rails_helper'
 
 RSpec.feature 'Resource manager modifies appointments' do
@@ -41,10 +42,17 @@ RSpec.feature 'Resource manager modifies appointments' do
   end
 
   def and_commit_their_modifications
-    @page.wait_for_action_panel
+    @page.wait_until_action_panel_visible
+    @page.action_panel.save.click
   end
 
   def then_the_appointment_is_modified
-    skip
+    @appointment.reload
+
+    expect(@appointment.start_at.hour).to eq(8)
+    expect(@appointment.start_at.min).to eq(30)
+
+    expect(@appointment.end_at.hour).to eq(9)
+    expect(@appointment.end_at.min).to eq(30)
   end
 end

--- a/spec/features/roles_spec.rb
+++ b/spec/features/roles_spec.rb
@@ -57,34 +57,6 @@ RSpec.feature 'Roles' do
   end
 
   context 'Users who are not Resource Managers, Agents, or Guiders' do
-    scenario 'Can not attempt appointments' do
-      given_the_user_has_no_permissions do
-        when_they_try_to_attempt_an_appointment
-        then_they_are_locked_out
-      end
-    end
-
-    scenario 'Can not book appointments' do
-      given_the_user_has_no_permissions do
-        when_they_try_to_book_an_appointment
-        then_they_are_locked_out
-      end
-    end
-
-    scenario 'Can edit appointments' do
-      given_the_user_has_no_permissions do
-        when_they_try_to_edit_appointments
-        then_they_are_allowed
-      end
-    end
-
-    scenario 'Can not reschedule appointments' do
-      given_the_user_has_no_permissions do
-        when_they_try_to_reschedule_an_appoinment
-        then_they_are_locked_out
-      end
-    end
-
     scenario 'Can not manage guiders' do
       given_the_user_has_no_permissions do
         when_they_try_to_manager_guiders

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -31,10 +31,14 @@ RSpec.describe Appointment, type: :model do
       end
     end
 
-    it 'cannot be booked within two working days' do
-      subject.start_at = BusinessDays.from_now(1)
-      subject.validate
-      expect(subject.errors[:start_at]).to_not be_empty
+    context 'when not persisted' do
+      before { allow(subject).to receive(:new_record?).and_return(true) }
+
+      it 'cannot be booked within two working days' do
+        subject.start_at = BusinessDays.from_now(1)
+        subject.validate
+        expect(subject.errors[:start_at]).to_not be_empty
+      end
     end
 
     it 'cannot be booked further ahead than thirty working days' do

--- a/spec/support/pages/resource_calendar.rb
+++ b/spec/support/pages/resource_calendar.rb
@@ -1,0 +1,7 @@
+module Pages
+  class ResourceCalendar < SitePrism::Page
+    set_url '/resource_calendar'
+
+    elements :guiders, '.fc-resource-cell'
+  end
+end

--- a/spec/support/pages/resource_calendar.rb
+++ b/spec/support/pages/resource_calendar.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/MethodLength
 module Pages
   class ResourceCalendar < SitePrism::Page
     set_url '/resource_calendar'
@@ -21,6 +22,7 @@ module Pages
           event.end.hours(#{hours + 1}).minutes(#{minutes});
 
           calendar.fullCalendar('updateEvent', event);
+          calendar.data('loaded-module').handleEventChange(event, function() {});
         }();
       JS
     end

--- a/spec/support/pages/resource_calendar.rb
+++ b/spec/support/pages/resource_calendar.rb
@@ -3,5 +3,26 @@ module Pages
     set_url '/resource_calendar'
 
     elements :guiders, '.fc-resource-cell'
+    elements :appointments, '.fc-event'
+
+    section :action_panel, '.t-action-panel' do
+      element :save, '.t-save'
+    end
+
+    def reschedule(appointment, hours:, minutes:)
+      id = appointment['id']
+
+      page.driver.evaluate_script <<-JS
+        function() {
+          var calendar = $('.js-calendar');
+          var event = calendar.fullCalendar('clientEvents', #{id})[0];
+
+          event.start.hours(#{hours}).minutes(#{minutes});
+          event.end.hours(#{hours + 1}).minutes(#{minutes});
+
+          calendar.fullCalendar('updateEvent', event);
+        }();
+      JS
+    end
   end
 end


### PR DESCRIPTION
Adds the basis of the resource manager's appointments calendar. From here they
can currently move appointments around in terms of timing and the guider
carrying them out.

The commits just break things up a bit as there is a whole bunch of code here.
I'll squash things down after the review.