### PR TITLE
Rerender edit page after editing an appointment

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,4 +1,6 @@
 class ActivitiesController < ApplicationController
+  store_previous_page_on :index
+
   def index
     @activities = current_user.activities.includes(:user, :appointment)
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,13 @@ class ApplicationController < ActionController::Base
 
   add_flash_types :success
 
+  def self.store_previous_page_on(actions)
+    before_action only: actions do |controller|
+      session[:previous_controller] = controller.controller_name
+      session[:previous_action]     = controller.action_name
+    end
+  end
+
   protected
 
   def authorise_for_guiders!

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -1,6 +1,7 @@
 # rubocop:disable Metrics/ClassLength
 class AppointmentsController < ApplicationController
   before_action :authenticate_user!
+  store_previous_page_on :search
 
   def batch_update
     BatchAppointmentUpdate.new(params[:changes]).call
@@ -27,7 +28,7 @@ class AppointmentsController < ApplicationController
     @appointment.assign_to_guider
     if @appointment.save
       Notifier.new(@appointment).call
-      redirect_after_successful_update
+      redirect_to search_appointments_path, success: 'Appointment has been rescheduled'
     else
       render :reschedule
     end
@@ -37,7 +38,7 @@ class AppointmentsController < ApplicationController
     @appointment = Appointment.find(params[:id])
     if @appointment.update_attributes(update_params)
       Notifier.new(@appointment).call
-      redirect_after_successful_update
+      render :edit, success: 'Appointment has been modified'
     else
       render :edit
     end
@@ -122,13 +123,5 @@ class AppointmentsController < ApplicationController
 
   def update_reschedule_params
     params.require(:appointment).permit(:start_at, :end_at)
-  end
-
-  def redirect_after_successful_update
-    if current_user.agent?
-      redirect_to search_appointments_path, success: 'Appointment has been modified'
-    else
-      redirect_to my_appointments_path, success: 'Appointment has been modified'
-    end
   end
 end

--- a/app/controllers/company_calendars_controller.rb
+++ b/app/controllers/company_calendars_controller.rb
@@ -1,6 +1,4 @@
 class CompanyCalendarsController < ApplicationController
   before_action :authorise_for_guiders!
-
-  def show
-  end
+  store_previous_page_on :show
 end

--- a/app/controllers/my_appointments_controller.rb
+++ b/app/controllers/my_appointments_controller.rb
@@ -1,4 +1,3 @@
 class MyAppointmentsController < ApplicationController
-  def show
-  end
+  store_previous_page_on :show
 end

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -1,33 +1,38 @@
 module BreadcrumbHelper
   def breadcrumb_part_for_previous_page
-    path, title = path_and_title_from_referer
-
     content_tag(:li) do
-      content_tag(:a, href: path) do
-        title
+      content_tag(:a, href: previous_page_path) do
+        previous_page_title
       end
     end
   end
 
   private
 
-  def path_and_title_from_referer # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-    if request_uri.start_with?(search_appointments_path)
-      [request_uri, 'Search']
-    elsif request_uri.start_with?(activities_path)
-      [request_uri, 'My activity']
-    elsif request_uri.start_with?(my_appointments_path)
-      [request_uri, 'My appointments']
-    elsif request_uri.start_with?(company_calendar_path)
-      [request_uri, 'Company']
-    elsif request_uri.start_with?(allocations_path)
-      [request_uri, 'Allocations']
-    end
+  def previous_action
+    session[:previous_action].to_s
   end
 
-  def request_uri
-    @request_uri ||= URI.parse(request.referer).request_uri
-  rescue URI::InvalidURIError
+  def previous_controller
+    session[:previous_controller].to_s
+  end
+
+  def previous_page_path
+    url_for(controller: previous_controller, action: previous_action)
+  rescue ActionController::UrlGenerationError
     search_appointments_path
+  end
+
+  def previous_page_title
+    case "#{previous_controller}##{previous_action}"
+    when 'activities#index'
+      'My activity'
+    when 'my_appointments#show'
+      'My appointments'
+    when 'company_calendars#show'
+      'Company'
+    else
+      'Search'
+    end
   end
 end

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -1,4 +1,4 @@
-<ol class="breadcrumb">
+<ol class="breadcrumb t-breadcrumb">
   <li><a href="<%= root_path %>">Home</a></li>
   <%= breadcrumb_part_for_previous_page %>
   <li class="active">Edit appointment for <%= @appointment.name %></li>

--- a/spec/features/breadcrumb_spec.rb
+++ b/spec/features/breadcrumb_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.feature 'Breadcrumb' do
+  describe 'Edit appointment after viewing Edit appointments' do
+    it 'shows the correct breadcrumb link' do
+      given_the_user_is_a_guider do
+        and_an_appointment_exists
+        and_they_edit_the_appointment
+        then_they_see_a_breadcrumb_pointing_to_search
+      end
+    end
+  end
+
+  describe 'Edit appointment after viewing appointments search' do
+    it 'shows the correct breadcrumb link' do
+      given_the_user_is_a_guider do
+        and_an_appointment_exists
+        and_they_search_appointments
+        and_they_edit_the_appointment
+        then_they_see_a_breadcrumb_pointing_to_search
+      end
+    end
+  end
+
+  describe 'Edit appointment after viewing company calendar' do
+    it 'shows the correct breadcrumb link' do
+      given_the_user_is_a_guider do
+        and_an_appointment_exists
+        and_they_view_the_company_calendar
+        and_they_edit_the_appointment
+        then_they_see_a_breadcrumb_pointing_to_the_company_calendar
+      end
+    end
+  end
+
+  describe 'Edit appointment after viewing my appointments' do
+    it 'shows the correct breadcrumb link' do
+      given_the_user_is_a_guider do
+        and_an_appointment_exists
+        and_they_view_their_appointments
+        and_they_edit_the_appointment
+        then_they_see_a_breadcrumb_pointing_to_their_appointments
+      end
+    end
+  end
+
+  describe 'Edit appointment after viewing my activity' do
+    it 'shows the correct breadcrumb link' do
+      given_the_user_is_a_guider do
+        and_an_appointment_exists
+        and_they_view_their_activity
+        and_they_edit_the_appointment
+        then_they_see_a_breadcrumb_pointing_to_their_activity
+      end
+    end
+  end
+
+  def and_an_appointment_exists
+    @appointment = create(:appointment)
+  end
+
+  def and_they_edit_the_appointment
+    @page = Pages::EditAppointment.new
+    @page.load(id: @appointment.id)
+  end
+
+  def and_they_search_appointments
+    Pages::Search.new.tap(&:load)
+  end
+
+  def and_they_view_the_company_calendar
+    Pages::CompanyCalendar.new.tap(&:load)
+  end
+
+  def and_they_view_their_appointments
+    Pages::MyAppointments.new.tap(&:load)
+  end
+
+  def and_they_view_their_activity
+    Pages::Activities.new.tap(&:load)
+  end
+
+  def then_they_see_a_breadcrumb_pointing_to_search
+    expect(@page.breadcrumb_links.second).to eq(
+      'Search' => search_appointments_path
+    )
+  end
+
+  def then_they_see_a_breadcrumb_pointing_to_the_company_calendar
+    expect(@page.breadcrumb_links.second).to eq(
+      'Company' => company_calendar_path
+    )
+  end
+
+  def then_they_see_a_breadcrumb_pointing_to_their_appointments
+    expect(@page.breadcrumb_links.second).to eq(
+      'My appointments' => my_appointments_path
+    )
+  end
+
+  def then_they_see_a_breadcrumb_pointing_to_their_activity
+    expect(@page.breadcrumb_links.second).to eq(
+      'My activity' => activities_path
+    )
+  end
+end

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -27,5 +27,15 @@ module Pages
       element :further_activities, '.t-further-activities'
       element :hidden_activities, '.t-hidden-activities'
     end
+
+    section :breadcrumb, '.t-breadcrumb' do
+      elements :links, 'a'
+    end
+
+    def breadcrumb_links
+      breadcrumb.links.map do |link|
+        { link.text => link['href'] }
+      end
+    end
   end
 end


### PR DESCRIPTION
Also, change the way that we store the previous page so that we can
always show the correct breadcrumb on appointments#edit.