### PR TITLE
Only link activity feed items from my activity page

### DIFF
--- a/app/views/activities/_activity.html.erb
+++ b/app/views/activities/_activity.html.erb
@@ -1,7 +1,15 @@
-<a class="list-group-item t-activity" href="<%= edit_appointment_path(activity.appointment) %>">
-  <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span>
-  <b><%= activity.user_name %></b>
-  <%= content_for(:activity_message) %>
-  <%= render('activities/details', appointment: activity.appointment) if details %>
-  <em class="badge"><%= activity.created_at.to_s(:govuk_date_short) %> (<%= time_ago_in_words(activity.created_at)%> ago)</em>
-</a>
+<% if details %>
+  <a class="list-group-item t-activity" href="<%= edit_appointment_path(activity.appointment) %>">
+<% else %>
+  <li class="list-group-item t-activity">
+<% end %>
+    <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span>
+    <b><%= activity.user_name %></b>
+    <%= content_for(:activity_message) %>
+    <%= render('activities/details', appointment: activity.appointment) if details %>
+    <em class="badge"><%= activity.created_at.to_s(:govuk_date_short) %> (<%= time_ago_in_words(activity.created_at)%> ago)</em>
+<% if details %>
+  </a>
+<% else %>
+  </li>
+<% end %>

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -7,11 +7,11 @@
 
 <div class="row t-activity-feed">
   <div class="col-md-12 border-bottom">
-
-    <div class="activity-feed">
-      <ul class="list-group" data-module="activity-feed" data-config='{"event": "guider_activity_<%= current_user.id %>"}'>
+    <div class="activity-feed activity-feed--with-links">
+      <div class="list-group" data-module="activity-feed" data-config='{"event": "guider_activity_<%= current_user.id %>"}'>
         <%= render(@activities, details: true) %>
-      </ul>
+      </div>
     </div>
   </div>
 </div>
+


### PR DESCRIPTION
On the edit page, each activity was a link back to the same page - this is not great for screen reader users, when they view the list of available links on the page.