### PR TITLE
Check for test coverage in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 
 # Node
 node_modules
+
+# Coverage reports
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ source 'https://rubygems.org' do
   end
 
   group :test do
+    gem 'coveralls', require: false
     gem 'poltergeist'
     gem 'phantomjs-binaries'
     gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,9 +90,16 @@ GEM
     concurrent-ruby (1.0.2)
     connection_pool (2.2.0)
     cookiejar (0.3.3)
+    coveralls (0.8.15)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.12.0)
+      term-ansicolor (~> 1.3)
+      thor (~> 0.19.1)
+      tins (>= 1.6.0, < 2)
     daemons (1.2.4)
     database_cleaner (1.5.3)
     diff-lcs (1.2.5)
+    docile (1.1.5)
     em-http-request (1.1.5)
       addressable (>= 2.3.4)
       cookiejar (!= 0.3.1)
@@ -143,6 +150,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.0.2)
     jsonapi (0.1.1.beta6)
       jsonapi-parser (= 0.1.1.beta3)
       jsonapi-renderer (= 0.1.1.beta1)
@@ -324,6 +332,11 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (~> 1.5)
       redis (~> 3.2, >= 3.2.1)
+    simplecov (0.12.0)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
     sinatra (1.0)
       rack (>= 1.0)
     site_prism (2.9)
@@ -343,6 +356,8 @@ GEM
       sprockets (>= 3.0.0)
     sys-uname (0.9.0)
       ffi (>= 1.0.0)
+    term-ansicolor (1.4.0)
+      tins (~> 1.0)
     thin (1.7.0)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -350,6 +365,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
+    tins (1.12.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (3.0.2)
@@ -380,6 +396,7 @@ DEPENDENCIES
   bugsnag!
   capybara!
   chronic!
+  coveralls!
   database_cleaner!
   factory_girl_rails (~> 4.0)!
   faker!

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,11 @@ require 'capybara/rspec'
 require 'database_cleaner'
 require 'pusher-fake/support/rspec'
 
+if ENV['TRAVIS']
+  require 'coveralls'
+  Coveralls.wear!
+end
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
This is fairly invasive so by default we opt-out of coverage in normal
usage. Obviously you can still `TRAVIS=true rspec` if you care.