### PR TITLE
Add 'list' view to guider's appointments page

### DIFF
--- a/app/assets/javascripts/calendars/guider-appointments.es6
+++ b/app/assets/javascripts/calendars/guider-appointments.es6
@@ -8,7 +8,10 @@
         columnFormat: 'ddd D/M',
         defaultView: 'agendaDay',
         header: {
-          right: 'agendaDay agendaWeek month today jumpToDate prev,next'
+          right: 'listWeek agendaDay agendaWeek month today jumpToDate prev,next'
+        },
+        buttonText: {
+          listWeek: 'List'
         },
         nowIndicator: true,
         slotDuration: '00:30:00',


### PR DESCRIPTION
Makes it easier to view the day at a glance.

Bit like this:

<img width="925" alt="screen shot 2016-11-16 at 13 39 21" src="https://cloud.githubusercontent.com/assets/295469/20349373/1cef60f2-ac02-11e6-9501-a3b9d4b545aa.png">

