### PR TITLE
Re-order items in navigation to stop it wrapping

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,12 +14,15 @@
       <% if current_user.resource_manager? %>
         <%= active_link_to 'Allocations', allocations_path, wrap_tag: :li %>
       <% end %>
+
+      <% if current_user.guider? %>
+        <%= active_link_to 'My appointments', my_appointments_path, wrap_tag: :li %>
+        <%= active_link_to 'Company appointments', company_calendar_path, wrap_tag: :li %>
+      <% end %>
     </ul>
   </li>
 
   <% if current_user.guider? %>
-    <%= active_link_to 'My appointments', my_appointments_path, wrap_tag: :li %>
-    <%= active_link_to 'Company', company_calendar_path, wrap_tag: :li %>
     <%= active_link_to 'My activity', activities_path, wrap_tag: :li %>
   <% end %>
 
@@ -32,9 +35,6 @@
         <%= active_link_to 'Display order', sort_users_path, wrap_tag: :li %>
       </ul>
     </li>
-  <% end %>
-
-  <% if current_user.resource_manager? %>
     <li class="dropdown">
       <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Reports <span class="caret"></span></a>
       <ul class="dropdown-menu">


### PR DESCRIPTION
**Before**

<img width="1189" alt="screen shot 2016-11-23 at 13 38 23" src="https://cloud.githubusercontent.com/assets/6049076/20563824/1eb1c2c4-b182-11e6-81ea-fe84e5a68760.png">

**After**

<img width="1193" alt="screen shot 2016-11-23 at 13 37 52" src="https://cloud.githubusercontent.com/assets/6049076/20563802/0c3ea4f4-b182-11e6-8023-36588162597b.png">


- move my/company appointments to appointments menu