### PR TITLE
Ensure action panel doesn't overlay bottom of calendar

### DIFF
--- a/app/assets/javascripts/calendars/guiders-appointments.es6
+++ b/app/assets/javascripts/calendars/guiders-appointments.es6
@@ -30,13 +30,16 @@
 
       super(el, calendarConfig);
 
-      this.alterHeight();
-      $(window).on('resize', this.debounce(this.alterHeight.bind(this), 20));
-
       this.eventChanges = [];
       this.actionPanel = $('[data-action-panel]');
 
+      this.setCalendarToCorrectHeight();
       this.setupUndo();
+    }
+
+    setCalendarToCorrectHeight() {
+      this.alterHeight();
+      $(window).on('resize', this.debounce(this.alterHeight.bind(this), 20));
     }
 
     debounce(func, wait, immediate) {
@@ -57,7 +60,13 @@
     }
 
     getHeight() {
-      return $(window).height() - this.$el.offset().top - $('.page-footer').outerHeight(true);
+      let height = $(window).height() - this.$el.offset().top - $('.page-footer').outerHeight(true);
+
+      if (this.actionPanel.is(':visible')) {
+        height -= this.actionPanel.height();
+      }
+
+      return height;
     }
 
     alterHeight() {
@@ -222,15 +231,19 @@
     checkToShowActionPanel() {
       const eventsChanged = this.uniqueEventsChanged();
 
+      let fadeAction = 'fadeIn';
+
       if (eventsChanged > 0) {
         this.actionPanel.find('[data-action-panel-event-count]').html(
           `${eventsChanged} event${eventsChanged == 1 ? '':'s'}`
         );
-
-        this.actionPanel.fadeIn();
       } else {
-        this.actionPanel.fadeOut();
+        fadeAction = 'fadeOut';
       }
+
+      this.actionPanel[fadeAction]({
+        complete: this.alterHeight.bind(this)
+      });
     }
 
     uniqueEventsChanged() {


### PR DESCRIPTION
- the resource calendar changes height to ensure we don't
  get a scroll within a scroll situation. When the action
  panel is displayed this could potentially obscure the
  bottom of the calendar - this fixes that issue!