### PR TITLE
Allow any user to book and reschedule appointments

### DIFF
--- a/app/controllers/appointment_attempts_controller.rb
+++ b/app/controllers/appointment_attempts_controller.rb
@@ -1,6 +1,4 @@
 class AppointmentAttemptsController < ApplicationController
-  before_action :authorise_for_agents!
-
   def new
     @appointment_attempt = AppointmentAttempt.new
   end

--- a/spec/features/roles_spec.rb
+++ b/spec/features/roles_spec.rb
@@ -33,30 +33,28 @@ RSpec.feature 'Roles' do
     end
   end
 
-  context 'Agents' do
+  context 'Users who are not Resource Managers, Agents, or Guiders' do
     scenario 'Can attempt appointments' do
-      given_the_user_is_an_agent do
+      given_the_user_has_no_permissions do
         when_they_try_to_attempt_an_appointment
         then_they_are_allowed
       end
     end
 
     scenario 'Can book appointments' do
-      given_the_user_is_an_agent do
+      given_the_user_has_no_permissions do
         when_they_try_to_book_an_appointment
         then_they_are_allowed
       end
     end
 
     scenario 'Can reschedule appointments' do
-      given_the_user_is_an_agent do
+      given_the_user_has_no_permissions do
         when_they_try_to_reschedule_an_appoinment
         then_they_are_allowed
       end
     end
-  end
 
-  context 'Users who are not Resource Managers, Agents, or Guiders' do
     scenario 'Can not manage guiders' do
       given_the_user_has_no_permissions do
         when_they_try_to_manager_guiders


### PR DESCRIPTION
Sometimes a guider will call the customer at the scheduled time,
and the customer is no longer available. Often the guider will
simply book another appointment for the customer at this stage.

There are other times that TPAS will want to book appointments in
the case that the customer has called through via a means other
than the contact centre.