### PR TITLE
Renamed guiders-schedules to guider-schedule-chart

### DIFF
--- a/app/assets/javascripts/guider-schedules-chart.es6
+++ b/app/assets/javascripts/guider-schedules-chart.es6
@@ -2,7 +2,7 @@
 {
   'use strict';
 
-  class GuiderSchedulesCalendar {
+  class GuiderSchedulesChart {
     constructor(el, config = {}) {
       const defaultConfig = {
         gridColumns: 12,
@@ -111,5 +111,5 @@
   }
 
   window.PWTAP = window.PWTAP || {};
-  window.PWTAP.GuiderSchedulesCalendar = GuiderSchedulesCalendar;
+  window.PWTAP.GuiderSchedulesChart = GuiderSchedulesChart;
 }

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -23,7 +23,7 @@
 </div>
 
 <% if @schedules.any? %>
-  <div class="guider-schedules" data-module="GuiderSchedulesCalendar" data-config='{"guiderScheduleDataSourceElementId": "guider-schedules"}' aria-hidden="true">
+  <div class="guider-schedules" data-module="GuiderSchedulesChart" data-config='{"guiderScheduleDataSourceElementId": "guider-schedules"}' aria-hidden="true">
     <div class="row">
       <div class="col-xs-12">
         <div class="guider-schedules__months"></div>


### PR DESCRIPTION
- moved the chart away from the calendar folder as it's not
  a class which inherits from calendar.es6