### PR TITLE
Guard against the absence of a customer email

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -33,7 +33,7 @@ class AppointmentsController < ApplicationController
     @appointment.assign_attributes(update_reschedule_params)
     @appointment.assign_to_guider
     if @appointment.save
-      AppointmentMailer.updated(@appointment).deliver_later if @appointment.email.present?
+      AppointmentMailer.updated(@appointment).deliver_later
       redirect_after_successful_update
     else
       render :reschedule
@@ -57,7 +57,7 @@ class AppointmentsController < ApplicationController
     @appointment = Appointment.new(create_params.merge(agent: current_user))
     @appointment.assign_to_guider
     if @appointment.save
-      AppointmentMailer.confirmation(@appointment).deliver_later if @appointment.email.present?
+      AppointmentMailer.confirmation(@appointment).deliver_later
       redirect_to(search_appointments_path, success: 'Appointment has been created')
     else
       render :new

--- a/app/forms/batch_appointment_update.rb
+++ b/app/forms/batch_appointment_update.rb
@@ -32,7 +32,7 @@ class BatchAppointmentUpdate
   def notify_customer(appointment)
     return unless appointment.previous_changes.slice('start_at', 'end_at').present?
 
-    AppointmentMailer.updated(appointment).deliver_later if appointment.email.present?
+    AppointmentMailer.updated(appointment).deliver_later
   end
 
   def update_appointment(change)

--- a/app/mailers/appointment_mailer.rb
+++ b/app/mailers/appointment_mailer.rb
@@ -2,11 +2,15 @@ class AppointmentMailer < ApplicationMailer
   default subject: 'Your Pension Wise Appointment'
 
   def confirmation(appointment)
+    return unless appointment.email?
+
     @appointment = appointment
     mail to: @appointment.email
   end
 
   def updated(appointment)
+    return unless appointment.email?
+
     @appointment = appointment
     mail to: @appointment.email
   end

--- a/spec/mailers/appointment_mailer_spec.rb
+++ b/spec/mailers/appointment_mailer_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe AppointmentMailer, type: :mailer do
   describe 'Confirmation' do
     subject(:mail) { described_class.confirmation(appointment) }
 
+    it 'guards against the absence of a recipient' do
+      appointment.email = ''
+
+      expect(mail.message).to be_an(ActionMailer::Base::NullMail)
+    end
+
     it 'renders the headers' do
       expect(mail.subject).to eq('Your Pension Wise Appointment')
       expect(mail.to).to eq([appointment.email])
@@ -34,6 +40,12 @@ RSpec.describe AppointmentMailer, type: :mailer do
 
   describe 'Updated' do
     subject(:mail) { described_class.updated(appointment) }
+
+    it 'guards against the absence of a recipient' do
+      appointment.email = ''
+
+      expect(mail.message).to be_an(ActionMailer::Base::NullMail)
+    end
 
     it 'renders the headers' do
       expect(mail.subject).to eq('Your Pension Wise Appointment')


### PR DESCRIPTION
The postfix statement modifier was following the mailer calls around
like a bad smell.