### PR TITLE
Disable ABC size cop for features

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,3 +28,7 @@ Style/FrozenStringLiteralComment:
 Metrics/MethodLength:
   Exclude:
     - 'spec/requests/*'
+
+Metrics/AbcSize:
+  Exclude:
+    - 'spec/features/*'

--- a/spec/features/agent_manages_appointments_spec.rb
+++ b/spec/features/agent_manages_appointments_spec.rb
@@ -79,7 +79,6 @@ RSpec.feature 'Agent manages appointments' do
     BookableSlot.generate_for_six_weeks
   end
 
-  # rubocop:disable Metrics/AbcSize
   def fill_in_appointment_details(options = {})
     @page.first_name.set 'Some'
     @page.last_name.set 'Person'

--- a/spec/features/guider_edits_an_appointment_spec.rb
+++ b/spec/features/guider_edits_an_appointment_spec.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/AbcSize
 require 'rails_helper'
 
 RSpec.feature 'Guider edits an appointment' do

--- a/spec/features/guider_views_appointments_spec.rb
+++ b/spec/features/guider_views_appointments_spec.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/AbcSize
 require 'rails_helper'
 
 RSpec.feature 'Guider views appointments' do

--- a/spec/features/resource_manager_downloads_appointment_reports_spec.rb
+++ b/spec/features/resource_manager_downloads_appointment_reports_spec.rb
@@ -76,7 +76,6 @@ RSpec.feature 'Resource manager downloads appointment reports' do
   end
 
   # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/AbcSize
   def expect_appointment_csv(appointment)
     expect(@page.csv.count).to eq 2
     expect(@page.csv.first).to eq AppointmentReport::EXPORTABLE_ATTRIBUTES

--- a/spec/features/resource_manager_downloads_utilisation_reports_spec.rb
+++ b/spec/features/resource_manager_downloads_utilisation_reports_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature 'Resource manager downloads utilisation reports' do
     ].join(' - ')
   end
 
-  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
   def and_there_are_data
     guider = create(:guider)
 
@@ -62,7 +62,7 @@ RSpec.feature 'Resource manager downloads utilisation reports' do
     holiday = create(:holiday, user: guider, start_at: start_at + 10.days, end_at: start_at + 11.days)
     create(:bookable_slot, guider: guider, start_at: holiday.start_at + 1.hour)
   end
-  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
 
   def when_they_download_utilisation_reports_for_a_date_range
     @page = Pages::NewUtilisationReport.new.tap(&:load)
@@ -80,11 +80,9 @@ RSpec.feature 'Resource manager downloads utilisation reports' do
     expect(@page.content_disposition).to eq "attachment; filename=#{file_name}"
   end
 
-  # rubocop:disable Metrics/AbcSize
   def expect_utilisation_csv(utilisation)
     expect(@page.csv.count).to eq 2
     expect(@page.csv.first).to eq [:booked_appointments, :bookable_slots, :blocked_slots]
     expect(@page.csv.second.map(&:to_i)).to eq utilisation
   end
-  # rubocop:enable Metrics/AbcSize
 end

--- a/spec/features/resource_manager_manages_guiders_spec.rb
+++ b/spec/features/resource_manager_manages_guiders_spec.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/AbcSize
 require 'rails_helper'
 
 RSpec.feature 'Resource manager manages guiders' do

--- a/spec/features/resource_manager_manages_holidays_spec.rb
+++ b/spec/features/resource_manager_manages_holidays_spec.rb
@@ -54,8 +54,6 @@ RSpec.feature 'Resource manager manages holidays' do
       end
     end
   end
-
-  # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/MethodLength
   def and_there_are_some_holidays
     create(

--- a/spec/features/resource_manager_manages_schedules_spec.rb
+++ b/spec/features/resource_manager_manages_schedules_spec.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/AbcSize
 # rubocop:disable Metrics/MethodLength
 
 require 'rails_helper'

--- a/spec/features/resource_manager_modifies_appointments_spec.rb
+++ b/spec/features/resource_manager_modifies_appointments_spec.rb
@@ -137,7 +137,7 @@ RSpec.feature 'Resource manager modifies appointments' do
     )
   end
 
-  def then_they_can_see_the_bookable_slot # rubocop:disable Metrics/AbcSize
+  def then_they_can_see_the_bookable_slot
     event = @page.calendar.background_events.first
     expect(Time.zone.parse(event[:start])).to eq @bookable_slot.start_at
     expect(Time.zone.parse(event[:end])).to eq @bookable_slot.end_at
@@ -151,7 +151,7 @@ RSpec.feature 'Resource manager modifies appointments' do
     @page = Pages::Calendar.new.tap(&:load)
   end
 
-  def then_they_are_notified_of_the_change # rubocop:disable Metrics/AbcSize
+  def then_they_are_notified_of_the_change
     @page = Pages::Calendar.new
     @page.wait_until_notification_visible
 
@@ -159,7 +159,7 @@ RSpec.feature 'Resource manager modifies appointments' do
     expect(@page.notification.guider.text).to include(@jan.name)
   end
 
-  def then_they_are_notified_of_the_rescheduling # rubocop:disable Metrics/AbcSize
+  def then_they_are_notified_of_the_rescheduling
     @page = Pages::Calendar.new
     @page.wait_until_notification_visible
 
@@ -220,7 +220,7 @@ RSpec.feature 'Resource manager modifies appointments' do
     @page.wait_until_saved_changes_message_visible
   end
 
-  def then_the_appointment_is_modified # rubocop:disable Metrics/AbcSize
+  def then_the_appointment_is_modified
     @appointment.reload
 
     expect(@appointment.start_at.hour).to eq(8)
@@ -230,7 +230,7 @@ RSpec.feature 'Resource manager modifies appointments' do
     expect(@appointment.end_at.min).to eq(30)
   end
 
-  def and_the_customer_is_notified_of_the_appointment_change # rubocop:disable Metrics/AbcSize
+  def and_the_customer_is_notified_of_the_appointment_change
     deliveries = ActionMailer::Base.deliveries
     expect(deliveries.count).to eq 1
     expect(deliveries.first.to).to eq [@appointment.email]


### PR DESCRIPTION
This is a useless check for the feature specs and it makes sense to
remove the individual enabling / disabling in favour of globally
disabling the cop for features.