### PR TITLE
Consolidate navigation into dropdown menus

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,14 +5,30 @@
 <% end %>
 
 <% content_for :navbar_items do %>
-  <% if current_user.resource_manager? %>
-    <%= active_link_to 'Manage guiders', users_path, wrap_tag: :li %>
-    <%= active_link_to 'Holidays', holidays_path, wrap_tag: :li %>
-  <% end %>
-  <% if current_user.agent? %>
-    <%= active_link_to 'Book appointment', new_appointment_attempt_path, wrap_tag: :li %>
+  <li class="dropdown">
+    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Appointments <span class="caret"></span></a>
+    <ul class="dropdown-menu">
+      <%= active_link_to 'Search', search_appointments_path, wrap_tag: :li %>
+      <%= active_link_to 'Book appointment', new_appointment_attempt_path, wrap_tag: :li %>
+
+      <% if current_user.resource_manager? %>
+        <%= active_link_to 'Allocations', resource_calendar_path, wrap_tag: :li %>
+      <% end %>
+    </ul>
+  </li>
+
+  <% if current_user.guider? %>
     <%= active_link_to 'My appointments', calendar_path, wrap_tag: :li %>
-    <%= active_link_to 'Search', search_appointments_path, wrap_tag: :li %>
+  <% end %>
+
+  <% if current_user.resource_manager? %>
+    <li class="dropdown">
+      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Availability <span class="caret"></span></a>
+      <ul class="dropdown-menu">
+        <%= active_link_to 'Groups & schedules', users_path, wrap_tag: :li %>
+        <%= active_link_to 'Holidays & unavailability', holidays_path, wrap_tag: :li %>
+      </ul>
+    </li>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
We were running out of room a little bit.

Also adds a link to the resource manager calendar if applicable. The labels could probably be improved but it looks less broken for now.

<img width="854" alt="screen shot 2016-10-31 at 14 28 32" src="https://cloud.githubusercontent.com/assets/295469/19857763/cda6c4be-9f76-11e6-8b40-7a1f95405876.png">
