### PR TITLE
Calendar colours

### DIFF
--- a/app/assets/javascripts/calendars/guider-appointments.es6
+++ b/app/assets/javascripts/calendars/guider-appointments.es6
@@ -19,7 +19,7 @@
           },
           {
             url: '/bookable_slots?mine',
-            color: 'green',
+            color: '#e1f5e1',
             rendering: 'background'
           }
         ]
@@ -64,7 +64,7 @@
       }
 
       if (event.status.indexOf('cancelled') > -1) {
-        element.addClass('cancelled');
+        element.addClass('fc-event--cancelled');
       }
     }
   }

--- a/app/assets/javascripts/calendars/guiders-appointments.es6
+++ b/app/assets/javascripts/calendars/guiders-appointments.es6
@@ -32,12 +32,12 @@
           },
           {
             url: '/holidays',
-            color: 'red',
+            color: '#ebebeb',
             rendering: 'background'
           },
           {
             url: '/bookable_slots',
-            color: 'green',
+            color: '#e1f5e1',
             rendering: 'background'
           }
         ],

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,3 @@
-@import "lib/colours";
+@import "lib/*";
 @import "vendor/vendor";
 @import "components/*";

--- a/app/assets/stylesheets/components/_calendars.scss
+++ b/app/assets/stylesheets/components/_calendars.scss
@@ -4,13 +4,17 @@ $calendar-moved-background: $color-green;
 $calendar-filter-box-shadow: transparentize($color-black, .825);
 $calendar-filter-arrow-border: transparentize($color-black, .8);
 $calendar-dragging-highlight: $color-givry;
+$calendar-appointment-background: $color-boston-blue;
+$calendar-appointment-cancelled-background: $color-muddy-waters;
+$calendar-appointment-moved-background: $color-green;
+$calendar-holiday-anchor-visited: $color-white;
 
 .holiday-calendar {
   margin-top: 1em;
 
   .fc-event {
     &:visited {
-      color: $color-white;
+      color: $calendar-holiday-anchor-visited;
     }
   }
 }
@@ -79,13 +83,6 @@ $calendar-dragging-highlight: $color-givry;
   border: 1px solid $state-danger-text;
 }
 
-.fc-event {
-  &.cancelled {
-    background: $brand-danger;
-    opacity: .8;
-  }
-}
-
 .fc-right {
   position: relative;
 }
@@ -99,13 +96,20 @@ $calendar-dragging-highlight: $color-givry;
   top: 20px;
 }
 
+.fc-event {
+  @include striped($calendar-appointment-background);
+}
+
 .fc-event--cancelled {
-  background: $calendar-cancelled-background;
-  opacity: .5;
+  @include striped($calendar-appointment-cancelled-background);
 }
 
 .fc-event--moved {
-  background: $calendar-moved-background;
+  @include striped($calendar-appointment-moved-background);
+}
+
+.fc-bgevent {
+  opacity: 1;
 }
 
 .resource-calendar-filter {

--- a/app/assets/stylesheets/components/_guider-schedules.scss
+++ b/app/assets/stylesheets/components/_guider-schedules.scss
@@ -2,23 +2,9 @@ $guider-schedules-bookable-window-color: transparentize($color-givry, .2);
 $guider-schedules-bookable-window-border-color: $color-silver;
 $guider-schedules-bookable-color: $color-feijoa;
 
-@function schedule-repeating-gradient($background) {
-  @return $background repeating-linear-gradient(
-    -45deg,
-    $background,
-    $background 10px,
-    transparentize($color-white, .8) 10px,
-    transparentize($color-white, .8) 20px
-  );
-}
-
 @mixin bookable-window-style {
   background: $guider-schedules-bookable-window-color;
   border: 1px dashed $guider-schedules-bookable-window-border-color;
-}
-
-@mixin schedule-style {
-  background: schedule-repeating-gradient($guider-schedules-bookable-color);
 }
 
 .guider-schedules {
@@ -53,7 +39,7 @@ $guider-schedules-bookable-color: $color-feijoa;
 }
 
 .guider-schedules__schedule {
-  @include schedule-style;
+  @include striped($guider-schedules-bookable-color);
   height: 25px;
   margin-top: 5px;
 }
@@ -62,7 +48,7 @@ $guider-schedules-bookable-color: $color-feijoa;
   display: none;
 
   &::before {
-    @include schedule-style;
+    @include striped($guider-schedules-bookable-color);
   }
 
   .js & {

--- a/app/assets/stylesheets/lib/_colours.scss
+++ b/app/assets/stylesheets/lib/_colours.scss
@@ -1,10 +1,12 @@
 // Names from http://chir.ag/projects/name-that-color/
 $color-alto: #ddd;
 $color-black: #000;
+$color-boston-blue: #3a87ad;
 $color-feijoa: #8fdf82;
-$color-green: #0c0;
 $color-givry: #f7f2c3;
+$color-green: #0c0;
 $color-guardsman-red: #c00;
+$color-muddy-waters: #bf886e;
 $color-roman: #d9534f;
 $color-silver: #ccc;
 $color-white: #fff;

--- a/app/assets/stylesheets/lib/_striped_background.scss
+++ b/app/assets/stylesheets/lib/_striped_background.scss
@@ -1,0 +1,13 @@
+@function striped-background($background) {
+  @return $background repeating-linear-gradient(
+    -45deg,
+    $background,
+    $background 10px,
+    transparentize($color-white, .8) 10px,
+    transparentize($color-white, .8) 20px
+  );
+}
+
+@mixin striped($bg-colour) {
+  background: striped-background($bg-colour);
+}


### PR DESCRIPTION
<img width="1176" alt="screen shot 2016-11-15 at 10 58 15" src="https://cloud.githubusercontent.com/assets/6049076/20303238/72e1e5ce-ab22-11e6-8d16-1847747812b5.png">

- attempted to make appointments stand out and make the calendar
  not so overwhelming with colour
- cancelled appointments now have the same hue as default appointment
  colour - so to not stand out too much
- holidays are now grey, so not to confuse with cancelled appointments