### PR TITLE
Highlight the currently 'dragged-over' resource and time

### DIFF
--- a/app/assets/javascripts/calendars/guiders-appointments.es6
+++ b/app/assets/javascripts/calendars/guiders-appointments.es6
@@ -25,6 +25,7 @@
         nowIndicator: true,
         slotDuration: '00:30:00',
         eventTextColor: '#fff',
+        eventDragStop: (...args) => this.eventDragStop(...args),
         eventSources: [
           {
             url: '/appointments'
@@ -51,6 +52,7 @@
       this.saveWarningMessage = 'You have unsaved changes - Save, or undo the changes.';
       this.filterButton = $('.fc-filter-button');
       this.filterPanel = $('.resource-calendar-filter');
+      this.$rowHighlighter = $(`<div class="calendar-row-highlighter"/>`).insertAfter(this.$el);
 
       this.bindEvents();
       this.setCalendarToCorrectHeight();
@@ -215,6 +217,41 @@
       } else if(event.cancelled) {
         element.addClass('fc-event--cancelled');
       }
+
+      if (event.className.indexOf('fc-helper') > -1) {
+        this.highlightResource(event);
+      }
+    }
+
+    highlightResource(event) {
+      let eventStartSelector = event.start.format('HH:mm:ss'),
+        $timeRow = this.$el.find(`[data-time="${eventStartSelector}"]`),
+        eventPosition = $timeRow.offset();
+
+      this.$rowHighlighter.css({
+        top: eventPosition.top,
+        left: eventPosition.left,
+        width: $timeRow.width()
+      }).addClass('active');
+
+      this.$el.find(`.fc-resource-cell`)
+        .removeClass('active')
+        .filter(`[data-resource-id="${event.resourceId}"]`)
+        .addClass('active');
+
+      this.$el.find(`tr[data-time]`)
+        .find('.fc-time')
+        .removeClass('active')
+        .parents(`tr`)
+        .filter(`[data-time="${eventStartSelector}"]`)
+        .find('.fc-time')
+        .addClass('active');
+    }
+
+    eventDragStop() {
+      this.$rowHighlighter.removeClass('active');
+      $(`.fc-resource-cell`).removeClass('active');
+      $(`tr[data-time]`).find('.fc-time').removeClass('active');
     }
 
     setupUndo() {

--- a/app/assets/stylesheets/components/_calendars.scss
+++ b/app/assets/stylesheets/components/_calendars.scss
@@ -3,6 +3,7 @@ $calendar-cancelled-background: $color-guardsman-red;
 $calendar-moved-background: $color-green;
 $calendar-filter-box-shadow: transparentize($color-black, .825);
 $calendar-filter-arrow-border: transparentize($color-black, .8);
+$calendar-dragging-highlight: $color-givry;
 
 .holiday-calendar {
   margin-top: 1em;
@@ -35,6 +36,22 @@ $calendar-filter-arrow-border: transparentize($color-black, .8);
   th {
     border-width: 0;
     overflow: hidden;
+  }
+
+  .active {
+    background-color: $calendar-dragging-highlight;
+  }
+}
+
+.calendar-row-highlighter {
+  display: none;
+
+  &.active {
+    display: block;
+    position: absolute;
+    width: 100%;
+    height: 5px;
+    background: $calendar-dragging-highlight;
   }
 }
 


### PR DESCRIPTION
To help resource managers know they're dragging and dropping
events into the correct areas.

![aomnmza5lo](https://cloud.githubusercontent.com/assets/295469/20300352/c696454a-ab16-11e6-9526-27cac42f8d3f.gif)
