### PR TITLE
When events overlap, make their widths more even

### DIFF
--- a/app/assets/javascripts/calendar.es6
+++ b/app/assets/javascripts/calendar.es6
@@ -27,6 +27,7 @@ class Calendar extends TapBase {
       minTime: '08:30:00',
       schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
       slotLabelFormat: 'H:mm',
+      slotEventOverlap: false,
       timeFormat: 'H:mm',
       weekends: false,
       select: (...args) => this.select(...args),


### PR DESCRIPTION
As we're dealing with quite small columns, the events display
a little odd.

More information here: https://fullcalendar.io/docs/agenda/slotEventOverlap/