### PR TITLE
Ensure there's a corresponding time being dragged to

### DIFF
--- a/app/assets/javascripts/calendars/allocations.es6
+++ b/app/assets/javascripts/calendars/allocations.es6
@@ -14,9 +14,10 @@
       this.eventChanges = [];
       this.actionPanel = $('[data-action-panel]');
       this.saveWarningMessage = 'You have unsaved changes - Save, or undo the changes.';
-      this.$rowHighlighter = $(`<div class="calendar-row-highlighter"/>`).insertAfter(this.$el);
 
       super.start(el);
+
+      this.$rowHighlighter = $(`<div class="calendar-row-highlighter"/>`).insertAfter(this.$el);
       this.setCalendarToCorrectHeight();
       this.setupUndo();
     }
@@ -83,14 +84,7 @@
 
     highlightResource(event) {
       let eventStartSelector = event.start.format('HH:mm:ss'),
-        $timeRow = this.$el.find(`[data-time="${eventStartSelector}"]`),
-        eventPosition = $timeRow.offset();
-
-      this.$rowHighlighter.css({
-        top: eventPosition.top,
-        left: eventPosition.left,
-        width: $timeRow.width()
-      }).addClass('active');
+        $timeRow = this.$el.find(`[data-time="${eventStartSelector}"]`);
 
       this.$el.find(`.fc-resource-cell`)
         .removeClass('active')
@@ -104,6 +98,16 @@
         .filter(`[data-time="${eventStartSelector}"]`)
         .find('.fc-time')
         .addClass('active');
+
+      if ($timeRow.length) {
+        let eventPosition = $timeRow.offset();
+
+        this.$rowHighlighter.css({
+          top: eventPosition.top,
+          left: eventPosition.left,
+          width: $timeRow.width()
+        }).addClass('active');
+      }
     }
 
     eventDragStop() {


### PR DESCRIPTION
We were trying to calculate position of elements that didn't exist.
E.g. dragging an event to before 8.30am or after 7pm.

Also adjusts the 'boot' order to ensure `this.$el` is defined
before we add the row highlighter.