### PR TITLE
Simplify appointment update

### DIFF
--- a/app/forms/batch_appointment_update.rb
+++ b/app/forms/batch_appointment_update.rb
@@ -36,10 +36,7 @@ class BatchAppointmentUpdate
   end
 
   def update_appointment(change)
-    Appointment.find(change['id']).tap do |appointment|
-      appointment.assign_attributes(permitted_attributes(change))
-      appointment.save!
-    end
+    Appointment.update(change['id'], permitted_attributes(change))
   end
 
   def permitted_attributes(change)


### PR DESCRIPTION
We didn't need to tap into the appointment, `.update` has the same
semantics.