### PR TITLE
Improve view templates for scheduling an appointment

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -20,6 +20,8 @@ class AppointmentsController < ApplicationController
 
   def reschedule
     @appointment = Appointment.find(params[:appointment_id])
+    @appointment.start_at = nil
+    @appointment.end_at = nil
   end
 
   def update_reschedule

--- a/app/views/appointments/_availability_calendar.html.erb
+++ b/app/views/appointments/_availability_calendar.html.erb
@@ -1,0 +1,14 @@
+<h2>Choose available slot <%= required_label %></h2>
+<% if @appointment.errors[:guider].any? %>
+  <%= render 'unable_to_assign' %>
+<% end %>
+<div
+  id="AppointmentAvailabilityCalendar"
+  class="appointment-availability-calendar"
+  data-module="appointment-availability-calendar"
+  data-available-slots-path="<%= available_bookable_slots_path %>"
+  data-default-date="<%= BookableSlot.next_valid_start_date %>"
+></div>
+<input type="hidden" name="available-slots-json" class="slots-data" value="<%= @available_slots_json %>">
+<%= form.hidden_field :start_at, data: { 'selected-start': true }, class: 't-start-at' %>
+<%= form.hidden_field :end_at, data: { 'selected-end': true }, class: 't-end-at' %>

--- a/app/views/appointments/_unable_to_assign.html.erb
+++ b/app/views/appointments/_unable_to_assign.html.erb
@@ -1,0 +1,3 @@
+<p class="text-danger js-slot-unavailable-message t-slot-unavailable-message">
+  Unable to assign appointment to a slot, please choose a slot.
+</p>

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -12,22 +12,7 @@
       <%= render 'shared/date_of_birth_form_field', form: f %>
     </div>
     <div class="col-md-12">
-      <h2>Choose available slot <%= required_label %></h2>
-      <% if @appointment.errors[:guider].any? %>
-        <p class="text-danger js-slot-unavailable-message t-slot-unavailable-message">
-          Unable to assign appointment to a slot, please chooose a slot.
-        </p>
-      <% end %>
-      <div
-          id="AppointmentAvailabilityCalendar"
-          class="appointment-availability-calendar"
-          data-module="appointment-availability-calendar"
-          data-available-slots-path="<%= available_bookable_slots_path %>"
-          data-default-date="<%= BookableSlot.next_valid_start_date %>"
-      ></div>
-      <input type="hidden" name="available-slots-json" class="slots-data" value="<%= @available_slots_json %>">
-      <%= f.hidden_field :start_at, data: { 'selected-start': true }, class: 't-start-at' %>
-      <%= f.hidden_field :end_at, data: { 'selected-end': true }, class: 't-end-at' %>
+      <%= render 'availability_calendar', form: f %>
     </div>
   </div>
   <%= render partial: 'personal_details_form', locals: { f: f } %>

--- a/app/views/appointments/reschedule.html.erb
+++ b/app/views/appointments/reschedule.html.erb
@@ -6,26 +6,10 @@
 <h1>Reschedule an appointment for <%= @appointment.name %></h1>
 
 <%= render 'shared/required_fields_note' %>
-
 <%= form_for [@appointment], url: appointment_update_reschedule_path(@appointment), layout: :basic do |f| %>
   <div class="row form-group">
     <div class="col-md-12">
-      <h2>Choose available slot <%= required_label %></h2>
-      <% if @appointment.errors[:guider].any? %>
-        <p class="text-danger js-slot-unavailable-message t-slot-unavailable-message">
-          Unable to assign appointment to a slot, please chooose a slot.
-        </p>
-      <% end %>
-      <div
-        id="AppointmentAvailabilityCalendar"
-        class="appointment-availability-calendar"
-        data-module="appointment-availability-calendar"
-        data-available-slots-path="<%= available_bookable_slots_path %>"
-        data-default-date="<%= BookableSlot.next_valid_start_date %>"
-      ></div>
-      <input type="hidden" name="available-slots-json" class="slots-data" value="<%= @available_slots_json %>">
-      <%= f.hidden_field :start_at, value: nil, data: { 'selected-start': true }, class: 't-start-at' %>
-      <%= f.hidden_field :end_at, value: nil, data: { 'selected-end': true }, class: 't-end-at' %>
+      <%= render 'availability_calendar', form: f %>
     </div>
   </div>
   <div class="row form-group">


### PR DESCRIPTION
**Fix typo in error message**

**Before**
<img width="431" alt="screen shot 2016-11-22 at 17 12 55" src="https://cloud.githubusercontent.com/assets/6049076/20533849/ee903d92-b0d6-11e6-8cf2-313fe44dfa30.png">

**After**
<img width="460" alt="screen shot 2016-11-22 at 17 04 18" src="https://cloud.githubusercontent.com/assets/6049076/20533533/be7c8af8-b0d5-11e6-8307-8816e265dfca.png">

**Reduce duplication across 'new' and 'reschedule' appointments**

<img width="1156" alt="screen shot 2016-11-22 at 17 06 53" src="https://cloud.githubusercontent.com/assets/6049076/20533631/1fbd59c8-b0d6-11e6-9842-20e24e5a7179.png">

