### PR TITLE
Ensure calendar doesn't break when guider for an event doesn't exist

### DIFF
--- a/app/assets/javascripts/calendars/guiders-appointments.es6
+++ b/app/assets/javascripts/calendars/guiders-appointments.es6
@@ -77,7 +77,7 @@
         return;
       }
 
-      var resource = this.$el.fullCalendar('getResourceById', event.resourceId);
+      const resource = this.$el.fullCalendar('getResourceById', event.resourceId);
 
       element.qtip({
         position: {
@@ -90,7 +90,7 @@
           text: `
           <p>${event.start.format('HH:mm')} - ${event.end.format('HH:mm')}</p>
           <p><span class="glyphicon glyphicon-phone-alt" aria-hidden="true"></span> ${event.title}</p>
-          <p><span class="glyphicon glyphicon-user" aria-hidden="true"></span> ${resource.title}</p>
+          <p><span class="glyphicon glyphicon-user" aria-hidden="true"></span> ${resource && resource.title ? resource.title : 'Unknown guider'}</p>
           `
         }
       });


### PR DESCRIPTION
- in the odd situation where there is an event without a guider
  in the resource list this ensures that the calendar doesn't
  break when in timeline mode