### PR TITLE
Process mailgun drop notifications as activities

### DIFF
--- a/app/controllers/mail_gun/drops_controller.rb
+++ b/app/controllers/mail_gun/drops_controller.rb
@@ -1,0 +1,24 @@
+module MailGun
+  class DropsController < ActionController::Base
+    def create
+      form = DropForm.new(drop_params)
+      form.create_activity
+
+      head :ok
+    end
+
+    private
+
+    def drop_params
+      params.permit(
+        :event,
+        :description,
+        :environment,
+        :appointment_id,
+        :timestamp,
+        :token,
+        :signature
+      )
+    end
+  end
+end

--- a/app/forms/drop_form.rb
+++ b/app/forms/drop_form.rb
@@ -1,0 +1,52 @@
+require 'openssl'
+
+TokenVerificationFailure = Class.new(StandardError)
+
+class DropForm
+  include ActiveModel::Model
+
+  attr_accessor :event
+  attr_accessor :description
+  attr_accessor :appointment_id
+  attr_accessor :timestamp
+  attr_accessor :token
+  attr_accessor :signature
+
+  validates :timestamp, presence: true
+  validates :token, presence: true
+  validates :signature, presence: true
+  validates :event, presence: true
+  validates :appointment_id, presence: true
+
+  def create_activity
+    return unless valid?
+
+    verify_token!
+
+    DropActivity.from(
+      event,
+      description,
+      appointment
+    )
+  end
+
+  private
+
+  def appointment
+    Appointment.find(appointment_id)
+  end
+
+  # rubocop:disable Style/GuardClause
+  def verify_token!
+    digest = OpenSSL::Digest::SHA256.new
+    data   = timestamp + token
+
+    unless signature == OpenSSL::HMAC.hexdigest(digest, api_token, data)
+      raise TokenVerificationFailure
+    end
+  end
+
+  def api_token
+    ENV['MAILGUN_API_TOKEN']
+  end
+end

--- a/app/lib/mailgun_headers.rb
+++ b/app/lib/mailgun_headers.rb
@@ -1,13 +1,14 @@
 module MailgunHeaders
-  def mailgun_headers(message_type)
-    headers['X-Mailgun-Variables'] = headers_hash(message_type)
+  def mailgun_headers(message_type, appointment_id)
+    headers['X-Mailgun-Variables'] = headers_hash(message_type, appointment_id)
   end
 
   private
 
-  def headers_hash(message_type)
+  def headers_hash(message_type, appointment_id)
     {
       message_type: message_type,
+      appointment_id: appointment_id,
       environment: Rails.env
     }.to_json
   end

--- a/app/mailers/appointment_mailer.rb
+++ b/app/mailers/appointment_mailer.rb
@@ -4,7 +4,7 @@ class AppointmentMailer < ApplicationMailer
   def confirmation(appointment)
     return unless appointment.email?
 
-    mailgun_headers('booking_created')
+    mailgun_headers('booking_created', appointment.id)
     @appointment = appointment
     mail to: @appointment.email
   end
@@ -12,7 +12,7 @@ class AppointmentMailer < ApplicationMailer
   def updated(appointment)
     return unless appointment.email?
 
-    mailgun_headers('booking_updated')
+    mailgun_headers('booking_updated', appointment.id)
     @appointment = appointment
     mail to: @appointment.email
   end

--- a/app/models/drop_activity.rb
+++ b/app/models/drop_activity.rb
@@ -1,0 +1,11 @@
+class DropActivity < Activity
+  def self.from(event, description, appointment)
+    create!(
+      message: "#{event.humanize} - #{description}",
+      appointment: appointment,
+      owner: appointment.guider
+    ).tap do |activity|
+      PusherActivityNotificationJob.perform_later(appointment.guider, activity)
+    end
+  end
+end

--- a/app/views/activities/_drop_activity.html.erb
+++ b/app/views/activities/_drop_activity.html.erb
@@ -1,0 +1,4 @@
+<% content_for(:activity_message, flush: true) do %>
+  <b>reported a delivery failure: </b><em><%= drop_activity.message %></em>
+<% end %>
+<%= render 'activities/activity', activity: drop_activity, details: details %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,10 @@ Rails.application.routes.draw do
 
   root 'home#index'
 
+  namespace :mail_gun do
+    resources :drops, only: :create
+  end
+
   resources :guiders, only: :index
   resources :users do
     resources :schedules

--- a/spec/forms/drop_form_spec.rb
+++ b/spec/forms/drop_form_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe DropForm, '#create_activity' do
+  let(:appointment) { create(:appointment) }
+  let(:params) do
+    {
+      'event'          => 'dropped',
+      'description'    => 'the reasoning',
+      'appointment_id' => appointment.to_param,
+      'timestamp'      => '1474638633',
+      'token'          => 'secret',
+      'signature'      => 'abf02bef01e803bea52213cb092a31dc2174f63bcc2382ba25732f4c84e084c1'
+    }
+  end
+  let(:token) { 'deadbeef' }
+
+  around do |example|
+    begin
+      existing = ENV['MAILGUN_API_TOKEN']
+
+      ENV['MAILGUN_API_TOKEN'] = token
+      example.run
+    ensure
+      ENV['MAILGUN_API_TOKEN'] = existing
+    end
+  end
+
+  subject { described_class.new(params) }
+
+  context 'when the signature is not verified' do
+    it 'raises an error' do
+      params['signature'] = 'whoops'
+
+      expect { subject.create_activity }.to raise_error(TokenVerificationFailure)
+    end
+  end
+
+  context 'when the signature is verified' do
+    it 'requires an event' do
+      params.delete('event')
+
+      expect(subject).not_to be_valid
+    end
+
+    it 'requires an appointment' do
+      params['appointment_id'] = '999'
+
+      expect { subject.create_activity }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    context 'when everything is validated' do
+      it 'creates the drop activity' do
+        expect(DropActivity).to receive(:from).with(
+          params['event'],
+          params['description'],
+          appointment
+        )
+
+        subject.create_activity
+      end
+    end
+  end
+end

--- a/spec/mailers/appointment_mailer_spec.rb
+++ b/spec/mailers/appointment_mailer_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe AppointmentMailer, type: :mailer do
 
   describe 'Confirmation' do
     subject(:mail) { described_class.confirmation(appointment) }
+    let(:mailgun_headers) { JSON.parse(mail['X-Mailgun-Variables'].value) }
 
     it 'guards against the absence of a recipient' do
       appointment.email = ''
@@ -25,7 +26,10 @@ RSpec.describe AppointmentMailer, type: :mailer do
     end
 
     it 'renders the mailgun specific headers' do
-      expect(mail['X-Mailgun-Variables'].value).to include('"message_type":"booking_created"')
+      expect(mailgun_headers).to include(
+        'message_type'   => 'booking_created',
+        'appointment_id' => appointment.id
+      )
     end
 
     describe 'rendering the body' do
@@ -44,6 +48,7 @@ RSpec.describe AppointmentMailer, type: :mailer do
 
   describe 'Updated' do
     subject(:mail) { described_class.updated(appointment) }
+    let(:mailgun_headers) { JSON.parse(mail['X-Mailgun-Variables'].value) }
 
     it 'guards against the absence of a recipient' do
       appointment.email = ''
@@ -58,7 +63,10 @@ RSpec.describe AppointmentMailer, type: :mailer do
     end
 
     it 'renders the mailgun specific headers' do
-      expect(mail['X-Mailgun-Variables'].value).to include('"message_type":"booking_updated"')
+      expect(mailgun_headers).to include(
+        'message_type'   => 'booking_updated',
+        'appointment_id' => appointment.id
+      )
     end
 
     describe 'rendering the body' do

--- a/spec/models/drop_activity_spec.rb
+++ b/spec/models/drop_activity_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe DropActivity, '.from' do
+  let(:appointment) { create(:appointment) }
+
+  before do
+    allow(PusherActivityNotificationJob).to receive(:perform_later)
+  end
+
+  subject { described_class.from('drop', 'message', appointment) }
+
+  it 'creates an activity entry' do
+    expect(subject).to have_attributes(
+      appointment_id: appointment.id,
+      owner_id: appointment.guider_id,
+      message: 'Drop - message'
+    )
+  end
+
+  it 'notifies asynchronously' do
+    expect(PusherActivityNotificationJob).to have_received(:perform_later).with(
+      appointment.guider,
+      subject
+    )
+  end
+end

--- a/spec/requests/mailgun_drop_notification_spec.rb
+++ b/spec/requests/mailgun_drop_notification_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'POST /mail_gun/drops' do
+  scenario 'inbound hooks create activity entries' do
+    with_a_configured_token('deadbeef') do
+      given_an_appointment
+      when_mail_gun_posts_a_drop_notification
+      then_an_activity_is_created
+      and_the_service_responds_ok
+    end
+  end
+
+  def with_a_configured_token(token)
+    existing = ENV['MAILGUN_API_TOKEN']
+
+    ENV['MAILGUN_API_TOKEN'] = token
+    yield
+  ensure
+    ENV['MAILGUN_API_TOKEN'] = existing
+  end
+
+  def given_an_appointment
+    @appointment = create(:appointment)
+  end
+
+  def when_mail_gun_posts_a_drop_notification
+    post mail_gun_drops_path, params: {
+      'event'          => 'dropped',
+      'description'    => 'the reasoning',
+      'appointment_id' => @appointment.to_param,
+      'timestamp'      => '1474638633',
+      'token'          => 'secret',
+      'signature'      => 'abf02bef01e803bea52213cb092a31dc2174f63bcc2382ba25732f4c84e084c1'
+    }
+  end
+
+  def then_an_activity_is_created
+    expect(@appointment.activities).to_not be_empty
+  end
+
+  def and_the_service_responds_ok
+    expect(response).to be_success
+  end
+end


### PR DESCRIPTION
Exposes a webhook end point to process delivery of mailgun drop / bounce
notifications. The 'owner' is the appointment's associated guider. We may
want to revisit this later.