### PR TITLE
Notify on appointment alterations

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -43,6 +43,7 @@ class AppointmentsController < ApplicationController
   def update
     @appointment = Appointment.find(params[:id])
     if @appointment.update_attributes(update_params)
+      Notifier.new(@appointment).call
       redirect_after_successful_update
     else
       render :edit

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -33,7 +33,7 @@ class AppointmentsController < ApplicationController
     @appointment.assign_attributes(update_reschedule_params)
     @appointment.assign_to_guider
     if @appointment.save
-      AppointmentMailer.updated(@appointment).deliver_later
+      Notifier.new(@appointment).call
       redirect_after_successful_update
     else
       render :reschedule

--- a/app/jobs/pusher_notification_job.rb
+++ b/app/jobs/pusher_notification_job.rb
@@ -16,6 +16,6 @@ class PusherNotificationJob < ApplicationJob
   private
 
   def current?(appointment)
-    appointment.start_at.to_date == Time.zone.today.to_date
+    appointment.start_at.to_date == Time.zone.today
   end
 end

--- a/app/lib/batch_appointment_update.rb
+++ b/app/lib/batch_appointment_update.rb
@@ -1,0 +1,25 @@
+class BatchAppointmentUpdate
+  def initialize(changes)
+    @changes = JSON.parse(changes)
+  end
+
+  def call
+    changes.each do |change|
+      appointment = update_appointment(change)
+
+      Notifier.new(appointment).call
+    end
+  end
+
+  private
+
+  def update_appointment(change)
+    Appointment.update(change['id'], permitted_attributes(change))
+  end
+
+  def permitted_attributes(change)
+    change.slice('guider_id', 'start_at', 'end_at')
+  end
+
+  attr_reader :changes
+end

--- a/app/lib/notifier.rb
+++ b/app/lib/notifier.rb
@@ -1,23 +1,16 @@
-class BatchAppointmentUpdate
-  def initialize(changes)
-    @changes = JSON.parse(changes)
+class Notifier
+  def initialize(appointment)
+    @appointment = appointment
   end
 
   def call
-    changes.each do |change|
-      appointment = update_appointment(change)
-      send_notifications(appointment)
-    end
-  end
-
-  private
-
-  def send_notifications(appointment)
     return unless appointment.previous_changes
 
     notify_customer(appointment)
     notify_guiders(appointment)
   end
+
+  private
 
   def notify_guiders(appointment)
     guiders_to_notify(appointment).each do |guider_id|
@@ -35,13 +28,5 @@ class BatchAppointmentUpdate
     AppointmentMailer.updated(appointment).deliver_later
   end
 
-  def update_appointment(change)
-    Appointment.update(change['id'], permitted_attributes(change))
-  end
-
-  def permitted_attributes(change)
-    change.slice('guider_id', 'start_at', 'end_at')
-  end
-
-  attr_reader :changes
+  attr_reader :appointment
 end

--- a/spec/features/guider_edits_an_appointment_spec.rb
+++ b/spec/features/guider_edits_an_appointment_spec.rb
@@ -4,11 +4,14 @@ require 'rails_helper'
 RSpec.feature 'Guider edits an appointment' do
   scenario 'Successfully editing an appointment' do
     given_the_user_is_a_guider do
-      and_they_have_an_appointment
-      when_they_attempt_to_edit_the_appointment
-      then_they_see_the_existing_details
-      when_they_modify_the_appointment
-      then_the_appointment_is_changed
+      perform_enqueued_jobs do
+        and_they_have_an_appointment
+        when_they_attempt_to_edit_the_appointment
+        then_they_see_the_existing_details
+        when_they_modify_the_appointment
+        then_the_appointment_is_changed
+        and_the_customer_is_not_notified
+      end
     end
   end
 
@@ -40,5 +43,9 @@ RSpec.feature 'Guider edits an appointment' do
 
   def then_the_appointment_is_changed
     expect(@appointment.reload.first_name).to eq('Rick')
+  end
+
+  def and_the_customer_is_not_notified
+    expect(ActionMailer::Base.deliveries).to be_empty
   end
 end

--- a/spec/jobs/pusher_notification_job_spec.rb
+++ b/spec/jobs/pusher_notification_job_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe PusherNotificationJob, '#perform' do
   subject { described_class.new.perform(0, appointment) }
 
   context 'when the appointment is for today' do
-    let(:appointment) { build_stubbed(:appointment, start_at: Time.zone.today) }
+    let(:appointment) { build_stubbed(:appointment, start_at: Time.zone.now) }
 
     it 'sends the push notification' do
       expect(Pusher).to receive(:trigger)
@@ -14,7 +14,7 @@ RSpec.describe PusherNotificationJob, '#perform' do
   end
 
   context 'when the appointment is for another day' do
-    let(:appointment) { build_stubbed(:appointment, start_at: Time.zone.tomorrow) }
+    let(:appointment) { build_stubbed(:appointment, start_at: 1.day.from_now) }
 
     it 'does nothing' do
       expect(Pusher).to_not receive(:trigger)


### PR DESCRIPTION
Notifies on more appointment scenarios. For now we just display the typical
push notification modal for changes made to appointments during 'today'.