### PR TITLE
Fix broken migration

### DIFF
--- a/db/migrate/20161004141342_break_apart_slots_start_and_end.rb
+++ b/db/migrate/20161004141342_break_apart_slots_start_and_end.rb
@@ -1,6 +1,6 @@
 class BreakApartSlotsStartAndEnd < ActiveRecord::Migration[5.0]
   def up
-    Slot.destroy_all
+    Slot.unscoped.destroy_all
 
     add_column :slots, :day_of_week, :integer
     add_column :slots, :start_hour, :integer
@@ -14,7 +14,7 @@ class BreakApartSlotsStartAndEnd < ActiveRecord::Migration[5.0]
   end
 
   def down
-    Slot.destroy_all
+    Slot.unscoped.destroy_all
 
     add_column :slots, :day, :string
     add_column :slots, :start_at, :string


### PR DESCRIPTION
This was borked as a `default_scope` on `Slot` was adding ordering by a
column that doesn't exist at this particular point in time.