### PR TITLE
Revert "Start appointments id at 100,000"

### DIFF
--- a/db/migrate/20161103134203_bump_appointments_id.rb
+++ b/db/migrate/20161103134203_bump_appointments_id.rb
@@ -1,5 +1,0 @@
-class BumpAppointmentsId < ActiveRecord::Migration[5.0]
-  def change
-    execute 'ALTER SEQUENCE appointments_id_seq RESTART 100000'
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161103134203) do
+ActiveRecord::Schema.define(version: 20161101163901) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This reverts commit 4e241309baac877c2795000fedb4fc4b4a10e60d.

This won't work under dbs that have been schema loaded.