### PR TITLE
Make resource calendar the homepage for resource managers

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,6 @@
 class HomeController < ApplicationController
   def index
-    return redirect_to users_path, status: :moved_permanently if current_user.resource_manager?
+    return redirect_to resource_calendar_path, status: :moved_permanently if current_user.resource_manager?
     return redirect_to new_appointment_path, status: :moved_permanently if current_user.agent?
     return redirect_to calendar_path, status: :moved_permanently if current_user.guider?
   end

--- a/spec/features/custom_role_redirects_spec.rb
+++ b/spec/features/custom_role_redirects_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Custom Role Redirects' do
   scenario 'Views the root path as a resource manager' do
     given_the_user_is_a_resource_manager do
       when_they_visit_the_home_page
-      then_they_see_the_guiders_page
+      then_they_see_the_resource_calendar_page
     end
   end
 
@@ -27,8 +27,8 @@ def when_they_visit_the_home_page
   @page = Pages::Home.new.tap(&:load)
 end
 
-def then_they_see_the_guiders_page
-  expect(current_path).to eq users_path
+def then_they_see_the_resource_calendar_page
+  expect(current_path).to eq resource_calendar_path
 end
 
 def then_they_see_the_calendar_page


### PR DESCRIPTION
Seems to be a more frequently used page than the groups management.