### PR TITLE
Balance column widths on guider list page

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -17,8 +17,8 @@
       <caption><span class="sr-only">List of guiders</span></caption>
       <colgroup>
         <col width="1%">
-        <col width="54%">
-        <col width="44%">
+        <col width="34%">
+        <col width="64%">
         <col width="1%">
       </colgroup>
       <thead>


### PR DESCRIPTION
Seems the groups are carrying the weight of the content on this
page, so this gives them a little more space.

Before:
<img width="1161" alt="screen shot 2016-11-17 at 11 34 38" src="https://cloud.githubusercontent.com/assets/295469/20387829/e9142638-acb9-11e6-8d11-7a1c7fc8d413.png">

After:
<img width="1193" alt="screen shot 2016-11-17 at 11 34 53" src="https://cloud.githubusercontent.com/assets/295469/20387832/eb2b33bc-acb9-11e6-8d5b-5dac23f04b0c.png">
