### PR TITLE
Alerts the resource manager that they are about to lose changes

### DIFF
--- a/app/assets/javascripts/calendars/guiders-appointments.es6
+++ b/app/assets/javascripts/calendars/guiders-appointments.es6
@@ -22,7 +22,7 @@
         resources: '/guiders',
         eventSources: [
           {
-            url: '/appointments?include_links=false'
+            url: '/appointments'
           },
           {
             url: '/holidays',

--- a/app/assets/javascripts/calendars/guiders-appointments.es6
+++ b/app/assets/javascripts/calendars/guiders-appointments.es6
@@ -36,6 +36,7 @@
 
       this.eventChanges = [];
       this.actionPanel = $('[data-action-panel]');
+      this.saveWarningMessage = 'You have unsaved changes - Save, or undo the changes.';
 
       this.setCalendarToCorrectHeight();
       this.setupUndo();
@@ -201,6 +202,7 @@
       const $hiddenInput = $('#event-changes');
       evt.preventDefault();
       $hiddenInput.val(this.getEventChangesForForm());
+      this.clearUnloadEvent();
       $hiddenInput.parents('form').submit();
     }
 
@@ -243,12 +245,28 @@
         this.actionPanel.find('[data-action-panel-event-count]').html(
           `${eventsChanged} event${eventsChanged == 1 ? '':'s'}`
         );
+        this.setUnloadEvent();
       } else {
         fadeAction = 'fadeOut';
+        this.clearUnloadEvent();
       }
 
       this.actionPanel[fadeAction]({
         complete: this.alterHeight.bind(this)
+      });
+    }
+
+    clearUnloadEvent() {
+      $(window).off('beforeunload unload');
+    }
+
+    setUnloadEvent() {
+      $(window).on('beforeunload', () => {
+        return this.saveWarningMessage;
+      });
+
+      $(window).on('unload', () => {
+        alert(this.saveWarningMessage);
       });
     }
 

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -17,7 +17,7 @@ class AppointmentsController < ApplicationController
 
     @appointments = scope.where(start_at: date_range_params)
 
-    render json: @appointments, include_links: include_links?
+    render json: @appointments
   end
 
   def edit
@@ -77,10 +77,6 @@ class AppointmentsController < ApplicationController
 
   def search_params
     params.fetch(:search, {}).permit(:q, :date_range)
-  end
-
-  def include_links?
-    params.fetch(:include_links, 'true') == 'true'
   end
 
   def date_range_params

--- a/app/serializers/appointment_serializer.rb
+++ b/app/serializers/appointment_serializer.rb
@@ -7,7 +7,7 @@ class AppointmentSerializer < ActiveModel::Serializer
   attribute :title
   attribute :memorable_word
   attribute :phone
-  attribute :url, if: -> { instance_options[:include_links] }
+  attribute :url
   attribute :status
   attribute :cancelled
   attribute :guider_id, key: :resourceId

--- a/spec/features/guider_views_appointments_spec.rb
+++ b/spec/features/guider_views_appointments_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Guider views appointments' do
         then_they_see_the_appointments_for_today
         when_they_advance_a_working_day
         then_they_see_the_appointments_for_that_day
-        and_they_cannot_edit_the_appointment
+        and_they_can_edit_an_appointment
       end
     end
   end
@@ -90,7 +90,7 @@ RSpec.feature 'Guider views appointments' do
     expect(@page.appointments.first.root_element['href']).to end_with(edit_appointment_path(@tomorrow))
   end
 
-  def and_they_cannot_edit_the_appointment
-    expect(@page.appointments.first['href']).to be_nil
+  def and_they_can_edit_an_appointment
+    expect(@page.appointments.first['href']).to end_with(edit_appointment_path(@tomorrow))
   end
 end


### PR DESCRIPTION
- if they move/resize an appointment then they are warned
  they are going to lose changes if they then try and navigate
  away
- enable links through to edit appointment page for events
  on resource manager calendar and company calendar for a guider