### PR TITLE
Ensure our calendar styles apply to month views

### DIFF
--- a/app/assets/stylesheets/components/_calendars.scss
+++ b/app/assets/stylesheets/components/_calendars.scss
@@ -116,6 +116,7 @@ $calendar-bookable-slot-background: $color-peppermint;
   @include striped($calendar-appointment-moved-background);
 }
 
+.fc-day-grid,
 .fc-time-grid,
 .fc-time-area {
   .fc-event--holiday,


### PR DESCRIPTION
We need to be quite specific to override FullCalendar's styles.

Before:
<img width="1158" alt="screen shot 2016-11-17 at 13 31 07" src="https://cloud.githubusercontent.com/assets/295469/20391173/230a74a4-acca-11e6-94dc-2d85fdbbb19a.png">

After:
<img width="1158" alt="screen shot 2016-11-17 at 13 31 14" src="https://cloud.githubusercontent.com/assets/295469/20391176/2570595c-acca-11e6-90ae-3e330df1eaf1.png">
