### PR TITLE
Return slots deterministically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
 - npm install
 - gem update --system
 - bundle exec rails assets:precompile RAILS_ENV=test
-- bundle exec rails db:create db:migrate RAILS_ENV=test
+- bundle exec rails db:create db:schema:load RAILS_ENV=test
 notifications:
   slack:
     secure: izFI8CV1BAc5Sk08/q84YijolWAY2Zm3JA4RPyilwjzfrro5v2lOM9rEX32W1fgPDu7hWq1bmqYcgxhVI+ecu2RFkI0iQklgNSe256HN7AKqRtSgtVx+3L6w8B9tBCJJ9wfj0lur/8x6oh8UwH8jExJmqtJbL3rxIq+O9N0/nJdf4jXR9vPHfFtprZwExQQTDQccqXkfyE+BqYRsFjoa/jL0utZlLt5kn8ErQPW/lDiSFvOA9OKk5o2ihQrndxkhAhZX6GbKp2aBP3xkom37aQZRyXsKIMXCz16+0IGOsTrW32j3lwLjsesb308Bp01e4q4ssp3a+2k5Hs2CKs0++b9Bb4GLpEl6Q63TGewUqK9/TXjvp7IWx5SOTQbktB5YLL6WmfR+j7MfD52VrEIHahEgJUwQQ+2+EG9MP0O8Qbs4Gek1FgGtpN7+rUS9WpOUIiGEjN7+uGd+PHTgSL7gf0kqrhtQcDHkP8KfI7KOrB1O0gO4DmdHNfJ184MXKEFlh7ULKtX08i8iB5GMVGQqsCuI7lfgR/P+u/SlIbPVu/aRoXpzo4e18UVpjBl9fR5mk6vroXqiR/5v4sHByFp5wn/QwvGszXjZcgmqTtZ7tyGGoq1IS6QdPr1Y0D/mBZT/O4N7QzG7fugPXwKOIfiktPooGt6CSVca5SHa13OkBrk=

--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -1,3 +1,5 @@
 class Slot < ApplicationRecord
   belongs_to :schedule
+
+  default_scope { order(:day_of_week) }
 end


### PR DESCRIPTION
This should resolve the intermittent test failures (the latest ones, at
least) in the CI environment. It seems the specs assert on the
particular ordering of `Schedule#slots` but the order was not
guaranteed.

I added a default scope as it's easiest and it seemed to make sense to
order slots in a schedule by their ordinal day of week.