### PR TITLE
Highlight the currently 'dragged-over' resource and time

### DIFF
--- a/app/assets/javascripts/calendars/guiders-appointments.es6
+++ b/app/assets/javascripts/calendars/guiders-appointments.es6
@@ -25,6 +25,7 @@
         nowIndicator: true,
         slotDuration: '00:30:00',
         eventTextColor: '#fff',
+        eventDragStop: this.eventDragStop,
         eventSources: [
           {
             url: '/appointments'
@@ -215,6 +216,32 @@
       } else if(event.cancelled) {
         element.addClass('fc-event--cancelled');
       }
+
+      if (event.className.indexOf('fc-helper') > -1) {
+        this.highlightResource(event);
+      }
+    }
+
+    highlightResource(event) {
+      let eventStartSelector = event.start.format('HH:mm:ss');
+
+      this.$el.find(`.fc-resource-cell`)
+        .removeClass('active')
+        .filter(`[data-resource-id="${event.resourceId}"]`)
+        .addClass('active');
+
+      this.$el.find(`tr[data-time]`)
+        .find('.fc-time')
+        .removeClass('active')
+        .parents(`tr`)
+        .filter(`[data-time="${eventStartSelector}"]`)
+        .find('.fc-time')
+        .addClass('active');
+    }
+
+    eventDragStop() {
+      $(`.fc-resource-cell`).removeClass('active');
+      $(`tr[data-time]`).find('.fc-time').removeClass('active');
     }
 
     setupUndo() {

--- a/app/assets/stylesheets/components/_calendars.scss
+++ b/app/assets/stylesheets/components/_calendars.scss
@@ -3,6 +3,7 @@ $calendar-cancelled-background: $color-guardsman-red;
 $calendar-moved-background: $color-green;
 $calendar-filter-box-shadow: transparentize($color-black, .825);
 $calendar-filter-arrow-border: transparentize($color-black, .8);
+$calendar-dragging-highlight: $color-givry;
 
 .holiday-calendar {
   margin-top: 1em;
@@ -35,6 +36,10 @@ $calendar-filter-arrow-border: transparentize($color-black, .8);
   th {
     border-width: 0;
     overflow: hidden;
+  }
+
+  .active {
+    background-color: $calendar-dragging-highlight;
   }
 }
 


### PR DESCRIPTION
To help resource managers know they're dragging and dropping
events into the correct areas.

![4knlut3mo5](https://cloud.githubusercontent.com/assets/295469/20275473/9a517b66-aa90-11e6-9a3c-90c24267f455.gif)
