### PR TITLE
Don't show an audit activity if only the guider was updated

### DIFF
--- a/app/models/audit_activity.rb
+++ b/app/models/audit_activity.rb
@@ -1,5 +1,7 @@
 class AuditActivity < Activity
   def self.from(audit, appointment)
+    return if only_the_guider_has_been_changed?(audit)
+
     activity = create!(
       user_id: audit.user_id,
       owner_id: appointment.guider.id,
@@ -7,5 +9,9 @@ class AuditActivity < Activity
       appointment_id: appointment.id
     )
     PusherActivityNotificationJob.perform_later(appointment.guider, activity)
+  end
+
+  def self.only_the_guider_has_been_changed?(audit)
+    audit.audited_changes.keys == ['guider_id']
   end
 end

--- a/spec/models/audit_activity_spec.rb
+++ b/spec/models/audit_activity_spec.rb
@@ -4,34 +4,53 @@ RSpec.describe AuditActivity do
   describe '.from' do
     before do
       allow(PusherActivityNotificationJob).to receive(:perform_later)
-      @appointment = create(:appointment).tap do |a|
-        # this will trigger the `after_audit` hook on `Appointment`
-        a.update(
-          first_name: 'Dave Jones',
-          email: 'dj@dj.com',
-          phone: '07715 930 455'
+    end
+
+    context 'with updated fields' do
+      before do
+        @appointment = create(:appointment).tap do |a|
+          # this will trigger the `after_audit` hook on `Appointment`
+          a.update(
+            first_name: 'Dave Jones',
+            email: 'dj@dj.com',
+            phone: '07715 930 455'
+          )
+        end
+      end
+
+      let(:audit) { @appointment.audits.first }
+      subject { @appointment.activities.first }
+
+      it 'creates an audit activity with the fields' do
+        expect(subject).to be_a(described_class)
+
+        expect(subject).to have_attributes(
+          user_id: audit.user_id,
+          owner_id: @appointment.guider.id,
+          appointment_id: @appointment.id,
+          message: 'first name, email, and phone'
         )
+      end
+
+      it 'pushes an activity update' do
+        expect(PusherActivityNotificationJob)
+          .to have_received(:perform_later)
+          .with(@appointment.guider, subject)
       end
     end
 
-    let(:audit) { @appointment.audits.first }
-    subject { @appointment.activities.first }
+    context 'guider_id is the only updated field' do
+      before do
+        @appointment = create(:appointment).tap do |a|
+          a.update(guider: create(:guider))
+        end
+      end
 
-    it 'creates an audit activity from the given audit' do
-      expect(subject).to be_a(described_class)
-
-      expect(subject).to have_attributes(
-        user_id: audit.user_id,
-        owner_id: @appointment.guider.id,
-        appointment_id: @appointment.id,
-        message: 'first name, email, and phone'
-      )
-    end
-
-    it 'pushes an activity update' do
-      expect(PusherActivityNotificationJob)
-        .to have_received(:perform_later)
-        .with(@appointment.guider, subject)
+      it 'does not create an audit activity' do
+        @appointment.activities.each do |activity|
+          expect(activity).to_not be_a(described_class)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
![screenshot from 2016-11-18 16 48 39](https://cloud.githubusercontent.com/assets/363618/20438279/ec1384b4-adae-11e6-91ff-650d9efab0c7.png)
