### PR TITLE
Accessibility fixes

### DIFF
--- a/app/assets/javascripts/modules/calendar.es6
+++ b/app/assets/javascripts/modules/calendar.es6
@@ -54,6 +54,12 @@ class Calendar extends TapBase {
     this.$el.fullCalendar(this.config);
 
     this.insertJumpToDate();
+    this.addAccessibilityImprovements();
+  }
+
+  addAccessibilityImprovements() {
+    $('.fc-prev-button').append('<span class="sr-only">Previous Date</span>');
+    $('.fc-next-button').append('<span class="sr-only">Next Date</span>');
   }
 
   jumpToDateClick() {

--- a/app/assets/javascripts/modules/calendars/company.es6
+++ b/app/assets/javascripts/modules/calendars/company.es6
@@ -166,7 +166,7 @@ class CompanyCalendar extends Calendar {
     $(element).attr('id', event.id);
 
     if (view.type === 'agendaDay') {
-      element.find('.fc-content').remove();
+      element.find('.fc-content').addClass('sr-only');
     } else {
       $('<span class="glyphicon glyphicon-phone-alt" aria-hidden="true" style="margin-right: 5px;"></span>').prependTo(
         element.find('.fc-content')

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,4 @@
 @import "lib/*";
-@import "vendor/vendor";
+@import "vendor/*";
 @import "components/*";
+@import "helper/*";

--- a/app/assets/stylesheets/helper/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/helper/_bootstrap_overrides.scss
@@ -1,0 +1,7 @@
+.breadcrumb > .active {
+  color: $color-black;
+}
+
+.breadcrumb > li + li::before {
+  color: $color-black;
+}

--- a/app/views/activities/_activity_feed.html.erb
+++ b/app/views/activities/_activity_feed.html.erb
@@ -6,6 +6,7 @@
       <div class="well js-message-form">
         <%= form_for MessageActivity.new(appointment: appointment, owner: appointment.guider), url: activities_path(appointment_id: appointment.id), remote: true do |f| %>
           <div class="input-group">
+            <label for="message_activity_message"><span class="sr-only">Activity message</span></label>
             <%= f.text_field :message, placeholder: 'Add an action to keep others in the loop', class: 'form-control js-message t-message' %>
             <span class="input-group-btn">
               <%= f.button class: 'btn btn-primary btn-block t-submit-message', data: { disable_with: 'Adding message...' } do %>

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -31,9 +31,9 @@
       %>
     </div>
     <div class="col-sm-9 text-right">
-      <label aria-hidden="true">Add common slots:</label>
+      <label for="early-slots" aria-hidden="true">Add common slots:</label>
       <div class="btn-group" role="group" aria-label="Add Common Slots" id="calendar-common">
-        <button type="button" class="btn btn-default" data-events='[
+        <button type="button" id="early-slots" class="btn btn-default" data-events='[
           { "start": "08:30", "end": "09:40" },
           { "start": "09:50", "end": "11:00" },
           { "start": "11:20", "end": "12:30" },

--- a/app/views/shared/_calendar_filter.html.erb
+++ b/app/views/shared/_calendar_filter.html.erb
@@ -1,5 +1,5 @@
 <div id="resource-calendar-filter" class="resource-calendar-filter hide">
-  <%= label_tag(:filter_users, 'Filter by guider/group') %>
+  <%= label_tag(:filter_guiders, 'Filter by guider/group') %>
   <%=
     select_tag(
       :filter_guiders,

--- a/app/views/shared/_date_of_birth_form_field.html.erb
+++ b/app/views/shared/_date_of_birth_form_field.html.erb
@@ -1,13 +1,18 @@
-<% start_year = 120.years.ago %>
+<%
+  start_year = 120.years.ago
+  form_element_day_id = "#{form.object_name}_date_of_birth_3i"
+  form_element_month_id = "#{form.object_name}_date_of_birth_2i"
+  form_element_year_id = "#{form.object_name}_date_of_birth_1i"
+%>
 
 <div class="form-dob clearfix" data-module="customer-age" data-output-id="js-customer-age">
   <%= field_with_errors_wrapper(form, :date_of_birth, 'form-dob__inputs-container') do %>
-    <label>
+    <label for="<%= form_element_day_id %>">
       <span class="sr-only">Date of birth</span> <%= required_label(:day) %>
       <%=
         form.number_field(
           'date_of_birth(3i)',
-          id: "#{form.object_name}_date_of_birth_3i",
+          id: form_element_day_id,
           use_label: false,
           value: form.object.date_of_birth.try(:day),
           placeholder: 'DD',
@@ -19,12 +24,12 @@
         )
       %>
     </label>
-    <label>
+    <label for="<%= form_element_month_id %>">
       <span class="sr-only">Date of birth</span> <%= required_label(:month) %>
       <%=
         form.number_field(
           'date_of_birth(2i)',
-          id: "#{form.object_name}_date_of_birth_2i",
+          id: form_element_month_id,
           use_label: false,
           value: form.object.date_of_birth.try(:month),
           placeholder: 'MM',
@@ -35,12 +40,12 @@
         )
       %>
     </label>
-    <label>
+    <label for="<%= form_element_year_id %>">
       <span class="sr-only">Date of birth</span> <%= required_label(:year) %>
       <%=
         form.number_field(
           'date_of_birth(1i)',
-          id: "#{form.object_name}_date_of_birth_1i",
+          id: form_element_year_id,
           use_label: false,
           value: form.object.date_of_birth.try(:year),
           placeholder: 'YYYY',

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -23,7 +23,7 @@
       </colgroup>
       <thead>
         <tr>
-          <th><label for="select-all"><input type="checkbox" class="select-all" data-multi-checkbox="all"> <span class="sr-only">Select All</span></label></th>
+          <th><label for="select-all"><input type="checkbox" id="select-all" class="select-all" data-multi-checkbox="all"> <span class="sr-only">Select All</span></label></th>
           <th><span class="sort" data-sort="name">Name</span></th>
           <th>Groups</th>
           <th>Actions</th>
@@ -52,9 +52,12 @@
   </div>
   <div class="action-panel t-action-panel" data-action-panel>
     With the <span class="guider__number-selected t-selected" data-action-panel-selected-count>0</span> <span data-action-panel-selected-guiders></span> selected
-    <select name="action" class="t-action" data-action-panel-actions>
-      <option value="/groups">Add/remove groups</option>
-    </select>
+    <label for="action-panel-select">
+      <span class="sr-only">Action to perform</span>
+      <select name="action" id="action-panel-select" class="t-action" data-action-panel-actions>
+        <option value="/groups">Add/remove groups</option>
+      </select>
+    </label>
     <button class="btn btn-primary t-go" data-action-panel-go>Go</button>
   </div>
 </div>


### PR DESCRIPTION
- Ensuring form elements have labels
- Ensuring there is enough colour contrast on the breadcrumb
- Just hide the contents of the events on the resource calendar
  from visual users, rather than removing it
- Ensuring that icon buttons on full calendar have
  hidden screen reader text alternatives