### PR TITLE
Ensure that list js ordering of appointments in search works

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -35,8 +35,8 @@ class Appointment < ApplicationRecord
   audited on: %i(create update)
 
   def self.full_search(query, start_at, end_at)
-    results = all
-    results = results.search(query) if query.present?
+    results = query.present? ? search(query) : order(created_at: :desc)
+
     if start_at && end_at
       results = results
                 .where('start_at > ?', start_at)

--- a/app/presenters/appointment_presenter.rb
+++ b/app/presenters/appointment_presenter.rb
@@ -5,6 +5,10 @@ class AppointmentPresenter < SimpleDelegator
     super.titleize
   end
 
+  def created_at
+    super.strftime(DATE_FORMAT)
+  end
+
   def date
     start_at.strftime(DATE_FORMAT)
   end

--- a/app/views/appointments/search.html.erb
+++ b/app/views/appointments/search.html.erb
@@ -31,13 +31,14 @@
   </div>
 </div>
 
-<table id="results" class="table table-striped table-bordered table-hover" data-module="SortableList" data-config='{"valueNames": ["id", "first_name", "last_name", "date", "status"]}' data-default-order='{"value": "id", "order": "asc"}'>
+<table id="results" class="table table-striped table-bordered table-hover" data-module="SortableList" data-config='{"valueNames": ["id", "created", "first_name", "last_name", "appointment_date", "status"]}' data-default-order='{"value": "created", "order": "desc"}'>
   <thead>
     <tr>
       <th><span class="sort" data-sort="id">Reference</span></th>
+      <th><span class="sort" data-sort="created">Created</span></th>
       <th><span class="sort" data-sort="first_name">First Name</span></th>
       <th><span class="sort" data-sort="last_name">Last Name</span></th>
-      <th><span class="sort" data-sort="date">Date</span></th>
+      <th><span class="sort" data-sort="appointment_date">Appointment Date/Time</span></th>
       <th><span class="sort" data-sort="status">Status</span></th>
       <th width="1%">Actions</th>
     </tr>
@@ -47,9 +48,10 @@
       <% result = AppointmentPresenter.new(result) %>
       <tr class='t-result'>
         <td class='t-id'><span class="id"><%= result.id %></span></td>
+        <td><span class="created"><%= result.created_at %></span></td>
         <td><span class="first_name"><%= result.first_name %></span></td>
         <td><span class="last_name"><%= result.last_name %></span></td>
-        <td><span class="date"><%= result.date %></span></td>
+        <td><span class="appointment_date"><%= result.date %></span></td>
         <td><span class="status"><%= result.status %></span></td>
         <td nowrap="true">
           <%= link_to edit_appointment_path(result), title: 'Edit appointment', class: 'btn btn-info' do %>

--- a/spec/features/agent_searches_for_appointments_spec.rb
+++ b/spec/features/agent_searches_for_appointments_spec.rb
@@ -27,7 +27,13 @@ RSpec.feature 'Agent searches for appointments' do
   end
 
   def and_appointments_exist
-    @appointments = create_list(:appointment, 3)
+    from = BusinessDays.from_now(3).at_midday
+
+    @appointments = [
+      create(:appointment, created_at: from + 2.seconds),
+      create(:appointment, created_at: from + 1.second),
+      create(:appointment, created_at: from)
+    ]
   end
 
   def when_they_search_for_nothing

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -152,7 +152,13 @@ RSpec.describe Appointment, type: :model do
 
   describe '#full_search' do
     before do
-      @appointments = create_list(:appointment, 3)
+      from = BusinessDays.from_now(3).at_midday
+
+      @appointments = [
+        create(:appointment, created_at: from + 2.seconds),
+        create(:appointment, created_at: from + 1.second),
+        create(:appointment, created_at: from)
+      ]
     end
 
     def results(q, start_at, end_at)


### PR DESCRIPTION
- ordering the search page by default by created_at
- when there is a search it orders by relevance
- added created_at as a column for clarity