### PR TITLE
Better validation for date of birth components

### DIFF
--- a/app/assets/javascripts/modules/customer-age.es6
+++ b/app/assets/javascripts/modules/customer-age.es6
@@ -23,19 +23,14 @@
 
     renderCustomerAge() {
       const year = parseInt(this.$year.val()),
-      month = (`00${this.$month.val()}`).substr(-2, 2),
-      day = (`00${this.$day.val()}`).substr(-2, 2);
-
-      if (year >= this.$year.attr('min')) {
-        const today = moment(),
+        month = (`00${this.$month.val()}`).substr(-2, 2),
+        day = (`00${this.$day.val()}`).substr(-2, 2),
+        today = moment(),
         inputDate = moment(`${year}-${month}-${day}`),
         age = Math.floor(today.diff(inputDate, 'year'));
 
-        if (age) {
-          this.$output.html(`Customer is <b>${age}</b> years old`);
-        } else {
-          this.emptyAge();
-        }
+      if (age) {
+        this.$output.html(`Customer is <b>${age}</b> years old`);
       } else {
         this.emptyAge();
       }

--- a/app/views/shared/_date_of_birth_form_field.html.erb
+++ b/app/views/shared/_date_of_birth_form_field.html.erb
@@ -19,6 +19,7 @@
           pattern: '(0?[1-9]|(1|2)[0-9]|3[0-1])',
           maxlength: 2,
           required: true,
+          title: 'Must be numeric eg 01',
           'aria-describedby': 'dob-hint'
         )
       %>
@@ -35,6 +36,7 @@
           class: 'form-dob__input js-dob-month t-date-of-birth-month',
           pattern: '(0?[1-9]|1[0-2])',
           maxlength: 2,
+          title: 'Must be numeric eg 01',
           required: true
         )
       %>
@@ -51,6 +53,7 @@
           class: 'form-dob__input form-dob__input--year js-dob-year t-date-of-birth-year',
           pattern: '(19)[0-9]{2}',
           maxlength: 4,
+          title: 'Must be numeric eg 1955',
           required: true
         )
       %>

--- a/app/views/shared/_date_of_birth_form_field.html.erb
+++ b/app/views/shared/_date_of_birth_form_field.html.erb
@@ -1,5 +1,4 @@
 <%
-  start_year = 120.years.ago
   form_element_day_id = "#{form.object_name}_date_of_birth_3i"
   form_element_month_id = "#{form.object_name}_date_of_birth_2i"
   form_element_year_id = "#{form.object_name}_date_of_birth_1i"
@@ -10,16 +9,16 @@
     <label for="<%= form_element_day_id %>">
       <span class="sr-only">Date of birth</span> <%= required_label(:day) %>
       <%=
-        form.number_field(
+        form.text_field(
           'date_of_birth(3i)',
           id: form_element_day_id,
           use_label: false,
           value: form.object.date_of_birth.try(:day),
           placeholder: 'DD',
           class: 'form-dob__input js-dob-day t-date-of-birth-day',
-          pattern: '[0-9]*',
-          min: 1,
-          max: 31,
+          pattern: '(0?[1-9]|(1|2)[0-9]|3[0-1])',
+          maxlength: 2,
+          required: true,
           'aria-describedby': 'dob-hint'
         )
       %>
@@ -27,32 +26,32 @@
     <label for="<%= form_element_month_id %>">
       <span class="sr-only">Date of birth</span> <%= required_label(:month) %>
       <%=
-        form.number_field(
+        form.text_field(
           'date_of_birth(2i)',
           id: form_element_month_id,
           use_label: false,
           value: form.object.date_of_birth.try(:month),
           placeholder: 'MM',
           class: 'form-dob__input js-dob-month t-date-of-birth-month',
-          pattern: '[0-9]*',
-          min: 1,
-          max: 12
+          pattern: '(0?[1-9]|1[0-2])',
+          maxlength: 2,
+          required: true
         )
       %>
     </label>
     <label for="<%= form_element_year_id %>">
       <span class="sr-only">Date of birth</span> <%= required_label(:year) %>
       <%=
-        form.number_field(
+        form.text_field(
           'date_of_birth(1i)',
           id: form_element_year_id,
           use_label: false,
           value: form.object.date_of_birth.try(:year),
           placeholder: 'YYYY',
           class: 'form-dob__input form-dob__input--year js-dob-year t-date-of-birth-year',
-          pattern: '[0-9]*',
-          min: start_year.year,
-          max: Date.today.year
+          pattern: '(19)[0-9]{2}',
+          maxlength: 4,
+          required: true
         )
       %>
     </label>


### PR DESCRIPTION
Makes the date of birth components required (client-side) plus:

Checks:

- the year is numeric, starts with 19 and is 4 digits
- the month is numeric, between 01-12 and max 2 digits
- the day is numeric, between 01-31 and max 2 digits

The only catch is that I'm not certain this kicks up the numeric keyboard on mobile devices.