### PR TITLE
Make copying an appointment's responsibility

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -44,7 +44,7 @@ class AppointmentsController < ApplicationController
   end
 
   def new
-    @appointment = copy_appointment || Appointment.new
+    @appointment = Appointment.copy_or_new_by(params[:copy_from])
   end
 
   def create
@@ -130,13 +130,5 @@ class AppointmentsController < ApplicationController
     else
       redirect_to my_appointments_path, success: 'Appointment has been modified'
     end
-  end
-
-  def copy_appointment
-    return nil unless params[:copy_from].present?
-    appointment = Appointment.find(params[:copy_from]).dup
-    appointment.start_at = nil
-    appointment.end_at = nil
-    appointment
   end
 end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -36,6 +36,15 @@ class Appointment < ApplicationRecord
 
   audited on: %i(create update)
 
+  def self.copy_or_new_by(id)
+    return new unless id
+
+    find(id).dup.tap do |appointment|
+      appointment.start_at = nil
+      appointment.end_at   = nil
+    end
+  end
+
   def self.full_search(query, start_at, end_at)
     results = query.present? ? search(query) : order(created_at: :desc)
 


### PR DESCRIPTION
Moves the copying to `Appointment` and golfs down the resulting code a
little bit.