### PR TITLE
Showing cancelled appointments on the resource calendar

### DIFF
--- a/app/assets/javascripts/calendars/guiders-appointments.es6
+++ b/app/assets/javascripts/calendars/guiders-appointments.es6
@@ -118,12 +118,12 @@
         );
       }
 
+      element.removeClass('fc-event--moved fc-event--cancelled');
+
       if (event.hasChanged) {
-        event.backgroundColor = 'red';
-        event.borderColor = '#c00';
-      } else {
-        delete event.backgroundColor;
-        delete event.borderColor;
+        element.addClass('fc-event--moved');
+      } else if(event.cancelled) {
+        element.addClass('fc-event--cancelled');
       }
     }
 

--- a/app/assets/stylesheets/components/_calendars.scss
+++ b/app/assets/stylesheets/components/_calendars.scss
@@ -1,4 +1,6 @@
 $calendar-today-background: $color-white;
+$calendar-cancelled-background: $color-guardsman-red;
+$calendar-moved-background: $color-green;
 
 .guiders-appointments-calendar {
   .fc-resource-cell {
@@ -70,4 +72,13 @@ $calendar-today-background: $color-white;
   position: absolute;
   right: 150px;
   top: 20px;
+}
+
+.fc-event--cancelled {
+  background: $calendar-cancelled-background;
+  opacity: .5;
+}
+
+.fc-event--moved {
+  background: $calendar-moved-background;
 }

--- a/app/assets/stylesheets/lib/_colours.scss
+++ b/app/assets/stylesheets/lib/_colours.scss
@@ -2,7 +2,9 @@
 $color-alto: #ddd;
 $color-black: #000;
 $color-feijoa: #8fdf82;
+$color-green: #0c0;
 $color-givry: #f7f2c3;
+$color-guardsman-red: #c00;
 $color-roman: #d9534f;
 $color-silver: #ccc;
 $color-white: #fff;

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -49,6 +49,10 @@ class Appointment < ApplicationRecord
     "#{first_name} #{last_name}"
   end
 
+  def cancelled?
+    status.start_with?('cancelled')
+  end
+
   def assign_to_guider
     slot = BookableSlot
            .without_appointments

--- a/app/serializers/appointment_serializer.rb
+++ b/app/serializers/appointment_serializer.rb
@@ -9,6 +9,7 @@ class AppointmentSerializer < ActiveModel::Serializer
   attribute :phone
   attribute :url, if: -> { instance_options[:include_links] }
   attribute :status
+  attribute :cancelled
   attribute :guider_id, key: :resourceId
 
   def title
@@ -17,5 +18,9 @@ class AppointmentSerializer < ActiveModel::Serializer
 
   def url
     edit_appointment_path(object)
+  end
+
+  def cancelled
+    object.cancelled?
   end
 end


### PR DESCRIPTION
- cancelled appointments are now red (and transparent)
- moved appointments are now altered to be green