### PR TITLE
Add assigned and reassigned activities to appointments

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -10,6 +10,7 @@ class ActivitiesController < ApplicationController
   end
 
   def create
+    @appointment = Appointment.find(params[:appointment_id])
     @activity = MessageActivity.create(message_params)
 
     respond_to do |format|
@@ -25,6 +26,7 @@ class ActivitiesController < ApplicationController
       .permit(:message)
       .merge(
         user: current_user,
+        owner: appointment.guider,
         appointment: appointment
       )
   end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -3,10 +3,13 @@ class Activity < ApplicationRecord
 
   belongs_to :appointment
   belongs_to :user
+  belongs_to :owner, class_name: User
+  belongs_to :prior_owner, class_name: User
+  validates :owner, presence: true
 
   scope :since, -> (since) { where('created_at > ?', since) }
 
-  def owner_name
+  def user_name
     user.try(:name) || 'Someone'
   end
 

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -73,6 +73,7 @@ class Appointment < ApplicationRecord
     else
       AuditActivity.from(audit, self)
     end
+    AssignmentActivity.from(audit, self)
   end
 
   def not_within_two_business_days

--- a/app/models/assignment_activity.rb
+++ b/app/models/assignment_activity.rb
@@ -1,0 +1,28 @@
+class AssignmentActivity < Activity
+  def self.from(audit, appointment)
+    if audit.action == 'create'
+      create_assignment(audit, appointment)
+    elsif audit.audited_changes['guider_id'].present?
+      create_reassignment(audit, appointment)
+    end
+  end
+
+  def self.create_assignment(audit, appointment)
+    create!(
+      user_id: audit.user_id,
+      message: 'assigned',
+      appointment: appointment,
+      owner: appointment.guider
+    )
+  end
+
+  def self.create_reassignment(audit, appointment)
+    create!(
+      user_id: audit.user_id,
+      message: 'reassigned',
+      appointment: appointment,
+      owner: appointment.guider,
+      prior_owner_id: audit.audited_changes['guider_id'].first
+    )
+  end
+end

--- a/app/models/audit_activity.rb
+++ b/app/models/audit_activity.rb
@@ -2,6 +2,7 @@ class AuditActivity < Activity
   def self.from(audit, appointment)
     create!(
       user_id: audit.user_id,
+      owner_id: appointment.guider.id,
       message: audit.audited_changes.keys.map(&:humanize).to_sentence.downcase,
       appointment_id: appointment.id
     )

--- a/app/models/create_activity.rb
+++ b/app/models/create_activity.rb
@@ -3,7 +3,8 @@ class CreateActivity < Activity
     create!(
       user_id: audit.user_id,
       message: 'created this appointment',
-      appointment_id: appointment.id
+      appointment_id: appointment.id,
+      owner_id: appointment.guider.id
     )
   end
 end

--- a/app/views/activities/_activity_feed.html.erb
+++ b/app/views/activities/_activity_feed.html.erb
@@ -4,7 +4,7 @@
 
     <div class="activity-feed">
       <div class="well js-message-form">
-        <%= form_for MessageActivity.new(appointment: appointment), url: appointment_activities_path(appointment), remote: true do |f| %>
+        <%= form_for MessageActivity.new(appointment: appointment, owner: appointment.guider), url: appointment_activities_path(appointment), remote: true do |f| %>
           <div class="input-group">
             <%= f.text_field :message, placeholder: 'Add an action to keep others in the loop', class: 'form-control js-message t-message' %>
             <span class="input-group-btn">

--- a/app/views/activities/_assignment_activity.html.erb
+++ b/app/views/activities/_assignment_activity.html.erb
@@ -1,0 +1,6 @@
+<li class="activity-feed__item t-activity" id="activity-<%= assignment_activity.id %>">
+  <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span>
+  <b><%= assignment_activity.user_name %></b>
+  <%= assignment_activity.message %> to <%= assignment_activity.owner.name %>
+  <em class="badge"><%= time_ago_in_words(assignment_activity.created_at) %> ago</em>
+</li>

--- a/app/views/activities/_audit_activity.html.erb
+++ b/app/views/activities/_audit_activity.html.erb
@@ -1,4 +1,4 @@
 <li class="activity-feed__item t-activity" id="activity-<%= audit_activity.id %>">
   <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-  <b><%= audit_activity.owner_name %></b> changed the <%= audit_activity.message %> <em class="badge"><%= time_ago_in_words(audit_activity.created_at) %> ago</em>
+  <b><%= audit_activity.user_name %></b> changed the <%= audit_activity.message %> <em class="badge"><%= time_ago_in_words(audit_activity.created_at) %> ago</em>
 </li>

--- a/app/views/activities/_create_activity.html.erb
+++ b/app/views/activities/_create_activity.html.erb
@@ -1,4 +1,4 @@
 <li class="activity-feed__item t-activity" id="activity-<%= create_activity.id %>">
   <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span>
-  <b><%= create_activity.owner_name %></b> <%= create_activity.message %> <em class="badge"><%= time_ago_in_words(create_activity.created_at) %> ago</em>
+  <b><%= create_activity.user_name %></b> <%= create_activity.message %> <em class="badge"><%= time_ago_in_words(create_activity.created_at) %> ago</em>
 </li>

--- a/app/views/activities/_message_activity.html.erb
+++ b/app/views/activities/_message_activity.html.erb
@@ -1,4 +1,4 @@
 <li class="activity-feed__item t-activity" id="activity-<%= message_activity.id %>">
   <span class="glyphicon glyphicon-user" aria-hidden="true"></span>
-  <b><%= message_activity.owner_name %></b> said <em><%= message_activity.message %></em> <em class="badge"><%= time_ago_in_words(message_activity.created_at) %> ago</em>
+  <b><%= message_activity.user_name %></b> said <em><%= message_activity.message %></em> <em class="badge"><%= time_ago_in_words(message_activity.created_at) %> ago</em>
 </li>

--- a/db/migrate/20161107140328_add_prior_owner_id_to_activities.rb
+++ b/db/migrate/20161107140328_add_prior_owner_id_to_activities.rb
@@ -1,0 +1,5 @@
+class AddPriorOwnerIdToActivities < ActiveRecord::Migration[5.0]
+  def change
+    add_column :activities, :prior_owner_id, :integer, index: true
+  end
+end

--- a/db/migrate/20161107141610_add_owner_to_activities.rb
+++ b/db/migrate/20161107141610_add_owner_to_activities.rb
@@ -1,0 +1,5 @@
+class AddOwnerToActivities < ActiveRecord::Migration[5.0]
+  def change
+    add_column :activities, :owner_id, :integer, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161104112041) do
+ActiveRecord::Schema.define(version: 20161107141610) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,8 @@ ActiveRecord::Schema.define(version: 20161104112041) do
     t.string   "type",           null: false
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
+    t.integer  "prior_owner_id"
+    t.integer  "owner_id"
     t.index ["appointment_id"], name: "index_activities_on_appointment_id", using: :btree
     t.index ["type"], name: "index_activities_on_type", using: :btree
   end

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :activity do
     user
     appointment
+    owner { create(:guider) }
     message 'did a thing to a thing'
     type 'AuditActivity'
   end

--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -12,6 +12,6 @@ FactoryGirl.define do
     opt_out_of_market_research true
     memorable_word 'lozenge'
     date_of_birth '1945-01-01'
-    guider { create(:user) }
+    guider { create(:guider) }
   end
 end

--- a/spec/features/user_views_booking_activities_spec.rb
+++ b/spec/features/user_views_booking_activities_spec.rb
@@ -76,7 +76,7 @@ RSpec.feature 'User views appointment activities' do
     @page.activity_feed.tap do |feed|
       feed.wait_until_hidden_activities_visible
 
-      expect(feed).to have_activities(count: 3)
+      expect(feed).to have_activities(count: 4)
       expect(feed.activities.last).to have_text('created')
     end
   end
@@ -89,7 +89,7 @@ RSpec.feature 'User views appointment activities' do
   def then_it_appears_dynamically
     @page.activity_feed.wait_for_dynamically_loaded_activities(3)
     activity = @page.activity_feed.dynamically_loaded_activities.first
-    expect(activity.text).to include(@activity.owner_name)
+    expect(activity.text).to include(@activity.user_name)
     expect(activity.text).to include(@activity.message)
   end
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Activity, type: :model do
+  describe 'validations' do
+    let(:subject) do
+      build_stubbed(:activity)
+    end
+
+    it 'is valid with valid parameters' do
+      expect(subject).to be_valid
+    end
+
+    it 'validates presence of owner' do
+      subject.owner = nil
+      subject.validate
+      expect(subject.errors[:owner]).to_not be_empty
+    end
+  end
+end

--- a/spec/models/assignment_activity_spec.rb
+++ b/spec/models/assignment_activity_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe AssignmentActivity do
+  describe '.from' do
+    before do
+      @appointment = create(:appointment)
+    end
+
+    let(:audit) { @appointment.audits.first }
+    subject { @appointment.activities.first }
+
+    it 'creates an assignment activity' do
+      expect(subject).to be_a(described_class)
+
+      expect(subject).to have_attributes(
+        appointment: @appointment,
+        owner: @appointment.guider,
+        prior_owner: nil,
+        message: 'assigned'
+      )
+    end
+
+    context 'appointment is reassigned' do
+      before do
+        @prior_owner = @appointment.guider
+        @appointment.guider = create(:guider)
+        @appointment.save!
+      end
+
+      it 'creates an assignment activity' do
+        expect(subject).to be_a(described_class)
+
+        expect(subject).to have_attributes(
+          prior_owner: @prior_owner,
+          owner: @appointment.guider,
+          appointment_id: @appointment.id,
+          message: 'reassigned'
+        )
+      end
+    end
+  end
+end

--- a/spec/models/audit_activity_spec.rb
+++ b/spec/models/audit_activity_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe AuditActivity do
 
       expect(subject).to have_attributes(
         user_id: audit.user_id,
+        owner_id: @appointment.guider.id,
         appointment_id: @appointment.id,
         message: 'first name, email, and phone'
       )

--- a/spec/models/create_activity_spec.rb
+++ b/spec/models/create_activity_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe CreateActivity do
       expect(subject).to have_attributes(
         user_id: audit.user_id,
         appointment_id: @appointment.id,
+        owner_id: @appointment.guider.id,
         message: 'created this appointment'
       )
     end


### PR DESCRIPTION
I'm tempted to introduce an additional STI called `ReassignmentActivity` to simplify things.

Also, notice that `Activity` now has `owner` and `prior_owner`. They will be used to query activities when we have a per-user activity-feed.

![https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-07-11-2016-15-20-26-aiPheey4.png](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-07-11-2016-15-20-26-aiPheey4.png)