### PR TITLE
Make schedule edit screen less painful on the eyes

### DIFF
--- a/app/assets/javascripts/calendars/guider-slot-picker.es6
+++ b/app/assets/javascripts/calendars/guider-slot-picker.es6
@@ -8,8 +8,6 @@
         columnFormat: 'dddd',
         defaultView: 'agendaWeek',
         editable: true,
-        eventColor: '#8fdf82',
-        eventTextColor: '#000',
         eventDurationEditable: false,
         eventOverlap: false,
         header: false,
@@ -46,6 +44,7 @@
     }
 
     eventRender(event, element) {
+      element.addClass('fc-event--bookable-slot');
       element.append('<button class="close"><span aria-hidden="true">X</span><span class="sr-only">Remove slot</span></button>');
       element.find('.close').on('click', () => {
         this.$el.fullCalendar('removeEvents', event._id);

--- a/app/assets/stylesheets/components/_calendars.scss
+++ b/app/assets/stylesheets/components/_calendars.scss
@@ -9,6 +9,7 @@ $calendar-appointment-cancelled-background: $color-muddy-waters;
 $calendar-appointment-moved-background: $color-green;
 $calendar-holiday-anchor-visited: $color-white;
 $calendar-holiday-background: $color-gallery;
+$calendar-schedule-background: $color-xanadu;
 $calendar-bookable-slot-background: $color-peppermint;
 
 .holiday-calendar {
@@ -114,6 +115,10 @@ $calendar-bookable-slot-background: $color-peppermint;
 .fc-event--holiday,
 .fc-bgevent--holiday {
   background: $calendar-holiday-background;
+}
+
+.fc-event--bookable-slot {
+  background: $calendar-schedule-background;
 }
 
 .fc-bgevent--bookable-slot {

--- a/app/assets/stylesheets/lib/_colours.scss
+++ b/app/assets/stylesheets/lib/_colours.scss
@@ -12,3 +12,4 @@ $color-peppermint: #e1f5e1;
 $color-roman: #d9534f;
 $color-silver: #ccc;
 $color-white: #fff;
+$color-xanadu: #768776;


### PR DESCRIPTION
Not sure about this colour but it sets up its own variable
for easy tweaking in the future.

Before:
<img width="1189" alt="screen shot 2016-11-15 at 16 03 07" src="https://cloud.githubusercontent.com/assets/295469/20313574/3ee2e7aa-ab4f-11e6-9574-06f1c4cc45d7.png">

Now:
<img width="1200" alt="screen shot 2016-11-15 at 16 18 56" src="https://cloud.githubusercontent.com/assets/295469/20313567/3c4bec12-ab4f-11e6-9b44-9f5b1edb5c68.png">
