### PR TITLE
Disable cookie config saving when using resource calendar

### DIFF
--- a/app/assets/javascripts/calendar.es6
+++ b/app/assets/javascripts/calendar.es6
@@ -91,6 +91,10 @@ class Calendar extends TapBase {
   }
 
   viewRender(view) {
+    this.setCookieConfig(view);
+  }
+
+  setCookieConfig(view) {
     GOVUKAdmin.cookie(
       this.config.cookieName,
       JSON.stringify({

--- a/app/assets/javascripts/calendar.es6
+++ b/app/assets/javascripts/calendar.es6
@@ -138,4 +138,8 @@ class Calendar extends TapBase {
   eventClick() {
 
   }
+
+  eventResize() {
+
+  }
 }

--- a/app/assets/javascripts/calendars/allocations.es6
+++ b/app/assets/javascripts/calendars/allocations.es6
@@ -22,6 +22,12 @@
       this.setupUndo();
     }
 
+    getCookieConfig() {
+    }
+
+    setCookieConfig() {
+    }
+
     setCalendarToCorrectHeight() {
       this.alterHeight();
       $(window).on('resize', this.debounce(this.alterHeight.bind(this), 20));

--- a/app/assets/javascripts/calendars/allocations.es6
+++ b/app/assets/javascripts/calendars/allocations.es6
@@ -14,18 +14,37 @@
       this.eventChanges = [];
       this.actionPanel = $('[data-action-panel]');
       this.saveWarningMessage = 'You have unsaved changes - Save, or undo the changes.';
+      this.$savedChanges = $('.js-saved-changes');
+      this.$form = $('.js-changes-form');
 
       super.start(el);
 
       this.$rowHighlighter = $(`<div class="calendar-row-highlighter"/>`).insertAfter(this.$el);
+
       this.setCalendarToCorrectHeight();
       this.setupUndo();
     }
 
+    bindEvents() {
+      super.bindEvents();
+
+      this.$form.on('ajax:success', this.afterChangesSaved.bind(this));
+    }
+
+    afterChangesSaved() {
+      this.eventChanges = [];
+      this.clearUnloadEvent();
+      this.checkToShowActionPanel();
+      this.$el.fullCalendar('refetchEvents');
+      this.$savedChanges.show();
+    }
+
     getCookieConfig() {
+
     }
 
     setCookieConfig() {
+
     }
 
     setCalendarToCorrectHeight() {
@@ -178,11 +197,11 @@
     }
 
     save(evt) {
-      const $hiddenInput = $('#event-changes');
+      const $hiddenInput = this.$form.find('#event-changes');
       evt.preventDefault();
+      this.$savedChanges.hide();
       $hiddenInput.val(this.getEventChangesForForm());
-      this.clearUnloadEvent();
-      $hiddenInput.parents('form').submit();
+      this.$form.submit();
     }
 
     getEventChangesForForm() {

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -4,8 +4,7 @@ class AppointmentsController < ApplicationController
 
   def batch_update
     BatchAppointmentUpdate.new(params[:changes]).call
-
-    redirect_to resource_calendar_path
+    head :ok
   end
 
   def index

--- a/app/views/resource_calendars/show.html.erb
+++ b/app/views/resource_calendars/show.html.erb
@@ -5,6 +5,10 @@
 
 <h1 class="sr-only">Allocations</h1>
 
+<div class="alert alert-success js-saved-changes t-saved-changes" role="alert" style="display:none;">
+  Your changes have been saved
+</div>
+
 <%= render 'shared/calendar_filter' %>
 
 <div
@@ -16,7 +20,7 @@
 </div>
 
 <div class="action-panel t-action-panel" data-action-panel>
-  <%= form_tag batch_update_appointments_path, method: :patch do %>
+  <%= form_tag batch_update_appointments_path, method: :patch, remote: true, class: 'js-changes-form' do %>
     <button class="btn btn-primary t-save" data-action-panel-save>
       <span class="glyphicon glyphicon-save" aria-hidden="true"></span> Save changes to
       <b>

--- a/spec/features/resource_manager_modifies_appointments_spec.rb
+++ b/spec/features/resource_manager_modifies_appointments_spec.rb
@@ -184,15 +184,6 @@ RSpec.feature 'Resource manager modifies appointments' do
     @other_appointment = create(:appointment, guider: @jan)
   end
 
-  def then_they_see_todays_date_shown
-    @page.wait_until_date_visible
-    expect(@page.date.text).to eq Time.zone.now.strftime('%B %e, %Y')
-  end
-
-  def when_they_click_the_next_day_button
-    @page.next_button.click
-  end
-
   def then_they_see_the_holiday_for_one_guider
     holiday = @page.find_holiday(@holiday)
     expect(holiday[:title]).to eq @holiday.title
@@ -206,11 +197,6 @@ RSpec.feature 'Resource manager modifies appointments' do
   end
 
   def when_they_view_the_appointments
-    @page = Pages::ResourceCalendar.new.tap(&:load)
-    expect(@page).to be_displayed
-  end
-
-  def and_they_view_the_appointments_again
     @page = Pages::ResourceCalendar.new.tap(&:load)
     expect(@page).to be_displayed
   end
@@ -231,9 +217,10 @@ RSpec.feature 'Resource manager modifies appointments' do
   def and_commit_their_modifications
     @page.wait_until_action_panel_visible
     @page.action_panel.save.click
+    @page.wait_until_saved_changes_message_visible
   end
 
-  def then_the_appointment_is_modified
+  def then_the_appointment_is_modified # rubocop:disable Metrics/AbcSize
     @appointment.reload
 
     expect(@appointment.start_at.hour).to eq(8)
@@ -243,7 +230,7 @@ RSpec.feature 'Resource manager modifies appointments' do
     expect(@appointment.end_at.min).to eq(30)
   end
 
-  def and_the_customer_is_notified_of_the_appointment_change
+  def and_the_customer_is_notified_of_the_appointment_change # rubocop:disable Metrics/AbcSize
     deliveries = ActionMailer::Base.deliveries
     expect(deliveries.count).to eq 1
     expect(deliveries.first.to).to eq [@appointment.email]

--- a/spec/features/resource_manager_modifies_appointments_spec.rb
+++ b/spec/features/resource_manager_modifies_appointments_spec.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/AbcSize
 require 'rails_helper'
 
 RSpec.feature 'Resource manager modifies appointments' do
@@ -138,7 +137,7 @@ RSpec.feature 'Resource manager modifies appointments' do
     )
   end
 
-  def then_they_can_see_the_bookable_slot
+  def then_they_can_see_the_bookable_slot # rubocop:disable Metrics/AbcSize
     event = @page.calendar.background_events.first
     expect(Time.zone.parse(event[:start])).to eq @bookable_slot.start_at
     expect(Time.zone.parse(event[:end])).to eq @bookable_slot.end_at
@@ -152,7 +151,7 @@ RSpec.feature 'Resource manager modifies appointments' do
     @page = Pages::Calendar.new.tap(&:load)
   end
 
-  def then_they_are_notified_of_the_change
+  def then_they_are_notified_of_the_change # rubocop:disable Metrics/AbcSize
     @page = Pages::Calendar.new
     @page.wait_until_notification_visible
 
@@ -160,7 +159,7 @@ RSpec.feature 'Resource manager modifies appointments' do
     expect(@page.notification.guider.text).to include(@jan.name)
   end
 
-  def then_they_are_notified_of_the_rescheduling
+  def then_they_are_notified_of_the_rescheduling # rubocop:disable Metrics/AbcSize
     @page = Pages::Calendar.new
     @page.wait_until_notification_visible
 
@@ -185,6 +184,15 @@ RSpec.feature 'Resource manager modifies appointments' do
     @other_appointment = create(:appointment, guider: @jan)
   end
 
+  def then_they_see_todays_date_shown
+    @page.wait_until_date_visible
+    expect(@page.date.text).to eq Time.zone.now.strftime('%B %e, %Y')
+  end
+
+  def when_they_click_the_next_day_button
+    @page.next_button.click
+  end
+
   def then_they_see_the_holiday_for_one_guider
     holiday = @page.find_holiday(@holiday)
     expect(holiday[:title]).to eq @holiday.title
@@ -198,6 +206,11 @@ RSpec.feature 'Resource manager modifies appointments' do
   end
 
   def when_they_view_the_appointments
+    @page = Pages::ResourceCalendar.new.tap(&:load)
+    expect(@page).to be_displayed
+  end
+
+  def and_they_view_the_appointments_again
     @page = Pages::ResourceCalendar.new.tap(&:load)
     expect(@page).to be_displayed
   end

--- a/spec/support/pages/resource_calendar.rb
+++ b/spec/support/pages/resource_calendar.rb
@@ -6,6 +6,7 @@ module Pages
     elements :guiders, '.fc-resource-cell'
     elements :appointments, '.fc-event'
     element :next_button, '.fc-next-button'
+    element :saved_changes_message, '.t-saved-changes'
 
     section :action_panel, '.t-action-panel' do
       element :save, '.t-save'

--- a/spec/support/pages/resource_calendar.rb
+++ b/spec/support/pages/resource_calendar.rb
@@ -2,8 +2,10 @@ module Pages
   class ResourceCalendar < SitePrism::Page
     set_url '/resource_calendar'
 
+    element :date, '.fc-left h2'
     elements :guiders, '.fc-resource-cell'
     elements :appointments, '.fc-event'
+    element :next_button, '.fc-next-button'
 
     section :action_panel, '.t-action-panel' do
       element :save, '.t-save'


### PR DESCRIPTION
- Store event changes with XHR
- Ensures that resource calendar always defaults to today
  when returning back to the calendar
- Ensures that the company calendar is unaffected by this
  change