### PR TITLE
More descriptive button labels on the resource calendar

### DIFF
--- a/app/assets/javascripts/calendars/guiders-appointments.es6
+++ b/app/assets/javascripts/calendars/guiders-appointments.es6
@@ -11,6 +11,10 @@
         header: {
           right: 'agendaDay timelineDay today jumpToDate prev,next'
         },
+        buttonText: {
+          agendaDay: 'Horizontal',
+          timelineDay: 'Vertical'
+        },
         groupByDateAndResource: true,
         nowIndicator: true,
         slotDuration: '00:30:00',


### PR DESCRIPTION
Previously they were a little terse and fullcalendar-specific, and
TPAS are familiar with the 'Vertical' and 'Horizontal' naming.

<img width="1161" alt="screen shot 2016-11-08 at 10 22 40" src="https://cloud.githubusercontent.com/assets/295469/20095412/505a3252-a59d-11e6-9946-f109744aa1cb.png">
