### PR TITLE
Ensure holidays appear over the top of bookable slots

### DIFF
--- a/app/assets/stylesheets/components/_calendars.scss
+++ b/app/assets/stylesheets/components/_calendars.scss
@@ -102,6 +102,7 @@ $calendar-bookable-slot-background: $color-peppermint;
 
 .fc-event {
   @include striped($calendar-appointment-background);
+  z-index: 3;
 }
 
 .fc-event--cancelled {
@@ -112,17 +113,22 @@ $calendar-bookable-slot-background: $color-peppermint;
   @include striped($calendar-appointment-moved-background);
 }
 
-.fc-event--holiday,
-.fc-bgevent--holiday {
-  background: $calendar-holiday-background;
-}
+.fc-time-grid,
+.fc-time-area {
+  .fc-event--holiday,
+  .fc-bgevent--holiday {
+    background: $calendar-holiday-background;
+    z-index: 2;
+  }
 
-.fc-event--bookable-slot {
-  background: $calendar-schedule-background;
-}
+  .fc-event--bookable-slot {
+    background: $calendar-schedule-background;
+  }
 
-.fc-bgevent--bookable-slot {
-  background: $calendar-bookable-slot-background;
+  .fc-bgevent--bookable-slot {
+    background: $calendar-bookable-slot-background;
+    z-index: 1;
+  }
 }
 
 .fc-bgevent {


### PR DESCRIPTION
When bookable slots starting after a holiday's start time, they would appear over the top of the holiday. This resulted in the guider appearing to be available when they were in fact not.

**See example below for a holiday that ends at 14:00, but appears to end earlier**

Before:
<img width="935" alt="screen shot 2016-11-16 at 14 28 05" src="https://cloud.githubusercontent.com/assets/295469/20350987/eb8de932-ac08-11e6-8d7e-7dedde509937.png">


After:
<img width="938" alt="screen shot 2016-11-16 at 14 27 39" src="https://cloud.githubusercontent.com/assets/295469/20350992/efe8c18c-ac08-11e6-9009-52957170e764.png">
