### PR TITLE
Display only my appointments

### DIFF
--- a/app/assets/javascripts/calendars/guider-appointments.es6
+++ b/app/assets/javascripts/calendars/guider-appointments.es6
@@ -13,7 +13,7 @@
         nowIndicator: true,
         slotDuration: '00:30:00',
         eventTextColor: '#fff',
-        events: '/appointments'
+        events: '/appointments?mine'
       };
 
       super.start(el);

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -9,13 +9,7 @@ class AppointmentsController < ApplicationController
   end
 
   def index
-    scope = if current_user.resource_manager?
-              Appointment.unscoped
-            elsif current_user.guider?
-              current_user.appointments
-            end
-
-    @appointments = scope.where(start_at: date_range_params)
+    @appointments = appointment_scope.where(start_at: date_range_params)
 
     render json: @appointments
   end
@@ -74,6 +68,20 @@ class AppointmentsController < ApplicationController
   end
 
   private
+
+  def appointment_scope
+    if scoped_to_me?
+      current_user.appointments
+    elsif current_user.resource_manager?
+      Appointment.unscoped
+    else
+      current_user.appointments
+    end
+  end
+
+  def scoped_to_me?
+    params.key?(:mine)
+  end
 
   def search_params
     params.fetch(:search, {}).permit(:q, :date_range)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,6 +8,10 @@ FactoryGirl.define do
 
     permissions ['signin']
 
+    factory :guider_and_resource_manager do
+      permissions { [User::RESOURCE_MANAGER_PERMISSION, User::GUIDER_PERMISSION] }
+    end
+
     factory :resource_manager do
       permissions { Array(User::RESOURCE_MANAGER_PERMISSION) }
     end

--- a/spec/features/guider_views_appointments_spec.rb
+++ b/spec/features/guider_views_appointments_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 RSpec.feature 'Guider views appointments' do
   scenario 'Guider views their own appointments', js: true do
-    given_the_user_is_a_guider do
+    given_the_user_is_both_guider_and_manager do
       and_there_are_appointments_for_multiple_guiders
       travel_to @appointment.start_at do
         when_they_view_their_calendar

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -14,6 +14,13 @@ module UserHelpers
     GDS::SSO.test_user    = nil
   end
 
+  def given_the_user_is_both_guider_and_manager
+    GDS::SSO.test_user = create(:guider_and_resource_manager)
+    yield
+  ensure
+    GDS::SSO.test_user = nil
+  end
+
   def given_the_user_is_a_guider
     GDS::SSO.test_user = create(:guider)
     yield

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -14,38 +14,30 @@ module UserHelpers
     GDS::SSO.test_user    = nil
   end
 
-  def given_the_user_is_both_guider_and_manager
-    GDS::SSO.test_user = create(:guider_and_resource_manager)
+  def given_the_user(type)
+    GDS::SSO.test_user = create(type)
     yield
   ensure
     GDS::SSO.test_user = nil
   end
 
-  def given_the_user_is_a_guider
-    GDS::SSO.test_user = create(:guider)
-    yield
-  ensure
-    GDS::SSO.test_user = nil
+  def given_the_user_is_both_guider_and_manager(&block)
+    given_the_user(:guider_and_resource_manager, &block)
   end
 
-  def given_the_user_is_a_resource_manager
-    GDS::SSO.test_user = create(:resource_manager)
-    yield
-  ensure
-    GDS::SSO.test_user = nil
+  def given_the_user_is_a_guider(&block)
+    given_the_user(:guider, &block)
   end
 
-  def given_the_user_is_an_agent
-    GDS::SSO.test_user = create(:agent)
-    yield
-  ensure
-    GDS::SSO.test_user = nil
+  def given_the_user_is_a_resource_manager(&block)
+    given_the_user(:resource_manager, &block)
   end
 
-  def given_the_user_has_no_permissions
-    GDS::SSO.test_user = create(:user)
-    yield
-  ensure
-    GDS::SSO.test_user = nil
+  def given_the_user_is_an_agent(&block)
+    given_the_user(:agent, &block)
+  end
+
+  def given_the_user_has_no_permissions(&block)
+    given_the_user(:user, &block)
   end
 end


### PR DESCRIPTION
When the user is both a resource manager and a guider - the scoping logic
for the appointments JSON would short-circuit to all appointments due to
ordering of conditionals favouring the resource manager permission.

This change ensures that when the user is both guider and manager they only
see appointments scoped directly to them - i.e. appointments they are
holding with the customer.