### PR TITLE
remove attribute 'pattern' which is not required on a number field

### DIFF
--- a/app/views/shared/_date_of_birth_form_field.html.erb
+++ b/app/views/shared/_date_of_birth_form_field.html.erb
@@ -17,7 +17,6 @@
           value: form.object.date_of_birth.try(:day),
           placeholder: 'DD',
           class: 'form-dob__input js-dob-day t-date-of-birth-day',
-          pattern: '[0-9]*',
           min: 1,
           max: 31,
           'aria-describedby': 'dob-hint'
@@ -34,7 +33,6 @@
           value: form.object.date_of_birth.try(:month),
           placeholder: 'MM',
           class: 'form-dob__input js-dob-month t-date-of-birth-month',
-          pattern: '[0-9]*',
           min: 1,
           max: 12
         )
@@ -50,7 +48,6 @@
           value: form.object.date_of_birth.try(:year),
           placeholder: 'YYYY',
           class: 'form-dob__input form-dob__input--year js-dob-year t-date-of-birth-year',
-          pattern: '[0-9]*',
           min: start_year.year,
           max: Date.today.year
         )


### PR DESCRIPTION
type=number automatically means that the pattern is [0-9]* - so no need to have it as an attribute.