### PR TITLE
Run js:lint using yarn where possible

### DIFF
--- a/lib/tasks/js.rake
+++ b/lib/tasks/js.rake
@@ -1,6 +1,12 @@
 namespace :js do
   desc 'lint all js'
   task :lint do
-    sh 'npm run js'
+    bin = command?('yarn') ? 'yarn' : 'npm'
+    sh "#{bin} run js"
+  end
+
+  def command?(name)
+    `which #{name}`
+    $CHILD_STATUS.success?
   end
 end


### PR DESCRIPTION
I'm using [yarn](yarnpkg.com) locally, so allow for running `yarn run` if it exists, but falling back to `npm run`