### PR TITLE
Configure mailers

### DIFF
--- a/app/lib/mailgun_headers.rb
+++ b/app/lib/mailgun_headers.rb
@@ -1,0 +1,14 @@
+module MailgunHeaders
+  def mailgun_headers(message_type)
+    headers['X-Mailgun-Variables'] = headers_hash(message_type)
+  end
+
+  private
+
+  def headers_hash(message_type)
+    {
+      message_type: message_type,
+      environment: Rails.env
+    }.to_json
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'Pension Wise Appointments <appointments@pensionwise.gov.uk>'
+  default from: 'Pension Wise Bookings <booking@pensionwise.gov.uk>'
+
   layout 'mailer'
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,6 @@
 class ApplicationMailer < ActionMailer::Base
+  include MailgunHeaders
+
   default from: 'Pension Wise Bookings <booking@pensionwise.gov.uk>'
 
   layout 'mailer'

--- a/app/mailers/appointment_mailer.rb
+++ b/app/mailers/appointment_mailer.rb
@@ -4,6 +4,7 @@ class AppointmentMailer < ApplicationMailer
   def confirmation(appointment)
     return unless appointment.email?
 
+    mailgun_headers('booking_created')
     @appointment = appointment
     mail to: @appointment.email
   end
@@ -11,6 +12,7 @@ class AppointmentMailer < ApplicationMailer
   def updated(appointment)
     return unless appointment.email?
 
+    mailgun_headers('booking_updated')
     @appointment = appointment
     mail to: @appointment.email
   end

--- a/spec/mailers/appointment_mailer_spec.rb
+++ b/spec/mailers/appointment_mailer_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe AppointmentMailer, type: :mailer do
       expect(mail.from).to eq(['booking@pensionwise.gov.uk'])
     end
 
+    it 'renders the mailgun specific headers' do
+      expect(mail['X-Mailgun-Variables'].value).to include('"message_type":"booking_created"')
+    end
+
     describe 'rendering the body' do
       let(:body) { subject.body.encoded }
 
@@ -51,6 +55,10 @@ RSpec.describe AppointmentMailer, type: :mailer do
       expect(mail.subject).to eq('Your Pension Wise Appointment')
       expect(mail.to).to eq([appointment.email])
       expect(mail.from).to eq(['booking@pensionwise.gov.uk'])
+    end
+
+    it 'renders the mailgun specific headers' do
+      expect(mail['X-Mailgun-Variables'].value).to include('"message_type":"booking_updated"')
     end
 
     describe 'rendering the body' do

--- a/spec/mailers/appointment_mailer_spec.rb
+++ b/spec/mailers/appointment_mailer_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe AppointmentMailer, type: :mailer do
     it 'renders the headers' do
       expect(mail.subject).to eq('Your Pension Wise Appointment')
       expect(mail.to).to eq([appointment.email])
-      expect(mail.from).to eq(['appointments@pensionwise.gov.uk'])
+      expect(mail.from).to eq(['booking@pensionwise.gov.uk'])
     end
 
     describe 'rendering the body' do
@@ -50,7 +50,7 @@ RSpec.describe AppointmentMailer, type: :mailer do
     it 'renders the headers' do
       expect(mail.subject).to eq('Your Pension Wise Appointment')
       expect(mail.to).to eq([appointment.email])
-      expect(mail.from).to eq(['appointments@pensionwise.gov.uk'])
+      expect(mail.from).to eq(['booking@pensionwise.gov.uk'])
     end
 
     describe 'rendering the body' do


### PR DESCRIPTION
Adds mailgun specific headers for identification.

Changes the `from` address so we're unique from planner and other apps we
send email from.