### PR TITLE
Reduce vertical spacing

### DIFF
--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -1,12 +1,10 @@
-<div class="page-header">
-  <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Home</a></li>
-    <li><a href="<%= search_appointments_path %>">Search</a></li>
-    <li class="active">Edit appointment for <%= @appointment.name %></li>
-  </ol>
+<ol class="breadcrumb">
+  <li><a href="<%= root_path %>">Home</a></li>
+  <li><a href="<%= search_appointments_path %>">Search</a></li>
+  <li class="active">Edit appointment for <%= @appointment.name %></li>
+</ol>
 
-  <h1>Edit appointment for <%= @appointment.name %></h1>
-</div>
+<h1>Edit appointment for <%= @appointment.name %></h1>
 
 <%=
   render(

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -1,11 +1,10 @@
-<div class="page-header">
-  <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Home</a></li>
-    <li class="active">Book an appointment</li>
-  </ol>
+<ol class="breadcrumb">
+  <li><a href="<%= root_path %>">Home</a></li>
+  <li class="active">Book an appointment</li>
+</ol>
 
-  <h1>Book an appointment</h1>
-</div>
+<h1>Book an appointment</h1>
+
 <%= render 'shared/required_fields_note' %>
 <%= form_for @appointment, layout: :basic do |f| %>
   <div class="row form-group">

--- a/app/views/appointments/reschedule.html.erb
+++ b/app/views/appointments/reschedule.html.erb
@@ -1,12 +1,10 @@
-<div class="page-header">
-  <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Home</a></li>
-    <li><a href="<%= search_appointments_path %>">Search</a></li>
-    <li class="active">Reschedule an appointment for <%= @appointment.name %></li>
-  </ol>
+<ol class="breadcrumb">
+  <li><a href="<%= root_path %>">Home</a></li>
+  <li><a href="<%= search_appointments_path %>">Search</a></li>
+  <li class="active">Reschedule an appointment for <%= @appointment.name %></li>
+</ol>
 
-  <h1>Reschedule an appointment for <%= @appointment.name %></h1>
-</div>
+<h1>Reschedule an appointment for <%= @appointment.name %></h1>
 
 <%= render 'shared/required_fields_note' %>
 

--- a/app/views/appointments/search.html.erb
+++ b/app/views/appointments/search.html.erb
@@ -1,10 +1,9 @@
-<div class="page-header">
-  <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Home</a></li>
-    <li class="active">Search</li>
-  </ol>
-  <h1>Search</h1>
-</div>
+<ol class="breadcrumb">
+  <li><a href="<%= root_path %>">Home</a></li>
+  <li class="active">Search</li>
+</ol>
+
+<h1>Search</h1>
 
 <div class="row form-group">
   <div class="col-md-12">

--- a/app/views/calendars/show.html.erb
+++ b/app/views/calendars/show.html.erb
@@ -1,11 +1,9 @@
-<div class="page-header">
-  <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Home</a></li>
-    <li class="active">My appointments</li>
-  </ol>
+<ol class="breadcrumb">
+  <li><a href="<%= root_path %>">Home</a></li>
+  <li class="active">My appointments</li>
+</ol>
 
-  <h1>My appointments</h1>
-</div>
+<h1>My appointments</h1>
 
 <div
   id="GuiderAppointmentsCalendar"

--- a/app/views/company_calendars/show.html.erb
+++ b/app/views/company_calendars/show.html.erb
@@ -1,11 +1,9 @@
-<div class="page-header">
-  <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Home</a></li>
-    <li class="active">Company appointments</li>
-  </ol>
+<ol class="breadcrumb">
+  <li><a href="<%= root_path %>">Home</a></li>
+  <li class="active">Company appointments</li>
+</ol>
 
-  <h1>Company appointments</h1>
-</div>
+<h1>Company appointments</h1>
 
 <div
   id="GuidersAppointmentsCalendar"

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,12 +1,10 @@
-<div class="page-header">
-  <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Home</a></li>
-    <li><a href="<%= users_path %>">Manage guiders</a></li>
-    <li class="active">Manage groups</li>
-  </ol>
+<ol class="breadcrumb">
+  <li><a href="<%= root_path %>">Home</a></li>
+  <li><a href="<%= users_path %>">Manage guiders</a></li>
+  <li class="active">Manage groups</li>
+</ol>
 
-  <h1>Manage groups</h1>
-</div>
+<h1>Manage groups</h1>
 
 <h2>Add/remove guider groups</h2>
 <p class="lead">Add or remove from the list below to set the group memberships for these guiders.</p>

--- a/app/views/holidays/edit.html.erb
+++ b/app/views/holidays/edit.html.erb
@@ -1,12 +1,10 @@
-<div class="page-header">
-  <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Home</a></li>
-    <li><a href="<%= holidays_path %>">Holidays &amp; unavailability</a></li>
-    <li class="active">Edit holiday</li>
-  </ol>
+<ol class="breadcrumb">
+  <li><a href="<%= root_path %>">Home</a></li>
+  <li><a href="<%= holidays_path %>">Holidays &amp; unavailability</a></li>
+  <li class="active">Edit holiday</li>
+</ol>
 
-  <h1>Edit holiday</h1>
-</div>
+<h1>Edit holiday</h1>
 
 <%= form_for @holiday, url: holiday_path(params[:id]), layout: :basic do |f| %>
   <%= f.text_field :title, class: 't-title' %>

--- a/app/views/holidays/index.html.erb
+++ b/app/views/holidays/index.html.erb
@@ -1,11 +1,9 @@
-<div class="page-header">
-  <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Home</a></li>
-    <li class="active">Holidays</li>
-  </ol>
+<ol class="breadcrumb">
+  <li><a href="<%= root_path %>">Home</a></li>
+  <li class="active">Holidays</li>
+</ol>
 
-  <h1>Holidays</h1>
-</div>
+<h1>Holidays</h1>
 
 <div class="row">
   <div class="col-xs-12">

--- a/app/views/holidays/new.html.erb
+++ b/app/views/holidays/new.html.erb
@@ -1,12 +1,10 @@
-<div class="page-header">
-  <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Home</a></li>
-    <li class="active"><a href="<%= holidays_path %>">Holidays</a></li>
-    <li class="active">Create a holiday</li>
-  </ol>
+<ol class="breadcrumb">
+  <li><a href="<%= root_path %>">Home</a></li>
+  <li class="active"><a href="<%= holidays_path %>">Holidays</a></li>
+  <li class="active">Create a holiday</li>
+</ol>
 
-  <h1>Create a holiday</h1>
-</div>
+<h1>Create a holiday</h1>
 
 <%= form_for @holiday, layout: :basic do |f| %>
   <%= f.text_field :title, class: 't-title' %>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,11 +1,9 @@
-<div class="page-header">
-  <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Home</a></li>
-    <li class="active">Reports</li>
-  </ol>
+<ol class="breadcrumb">
+  <li><a href="<%= root_path %>">Home</a></li>
+  <li class="active">Reports</li>
+</ol>
 
-  <h1>Generate a report</h1>
-</div>
+<h1>Generate a report</h1>
 
 <%= form_for @report, method: 'GET', target: '_blank', 'data-disable-with': nil, layout: :basic do |f| %>
   <%=

--- a/app/views/resource_calendars/show.html.erb
+++ b/app/views/resource_calendars/show.html.erb
@@ -1,9 +1,9 @@
-<div class="page-header">
-  <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Home</a></li>
-    <li class="active">Appointments</li>
-  </ol>
-</div>
+<ol class="breadcrumb">
+  <li><a href="<%= root_path %>">Home</a></li>
+  <li class="active">Appointments</li>
+</ol>
+
+<h1 class="sr-only">Appointments</h1>
 
 <div
   id="GuidersAppointmentsCalendar"

--- a/app/views/resource_calendars/show.html.erb
+++ b/app/views/resource_calendars/show.html.erb
@@ -3,8 +3,6 @@
     <li><a href="<%= root_path %>">Home</a></li>
     <li class="active">Appointments</li>
   </ol>
-
-  <h1>Appointments</h1>
 </div>
 
 <div

--- a/app/views/schedules/edit.html.erb
+++ b/app/views/schedules/edit.html.erb
@@ -1,12 +1,10 @@
-<div class="page-header">
-  <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Home</a></li>
-    <li><a href="<%= users_path %>">Manage guiders</a></li>
-    <li><a href="<%= edit_user_path(@guider) %>">Manage schedules for <%=@guider.name %></a></li>
-    <li class="active">Edit schedule <%=@schedule.title %> for <%=@guider.name %></li>
-  </ol>
+<ol class="breadcrumb">
+  <li><a href="<%= root_path %>">Home</a></li>
+  <li><a href="<%= users_path %>">Manage guiders</a></li>
+  <li><a href="<%= edit_user_path(@guider) %>">Manage schedules for <%=@guider.name %></a></li>
+  <li class="active">Edit schedule <%=@schedule.title %> for <%=@guider.name %></li>
+</ol>
 
-  <h1>Edit schedule <%=@schedule.title %> for <%=@guider.name %></h1>
-</div>
+<h1>Edit schedule <%=@schedule.title %> for <%=@guider.name %></h1>
 
 <%= render "form" %>

--- a/app/views/schedules/new.html.erb
+++ b/app/views/schedules/new.html.erb
@@ -1,12 +1,10 @@
-<div class="page-header">
-  <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Home</a></li>
-    <li><a href="<%= users_path %>">Manage guiders</a></li>
-    <li><a href="<%= edit_user_path(@guider) %>">Edit User &quot;<%=@guider.name %>&quot;</a></li>
-    <li class="active">New Schedule</li>
-  </ol>
+<ol class="breadcrumb">
+  <li><a href="<%= root_path %>">Home</a></li>
+  <li><a href="<%= users_path %>">Manage guiders</a></li>
+  <li><a href="<%= edit_user_path(@guider) %>">Edit User &quot;<%=@guider.name %>&quot;</a></li>
+  <li class="active">New Schedule</li>
+</ol>
 
-  <h1>New schedule for "<%=@guider.name %>"</h1>
-</div>
+<h1>New schedule for "<%=@guider.name %>"</h1>
 
 <%= render "form" %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,12 +1,10 @@
-<div class="page-header">
-  <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Home</a></li>
-    <li><a href="<%= users_path %>">Manage guiders</a></li>
-    <li class="active">Manage schedules for <%=@guider.name %></li>
-  </ol>
+<ol class="breadcrumb">
+  <li><a href="<%= root_path %>">Home</a></li>
+  <li><a href="<%= users_path %>">Manage guiders</a></li>
+  <li class="active">Manage schedules for <%=@guider.name %></li>
+</ol>
 
-  <h1>Manage schedules for <%=@guider.name %></h1>
-</div>
+<h1>Manage schedules for <%=@guider.name %></h1>
 
 <div class="row">
   <div class="col-md-4">

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,11 +1,9 @@
-<div class="page-header">
-  <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Home</a></li>
-    <li class="active">Manage guiders</li>
-  </ol>
+<ol class="breadcrumb">
+  <li><a href="<%= root_path %>">Home</a></li>
+  <li class="active">Manage guiders</li>
+</ol>
 
-  <h1>Manage guiders</h1>
-</div>
+<h1>Manage guiders</h1>
 
 <div data-module="guiders-multi-action">
   <div id="guiders" data-module="sortable-list" data-default-order='{"value": "name", "order": "asc"}' data-config='<%= sortable_list_config(@groups) %>'>


### PR DESCRIPTION
Kills the H1 on the resource calendar page and moves breadcrumbs (on all pages) out of the `page-header`, which buys us quite a bit more vertical spacing.

**Before:**
<img width="1266" alt="screen shot 2016-11-07 at 16 36 50" src="https://cloud.githubusercontent.com/assets/295469/20066137/776bb2a2-a508-11e6-874e-294da2ecf026.png">


**After:**
<img width="1266" alt="screen shot 2016-11-07 at 16 37 08" src="https://cloud.githubusercontent.com/assets/295469/20066142/79c1a444-a508-11e6-89e3-1eaf4a437fcc.png">

