### PR TITLE
Rewrite JS modules to use GOVUK Admin template module loader

### DIFF
--- a/app/assets/javascripts/activity-feed-poller.es6
+++ b/app/assets/javascripts/activity-feed-poller.es6
@@ -1,18 +1,12 @@
 'use strict';
 
-class ActivityFeedPoller {
-  constructor(el, config = {}) {
-    const defaultConfig = { };
-    this.config = $.extend(true, defaultConfig, config);
+class ActivityFeedPoller extends TapBase {
+  start(el) {
+    super.start(el);
 
-    this.$el = el;
     this.$messageForm = this.$el.find('.js-message-form');
 
     this.setLastTimestamp(this.timestamp());
-    this.start();
-  }
-
-  start() {
     setInterval(() => this.poll(), this.$el.data('interval'));
   }
 
@@ -47,5 +41,4 @@ class ActivityFeedPoller {
   }
 }
 
-window.PWTAP = window.PWTAP || {};
-window.PWTAP.ActivityFeedPoller = ActivityFeedPoller;
+window.GOVUKAdmin.Modules.ActivityFeedPoller = ActivityFeedPoller;

--- a/app/assets/javascripts/advanced-select.es6
+++ b/app/assets/javascripts/advanced-select.es6
@@ -1,14 +1,13 @@
 'use strict';
 
-class AdvancedSelect {
-  constructor(el, config = {}) {
-    const defaultConfig = {
+class AdvancedSelect extends TapBase {
+  start(el) {
+    this.config = {
       theme: 'bootstrap',
       templateResult: this.renderTemplate.bind(this)
     };
 
-    this.config = $.extend(true, defaultConfig, config);
-    this.$el = el;
+    super.start(el);
 
     this.$el.select2(this.config);
     this.$el.on('select2:select', this.handleSelect.bind(this));
@@ -41,5 +40,4 @@ class AdvancedSelect {
   }
 }
 
-window.PWTAP = window.PWTAP || {};
-window.PWTAP.AdvancedSelect = AdvancedSelect;
+window.GOVUKAdmin.Modules.AdvancedSelect = AdvancedSelect;

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,6 +17,7 @@
 //= require listjs
 //= require bootstrap-daterangepicker
 //= require core.js/core.js
+//= require tap-base
 //= require calendar
 //= require customer-age
 //= require calendars/appointment-availability

--- a/app/assets/javascripts/calendar.es6
+++ b/app/assets/javascripts/calendar.es6
@@ -2,15 +2,11 @@
 
 'use strict';
 
-window.PWTAP = window.PWTAP || {};
-
-class Calendar {
-  constructor(el, config = {}) {
-    this.$el = el;
-
+class Calendar extends TapBase {
+  start(el) {
     const defaultConfig = {
       allDaySlot: false,
-      cookieName: this.$el.attr('id') || 'calendar',
+      cookieName: el.attr('id') || 'calendar',
       customButtons: {
         jumpToDate: {
           text: 'Jump to date',
@@ -24,7 +20,7 @@ class Calendar {
         month: 'Month',
         week: 'Week'
       },
-      defaultDate: moment(this.$el.data('default-date')),
+      defaultDate: moment(el.data('default-date')),
       firstDay: 1,
       height: 'auto',
       maxTime: '19:00:00',
@@ -47,9 +43,10 @@ class Calendar {
     this.config = $.extend(
       true,
       defaultConfig,
-      config,
-      this.getCookieConfig(defaultConfig.cookieName)
+      this.config
     );
+
+    super.start(el);
 
     this.$el.fullCalendar(this.config);
 
@@ -108,16 +105,6 @@ class Calendar {
 
   getCurrentDate(format = 'YYYY-MM-DD') {
     return this.$el.fullCalendar('getDate').format(format);
-  }
-
-  getCookieConfig(cookieName) {
-    const cookieValue = GOVUKAdmin.cookie(cookieName);
-
-    if (cookieValue) {
-      return JSON.parse(cookieValue);
-    }
-
-    return {};
   }
 
   loading(isLoading) {

--- a/app/assets/javascripts/calendars/appointment-availability.es6
+++ b/app/assets/javascripts/calendars/appointment-availability.es6
@@ -3,8 +3,8 @@
   'use strict';
 
   class AppointmentAvailabilityCalendar extends Calendar {
-    constructor(el, config = {}) {
-      const calendarConfig = $.extend(true, {
+    start(el) {
+      this.config = {
         defaultView: 'agendaWeek',
         weekends: false,
         columnFormat: 'ddd D/M',
@@ -21,9 +21,9 @@
             duration: { days: 3 }
           }
         }
-      }, config);
+      };
 
-      super(el, calendarConfig);
+      super.start(el);
 
       this.coloursConfig = [
         { count: 1,  colour: 'hsl(200, 50%, 65%)' },
@@ -129,6 +129,5 @@
     }
   }
 
-  window.PWTAP = window.PWTAP || {};
-  window.PWTAP.AppointmentAvailabilityCalendar = AppointmentAvailabilityCalendar;
+  window.GOVUKAdmin.Modules.AppointmentAvailabilityCalendar = AppointmentAvailabilityCalendar;
 }

--- a/app/assets/javascripts/calendars/guider-appointments.es6
+++ b/app/assets/javascripts/calendars/guider-appointments.es6
@@ -3,8 +3,8 @@
   'use strict';
 
   class GuiderAppointmentsCalendar extends Calendar {
-    constructor(el, config = {}) {
-      const calendarConfig = $.extend(true, {
+    start(el) {
+      this.config = {
         columnFormat: 'ddd D/M',
         defaultView: 'agendaDay',
         header: {
@@ -14,16 +14,16 @@
         slotDuration: '00:30:00',
         eventTextColor: '#fff',
         events: '/appointments'
-      }, config);
+      };
 
-      super(el, calendarConfig);
+      super.start(el);
 
       this.guiderId = this.$el.data('guider-id');
       this.setupPusher();
     }
 
     setupPusher() {
-      var channel = Pusher.instance.subscribe('telephone_appointment_planner');
+      const channel = Pusher.instance.subscribe('telephone_appointment_planner');
       channel.bind(`${this.guiderId}`, this.handlePushEvent.bind(this));
     }
 
@@ -56,6 +56,5 @@
     }
   }
 
-  window.PWTAP = window.PWTAP || {};
-  window.PWTAP.GuiderAppointmentsCalendar = GuiderAppointmentsCalendar;
+  window.GOVUKAdmin.Modules.GuiderAppointmentsCalendar = GuiderAppointmentsCalendar;
 }

--- a/app/assets/javascripts/calendars/guider-slot-picker.es6
+++ b/app/assets/javascripts/calendars/guider-slot-picker.es6
@@ -3,8 +3,8 @@
   'use strict';
 
   class GuiderSlotPickerCalendar extends Calendar {
-    constructor(el, config = {}) {
-      const calendarConfig = $.extend(true, {
+    start(el) {
+      this.config = {
         columnFormat: 'dddd',
         defaultView: 'agendaWeek',
         editable: true,
@@ -18,9 +18,9 @@
         selectHelper: true,
         slotDuration: '00:10:00',
         slotEventOverlap: false
-      }, config);
+      };
 
-      super(el, calendarConfig);
+      super.start(el);
 
       this.addEvents();
       this.generateJSON();
@@ -138,6 +138,5 @@
     }
   }
 
-  window.PWTAP = window.PWTAP || {};
-  window.PWTAP.GuiderSlotPickerCalendar = GuiderSlotPickerCalendar;
+  window.GOVUKAdmin.Modules.GuiderSlotPickerCalendar = GuiderSlotPickerCalendar;
 }

--- a/app/assets/javascripts/calendars/guiders-appointments.es6
+++ b/app/assets/javascripts/calendars/guiders-appointments.es6
@@ -3,8 +3,8 @@
   'use strict';
 
   class GuidersAppointmentsCalendar extends Calendar {
-    constructor(el, config = {}) {
-      const calendarConfig = $.extend(true, {
+    start(el) {
+      this.config = {
         columnFormat: 'ddd D/M',
         defaultView: 'agendaDay',
         resourceLabelText: 'Guiders',
@@ -26,9 +26,9 @@
             rendering: 'background'
           }
         ]
-      }, config);
+      };
 
-      super(el, calendarConfig);
+      super.start(el);
 
       this.eventChanges = [];
       this.actionPanel = $('[data-action-panel]');
@@ -258,6 +258,5 @@
     }
   }
 
-  window.PWTAP = window.PWTAP || {};
-  window.PWTAP.GuidersAppointmentsCalendar = GuidersAppointmentsCalendar;
+  window.GOVUKAdmin.Modules.GuidersAppointmentsCalendar = GuidersAppointmentsCalendar;
 }

--- a/app/assets/javascripts/calendars/holidays.es6
+++ b/app/assets/javascripts/calendars/holidays.es6
@@ -3,8 +3,8 @@
   'use strict';
 
   class HolidaysCalendar extends Calendar {
-    constructor(el, config = {}) {
-      const calendarConfig = $.extend(true, {
+    start(el) {
+      this.config = {
         defaultView: 'agendaWeek',
         columnFormat: 'ddd D/M',
         slotDuration: '00:30:00',
@@ -19,9 +19,9 @@
             duration: { days: 3 }
           }
         }
-      }, config);
+      };
 
-      super(el, calendarConfig);
+      super.start(el);
     }
 
     eventRender(event, element) {
@@ -48,6 +48,5 @@
     }
   }
 
-  window.PWTAP = window.PWTAP || {};
-  window.PWTAP.HolidaysCalendar = HolidaysCalendar;
+  window.GOVUKAdmin.Modules.HolidaysCalendar = HolidaysCalendar;
 }

--- a/app/assets/javascripts/customer-age.es6
+++ b/app/assets/javascripts/customer-age.es6
@@ -2,10 +2,9 @@
 {
   'use strict';
 
-  class CustomerAge {
-    constructor(el, config = {}) {
-      this.$el = el;
-      this.config = config;
+  class CustomerAge extends TapBase {
+    start(el) {
+      super.start(el);
 
       this.$day = this.$el.find('.js-dob-day');
       this.$month = this.$el.find('.js-dob-month');
@@ -47,6 +46,5 @@
     }
   }
 
-  window.PWTAP = window.PWTAP || {};
-  window.PWTAP.CustomerAge = CustomerAge;
+  window.GOVUKAdmin.Modules.CustomerAge = CustomerAge;
 }

--- a/app/assets/javascripts/date-range-picker.es6
+++ b/app/assets/javascripts/date-range-picker.es6
@@ -2,22 +2,22 @@
 {
   'use strict';
 
-  class DateRangePicker {
-    constructor(el, config = {}) {
-      this.$el = el;
-      const defaultConfig = {
+  class DateRangePicker extends TapBase {
+    start(el) {
+      this.config = {
         timePicker24Hour: true,
         locale: {
           format: 'D MMM YYYY'
         }
       };
 
-      this.config = $.extend(true, defaultConfig, config);
+      super.start(el);
+
       this.init();
 
-      if (config.autoUpdateInput == false) {
+      if (this.config.autoUpdateInput == false) {
         this.$el.on('apply.daterangepicker', function(ev, picker) {
-          $(this).val(picker.startDate.format(config.locale.format) + ' - ' + picker.endDate.format(config.locale.format));
+          $(this).val(picker.startDate.format(this.config.locale.format) + ' - ' + picker.endDate.format(this.config.locale.format));
         });
         this.$el.on('cancel.daterangepicker', function(ev, picker) {
           $(this).val('');
@@ -30,6 +30,5 @@
     }
   }
 
-  window.PWTAP = window.PWTAP || {};
-  window.PWTAP.DateRangePicker = DateRangePicker;
+  window.GOVUKAdmin.Modules.DateRangePicker = DateRangePicker;
 }

--- a/app/assets/javascripts/guider-schedules-chart.es6
+++ b/app/assets/javascripts/guider-schedules-chart.es6
@@ -2,9 +2,9 @@
 {
   'use strict';
 
-  class GuiderSchedulesChart {
-    constructor(el, config = {}) {
-      const defaultConfig = {
+  class GuiderSchedulesChart extends TapBase {
+    start(el) {
+      this.config = {
         gridColumns: 12,
         windowStartMonthsAgo: 1,
         windowLengthInMonths: 12,
@@ -20,8 +20,8 @@
         }
       };
 
-      this.config = $.extend(true, defaultConfig, config);
-      this.$el = el;
+      super.start(el);
+
       this.today = moment().startOf('day');
 
       this.displayMonths();
@@ -110,6 +110,5 @@
     }
   }
 
-  window.PWTAP = window.PWTAP || {};
-  window.PWTAP.GuiderSchedulesChart = GuiderSchedulesChart;
+  window.GOVUKAdmin.Modules.GuiderSchedulesChart = GuiderSchedulesChart;
 }

--- a/app/assets/javascripts/guiders-multi-action.es6
+++ b/app/assets/javascripts/guiders-multi-action.es6
@@ -1,13 +1,14 @@
 {
   'use strict';
 
-  class GuidersMultiAction {
-    constructor(el, config = {}) {
-      this.$el = el;
-      this.config = config;
+  class GuidersMultiAction extends TapBase {
+    start(el) {
+      super.start(el);
+
       this.$actionPanel = this.$el.find('[data-action-panel]');
       this.$actionsSelect = this.$actionPanel.find('[data-action-panel-actions]');
       this.$goButton = this.$actionPanel.find('[data-action-panel-go]');
+
       this.bindEvents();
       this.hideActionPanel();
     }
@@ -69,6 +70,5 @@
     }
   }
 
-  window.PWTAP = window.PWTAP || {};
-  window.PWTAP.GuidersMultiAction = GuidersMultiAction;
+  window.GOVUKAdmin.Modules.GuidersMultiAction = GuidersMultiAction;
 }

--- a/app/assets/javascripts/multi-checkbox.es6
+++ b/app/assets/javascripts/multi-checkbox.es6
@@ -1,12 +1,13 @@
 {
   'use strict';
 
-  class MultiCheckbox {
-    constructor(el, config = {}) {
-      this.$el = el;
-      this.config = config;
+  class MultiCheckbox extends TapBase {
+    start(el) {
+      super.start(el);
+
       this.allCheckbox = this.$el.find('[data-multi-checkbox="all"]');
       this.itemCheckboxes = this.$el.find('[data-multi-checkbox="item"]');
+
       this.bindEvents();
     }
 
@@ -54,6 +55,5 @@
     }
   }
 
-  window.PWTAP = window.PWTAP || {};
-  window.PWTAP.MultiCheckbox = MultiCheckbox;
+  window.GOVUKAdmin.Modules.MultiCheckbox = MultiCheckbox;
 }

--- a/app/assets/javascripts/sortable-list.es6
+++ b/app/assets/javascripts/sortable-list.es6
@@ -2,10 +2,9 @@
 {
   'use strict';
 
-  class SortableList {
-    constructor(el, config = {}) {
-      this.$el = el;
-      this.config = config;
+  class SortableList extends TapBase {
+    start(el) {
+      super.start(el);
 
       this.setupSortButtons();
       this.init();
@@ -41,6 +40,5 @@
     }
   }
 
-  window.PWTAP = window.PWTAP || {};
-  window.PWTAP.SortableList = SortableList;
+  window.GOVUKAdmin.Modules.SortableList = SortableList;
 }

--- a/app/assets/javascripts/tap-base.es6
+++ b/app/assets/javascripts/tap-base.es6
@@ -1,0 +1,30 @@
+'use strict';
+
+class TapBase {
+  start(el) {
+    this.$el = el;
+
+    this.config = $.extend(
+      true,
+      this.config || {},
+      this.getElementConfig(),
+      this.getCookieConfig()
+    );
+  }
+
+  getElementConfig() {
+    return this.$el.data('config');
+  }
+
+  getCookieConfig() {
+    if (this.config && this.config.cookieName) {
+      const cookieValue = GOVUKAdmin.cookie(this.config.cookieName);
+
+      if (cookieValue) {
+        return JSON.parse(cookieValue);
+      }
+    }
+
+    return {};
+  }
+}

--- a/app/views/activities/_activity_feed.html.erb
+++ b/app/views/activities/_activity_feed.html.erb
@@ -17,7 +17,7 @@
         <% end %>
       </div>
       <ul class="activity-feed__list"
-        data-module='ActivityFeedPoller'
+        data-module='activity-feed-poller'
         data-interval="<%= poll_interval_milliseconds %>"
         data-url="<%= appointment_activities_path(appointment) %>">
         <%= render appointment.activities.first if appointment.activities.present? %>

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -23,7 +23,7 @@
       <div
           id="AppointmentAvailabilityCalendar"
           class="appointment-availability-calendar"
-          data-module="AppointmentAvailabilityCalendar"
+          data-module="appointment-availability-calendar"
           data-available-slots-path="<%= bookable_slots_available_path %>"
           data-default-date="<%= BookableSlot.next_valid_start_date %>"
       ></div>

--- a/app/views/appointments/reschedule.html.erb
+++ b/app/views/appointments/reschedule.html.erb
@@ -22,7 +22,7 @@
       <div
         id="AppointmentAvailabilityCalendar"
         class="appointment-availability-calendar"
-        data-module="AppointmentAvailabilityCalendar"
+        data-module="appointment-availability-calendar"
         data-available-slots-path="<%= bookable_slots_available_path %>"
         data-default-date="<%= BookableSlot.next_valid_start_date %>"
       ></div>

--- a/app/views/appointments/search.html.erb
+++ b/app/views/appointments/search.html.erb
@@ -15,7 +15,7 @@
           :date_range,
           class: 't-date-range',
           data: {
-            module: 'DateRangePicker',
+            module: 'date-range-picker',
             config: {
               autoUpdateInput: false,
               locale: {

--- a/app/views/calendars/show.html.erb
+++ b/app/views/calendars/show.html.erb
@@ -8,7 +8,8 @@
 </div>
 
 <div
-  data-module="GuiderAppointmentsCalendar"
+  id="GuiderAppointmentsCalendar"
+  data-module="guider-appointments-calendar"
   data-default-date="<%= Time.zone.now %>"
   data-guider-id="<%= current_user.id %>"
 ></div>
@@ -30,15 +31,13 @@
 
 <% content_for :body_end do %>
   <script>
-    $(function() {
-      <% if defined?(PusherFake) %>
-          Pusher.instance = <%= raw PusherFake.javascript %>;
-      <% else %>
-          Pusher.instance = new Pusher('<%= ENV['PUSHER_KEY'] %>', {
-            cluster: 'eu',
-            encrypted: true
-          });
-      <% end %>
-    });
+  <% if defined?(PusherFake) %>
+      Pusher.instance = <%= raw PusherFake.javascript %>;
+  <% else %>
+      Pusher.instance = new Pusher('<%= ENV['PUSHER_KEY'] %>', {
+        cluster: 'eu',
+        encrypted: true
+      });
+  <% end %>
   </script>
 <% end %>

--- a/app/views/company_calendars/show.html.erb
+++ b/app/views/company_calendars/show.html.erb
@@ -10,6 +10,6 @@
 <div
   id="GuidersAppointmentsCalendar"
   class="guiders-appointments-calendar js-calendar"
-  data-module="GuidersAppointmentsCalendar"
+  data-module="guiders-appointments-calendar"
   data-default-date="<%= Time.zone.now %>">
 </div>

--- a/app/views/holidays/index.html.erb
+++ b/app/views/holidays/index.html.erb
@@ -17,7 +17,7 @@
 <div
   id="HolidaysCalendar"
   class="holiday-calendar"
-  data-module="HolidaysCalendar"
+  data-module="holidays-calendar"
   data-holidays-path="<%= merged_holidays_path %>"
   data-new-holiday-path="<%= new_holiday_path %>"
   data-default-date="<%= Time.zone.now %>"

--- a/app/views/holidays/new.html.erb
+++ b/app/views/holidays/new.html.erb
@@ -15,7 +15,7 @@
       :date_range,
       class: 't-date-range',
       data: {
-        module: 'DateRangePicker',
+        module: 'date-range-picker',
         config: {
           timePicker: true,
           timePickerIncrement: 5,
@@ -33,7 +33,7 @@
       {},
       multiple: 'multiple',
       class: 't-users',
-      data: { module: 'AdvancedSelect' },
+      data: { module: 'advanced-select' },
     )
   %>
   <%= f.submit 'Save', class: 't-save' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,19 +34,4 @@
   <% end %>
 <% end %>
 
-<% content_for :body_end do %>
-  <script>
-  $(function() {
-    $('[data-module]:not([data-module-loaded])').each(function() {
-      var $el = $(this),
-      type = $el.data('module'),
-      config = $el.data('config');
-
-      $el.data('loaded-module', new PWTAP[type]($el, config));
-      $el.attr('data-module-loaded', true);
-    });
-  });
-  </script>
-<% end %>
-
 <%= render template: 'layouts/govuk_admin_template' %>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -14,7 +14,7 @@
       options_for_select(@where_options),
       {},
       class: 't-where',
-      data: { module: 'AdvancedSelect' }
+      data: { module: 'advanced-select' }
     )
   %>
   <%=
@@ -23,7 +23,7 @@
       class: 't-is-within',
       label: 'Is within',
       data: {
-        module: 'DateRangePicker',
+        module: 'date-range-picker',
         config: {
           autoUpdateInput: false,
           locale: {

--- a/app/views/resource_calendars/show.html.erb
+++ b/app/views/resource_calendars/show.html.erb
@@ -11,7 +11,7 @@
   id="GuidersAppointmentsCalendar"
   class="guiders-appointments-calendar js-calendar"
   data-config='{"editable": true, "eventDurationEditable": true, "slotDuration": "00:10:00"}'
-  data-module="GuidersAppointmentsCalendar"
+  data-module="guiders-appointments-calendar"
   data-default-date="<%= Time.zone.now %>">
 </div>
 

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -20,7 +20,7 @@
           :start_at,
           value: @schedule.start_at.try(:strftime, '%-e %b %Y'),
           data: {
-            module: 'DateRangePicker',
+            module: 'date-range-picker',
             config: {
               singleDatePicker: true,
               showDropdowns: true
@@ -58,7 +58,7 @@
     </div>
   </div>
   <div class="form-group">
-    <div id="GuiderSlotPickerCalendar" data-module="GuiderSlotPickerCalendar" data-events=".slots-data" data-events-common="calendar-common" data-config='{"slotDurationMinutes": 70}'></div>
+    <div id="GuiderSlotPickerCalendar" data-module="guider-slot-picker-calendar" data-events=".slots-data" data-events-common="calendar-common" data-config='{"slotDurationMinutes": 70}'></div>
   </div>
 
   <%= f.hidden_field :slots, class: 'slots-data', value: @slots_as_json %>

--- a/app/views/shared/_date_of_birth_form_field.html.erb
+++ b/app/views/shared/_date_of_birth_form_field.html.erb
@@ -1,6 +1,6 @@
 <% start_year = 120.years.ago %>
 
-<div class="form-dob" data-module="CustomerAge" data-output-id="js-customer-age">
+<div class="form-dob" data-module="customer-age" data-output-id="js-customer-age">
   <%= field_with_errors_wrapper(form, :date_of_birth) do %>
     <label>
       <span class="sr-only">Date of birth</span> <%= required_label(:day) %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -23,7 +23,7 @@
 </div>
 
 <% if @schedules.any? %>
-  <div class="guider-schedules" data-module="GuiderSchedulesChart" data-config='{"guiderScheduleDataSourceElementId": "guider-schedules"}' aria-hidden="true">
+  <div class="guider-schedules" data-module="guider-schedules-chart" data-config='{"guiderScheduleDataSourceElementId": "guider-schedules"}' aria-hidden="true">
     <div class="row">
       <div class="col-xs-12">
         <div class="guider-schedules__months"></div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -7,15 +7,15 @@
   <h1>Manage guiders</h1>
 </div>
 
-<div data-module="GuidersMultiAction">
-  <div id="guiders" data-module="SortableList" data-default-order='{"value": "name", "order": "asc"}' data-config='<%= sortable_list_config(@groups) %>'>
+<div data-module="guiders-multi-action">
+  <div id="guiders" data-module="sortable-list" data-default-order='{"value": "name", "order": "asc"}' data-config='<%= sortable_list_config(@groups) %>'>
     <form class="form-inline">
       <div class="form-group">
         <label for="user-search">Search</label>
         <input class="search form-control t-search" name="user-search" id="user-search" placeholder="Search">
       </div>
     </form>
-    <table class="table table-striped table-bordered table-hover" data-module="MultiCheckbox" data-config='{"selectedClassName":"info"}'>
+    <table class="table table-striped table-bordered table-hover" data-module="multi-checkbox" data-config='{"selectedClassName":"info"}'>
       <caption><span class="sr-only">List of guiders</span></caption>
       <colgroup>
         <col width="1%">

--- a/spec/features/resource_manager_manages_schedules_spec.rb
+++ b/spec/features/resource_manager_manages_schedules_spec.rb
@@ -64,11 +64,11 @@ RSpec.feature 'Resource manager manages schedules' do
   end
 
   def click_on_day_and_time(day, time)
-    page.find('[data-module="GuiderSlotPickerCalendar"]')
+    page.find('[data-module="guider-slot-picker-calendar"]')
     time = "#{time}:00"
     x, y = page.driver.evaluate_script <<-JS
       function() {
-        var $calendar = $('[data-module="GuiderSlotPickerCalendar"]');
+        var $calendar = $('[data-module="guider-slot-picker-calendar"]');
         var $header = $calendar.find(".fc-day-header:contains('#{day}')");
         var $row = $calendar.find('[data-time="#{time}"]');
         return [$header.offset().left + 10, $row.offset().top + 10];

--- a/spec/support/pages/resource_calendar.rb
+++ b/spec/support/pages/resource_calendar.rb
@@ -44,7 +44,7 @@ module Pages
           #{yield}
 
           calendar.fullCalendar('updateEvent', event);
-          calendar.data('loaded-module').handleEventChange(event, function() {});
+          calendar.data('fullCalendar').view.triggerEventDrop(event, moment(), function() {}, $('.fc-event'));
         }();
       JS
     end


### PR DESCRIPTION
- every module uses TapBase class which deals with setting up config
- all modules can now load config from a cookie
- figured out a way to trigger an event drop in fullcalendar
  without needing to access the instance of the module
  (which we no longer have access to now that we are using
  GOVUK Admin template module loader)