### PR TITLE
Push notify for appointments on the same day

### DIFF
--- a/app/jobs/pusher_notification_job.rb
+++ b/app/jobs/pusher_notification_job.rb
@@ -2,6 +2,8 @@ class PusherNotificationJob < ApplicationJob
   queue_as :default
 
   def perform(guider_id, appointment)
+    return unless current?(appointment)
+
     Pusher.trigger(
       'telephone_appointment_planner',
       guider_id.to_s,
@@ -9,5 +11,11 @@ class PusherNotificationJob < ApplicationJob
       start: appointment.start_at.strftime('%d %B %Y %H:%M'),
       guider_name: appointment.guider.name
     )
+  end
+
+  private
+
+  def current?(appointment)
+    appointment.start_at.to_date == Time.zone.today.to_date
   end
 end

--- a/spec/jobs/pusher_notification_job_spec.rb
+++ b/spec/jobs/pusher_notification_job_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe PusherNotificationJob, '#perform' do
+  subject { described_class.new.perform(0, appointment) }
+
+  context 'when the appointment is for today' do
+    let(:appointment) { build_stubbed(:appointment, start_at: Time.zone.today) }
+
+    it 'sends the push notification' do
+      expect(Pusher).to receive(:trigger)
+
+      subject
+    end
+  end
+
+  context 'when the appointment is for another day' do
+    let(:appointment) { build_stubbed(:appointment, start_at: Time.zone.tomorrow) }
+
+    it 'does nothing' do
+      expect(Pusher).to_not receive(:trigger)
+
+      subject
+    end
+  end
+end


### PR DESCRIPTION
Limits the guider notifications to the same day otherwise the guider
may be overwhelmed by notifications and do a frighten.