### PR TITLE
Dequeue jobs inline by default

### DIFF
--- a/spec/features/agent_manages_appointments_spec.rb
+++ b/spec/features/agent_manages_appointments_spec.rb
@@ -5,25 +5,21 @@ RSpec.feature 'Agent manages appointments' do
   let(:day) { BusinessDays.from_now(5) }
 
   scenario 'Agent creates appointments' do
-    perform_enqueued_jobs do
-      given_the_user_is_an_agent do
-        and_there_is_a_guider_with_available_slots
-        when_they_want_to_book_an_appointment
-        and_they_fill_in_their_appointment_details
-        then_that_appointment_is_created
-        and_the_customer_gets_an_email_confirmation
-      end
+    given_the_user_is_an_agent do
+      and_there_is_a_guider_with_available_slots
+      when_they_want_to_book_an_appointment
+      and_they_fill_in_their_appointment_details
+      then_that_appointment_is_created
+      and_the_customer_gets_an_email_confirmation
     end
   end
 
   scenario 'Agent creates appointment without an email' do
-    perform_enqueued_jobs do
-      given_the_user_is_an_agent do
-        and_there_is_a_guider_with_available_slots
-        when_they_want_to_book_an_appointment
-        and_they_fill_in_their_appointment_details_without_an_email
-        then_the_customer_does_not_get_an_email_confirmation
-      end
+    given_the_user_is_an_agent do
+      and_there_is_a_guider_with_available_slots
+      when_they_want_to_book_an_appointment
+      and_they_fill_in_their_appointment_details_without_an_email
+      then_the_customer_does_not_get_an_email_confirmation
     end
   end
 
@@ -38,27 +34,23 @@ RSpec.feature 'Agent manages appointments' do
   end
 
   scenario 'Agent reschedules an appointment' do
-    perform_enqueued_jobs do
-      given_the_user_is_an_agent do
-        and_there_is_a_guider_with_available_slots
-        and_there_is_an_appointment
-        and_they_want_to_reschedule_the_appointment
-        when_they_reschedule_the_appointment
-        then_the_appointment_is_rescheduled
-        and_the_customer_gets_an_updated_email_confirmation
-      end
+    given_the_user_is_an_agent do
+      and_there_is_a_guider_with_available_slots
+      and_there_is_an_appointment
+      and_they_want_to_reschedule_the_appointment
+      when_they_reschedule_the_appointment
+      then_the_appointment_is_rescheduled
+      and_the_customer_gets_an_updated_email_confirmation
     end
   end
 
   scenario 'Agent reschedules an appointment without an email' do
-    perform_enqueued_jobs do
-      given_the_user_is_an_agent do
-        and_there_is_a_guider_with_available_slots
-        and_there_is_an_appointment_without_an_email
-        and_they_want_to_reschedule_the_appointment
-        when_they_reschedule_the_appointment
-        then_the_customer_does_not_get_an_updated_email_confirmation
-      end
+    given_the_user_is_an_agent do
+      and_there_is_a_guider_with_available_slots
+      and_there_is_an_appointment_without_an_email
+      and_they_want_to_reschedule_the_appointment
+      when_they_reschedule_the_appointment
+      then_the_customer_does_not_get_an_updated_email_confirmation
     end
   end
 

--- a/spec/features/guider_edits_an_appointment_spec.rb
+++ b/spec/features/guider_edits_an_appointment_spec.rb
@@ -4,14 +4,12 @@ require 'rails_helper'
 RSpec.feature 'Guider edits an appointment' do
   scenario 'Successfully editing an appointment' do
     given_the_user_is_a_guider do
-      perform_enqueued_jobs do
-        and_they_have_an_appointment
-        when_they_attempt_to_edit_the_appointment
-        then_they_see_the_existing_details
-        when_they_modify_the_appointment
-        then_the_appointment_is_changed
-        and_the_customer_is_not_notified
-      end
+      and_they_have_an_appointment
+      when_they_attempt_to_edit_the_appointment
+      then_they_see_the_existing_details
+      when_they_modify_the_appointment
+      then_the_appointment_is_changed
+      and_the_customer_is_not_notified
     end
   end
 

--- a/spec/features/resource_manager_modifies_appointments_spec.rb
+++ b/spec/features/resource_manager_modifies_appointments_spec.rb
@@ -18,15 +18,13 @@ RSpec.feature 'Resource manager modifies appointments' do
 
     # start resource manager's session and reassign the appointment
     given_the_user_is_a_resource_manager do
-      perform_enqueued_jobs do
-        travel_to @appointment.start_at do
-          when_they_view_the_appointments
-          then_they_see_appointments_for_multiple_guiders
-          when_they_change_the_guider
-          and_commit_their_modifications
-          then_the_guider_is_modified
-          and_no_customer_notifications_are_sent
-        end
+      travel_to @appointment.start_at do
+        when_they_view_the_appointments
+        then_they_see_appointments_for_multiple_guiders
+        when_they_change_the_guider
+        and_commit_their_modifications
+        then_the_guider_is_modified
+        and_no_customer_notifications_are_sent
       end
     end
 
@@ -52,15 +50,13 @@ RSpec.feature 'Resource manager modifies appointments' do
 
     # reschedule the appointment
     given_the_user_is_a_resource_manager do
-      perform_enqueued_jobs do
-        travel_to @appointment.start_at do
-          when_they_view_the_appointments
-          then_they_see_appointments_for_multiple_guiders
-          when_they_reschedule_an_appointment
-          and_commit_their_modifications
-          then_the_appointment_is_modified
-          and_the_customer_is_notified_of_the_appointment_change
-        end
+      travel_to @appointment.start_at do
+        when_they_view_the_appointments
+        then_they_see_appointments_for_multiple_guiders
+        when_they_reschedule_an_appointment
+        and_commit_their_modifications
+        then_the_appointment_is_modified
+        and_the_customer_is_notified_of_the_appointment_change
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,7 +62,6 @@ RSpec.configure do |config|
   config.include UserHelpers
   config.include ActiveSupport::Testing::TimeHelpers
   config.include ActionView::Helpers::DateHelper
-  config.include ActiveJob::TestHelper
 
   config.before(:each) { ActionMailer::Base.deliveries.clear }
 end


### PR DESCRIPTION
Including the Active Job test helpers stops jobs being performed inline
unless scoped within the `perform_enqueued_jobs` helper. By not mixing
this into our feature specs we can implicitly dequeue jobs inline.