### PR TITLE
Only use the floating 'fixed' flash message style on allocations

### DIFF
--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -1,9 +1,12 @@
 .alert {
   border-width: 5px;
   font-size: 130%;
-  position: fixed;
-  margin-top: 120px;
   min-width: 33%;
   top: 0;
+}
+
+.alert--fixed {
+  margin-top: 120px;
+  position: fixed;
   z-index: 1000;
 }

--- a/app/views/resource_calendars/show.html.erb
+++ b/app/views/resource_calendars/show.html.erb
@@ -5,11 +5,11 @@
 
 <h1 class="sr-only">Allocations</h1>
 
-<div class="alert alert-success js-saved-changes t-saved-changes" role="alert" style="display:none;">
+<div class="alert alert--fixed alert-success js-saved-changes t-saved-changes" role="alert" style="display:none;">
   <span class="glyphicon glyphicon-ok"></span> Changes saved.
 </div>
 
-<div class="alert alert-danger js-saved-changes t-saved-changes" role="alert" style="display:none;">
+<div class="alert alert--fixed alert-danger js-saved-changes t-saved-changes" role="alert" style="display:none;">
   <span class="glyphicon glyphicon-alert"></span> Unable to save changes. Please try again.
 </div>
 


### PR DESCRIPTION
As we use AJAX-style saving on this calendar, it makes sense to
flash the message and then fade it out. But on other pages
this just looks a little strange, so they get the standard
full width, block style message.

This essentially fixes the following:
<img width="1157" alt="screen shot 2016-11-17 at 11 10 02" src="https://cloud.githubusercontent.com/assets/295469/20387096/6e1c3568-acb6-11e6-96df-20fb6fc04d93.png">

with:
<img width="1165" alt="screen shot 2016-11-17 at 11 10 08" src="https://cloud.githubusercontent.com/assets/295469/20387100/711ef9da-acb6-11e6-8c9c-69de052545a0.png">
