### PR TITLE
Adding 'quick search' functionality

### DIFF
--- a/app/assets/javascripts/modules/quick-search.es6
+++ b/app/assets/javascripts/modules/quick-search.es6
@@ -1,0 +1,23 @@
+/* global TapBase */
+{
+  'use strict';
+
+  class QuickSearch extends TapBase {
+    start(el) {
+      super.start(el);
+
+      this.$button = this.$el.find('.js-quick-search-button');
+      this.$input = this.$el.find('.js-quick-search-input');
+
+      this.bindEvents();
+    }
+
+    bindEvents() {
+      this.$button.on('click', () => {
+        setTimeout(() => this.$input.focus(), 0); // next tick
+      });
+    }
+  }
+
+  window.GOVUKAdmin.Modules.QuickSearch = QuickSearch;
+}

--- a/app/assets/stylesheets/components/_action-buttons.scss
+++ b/app/assets/stylesheets/components/_action-buttons.scss
@@ -1,0 +1,4 @@
+.action-buttons {
+  margin-top: 1.4em;
+  text-align: right;
+}

--- a/app/assets/stylesheets/components/_quick-search.scss
+++ b/app/assets/stylesheets/components/_quick-search.scss
@@ -1,0 +1,15 @@
+$quick-search-panel-width: 233px;
+
+.quick-search__dropdown {
+  box-sizing: border-box;
+  padding: 8px;
+  width: $quick-search-panel-width;
+}
+
+.quick-search__input {
+  font-weight: normal;
+}
+
+.quick-search__label {
+  margin-bottom: 0;
+}

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -30,7 +30,7 @@ class AppointmentsController < ApplicationController
     @appointment.assign_to_guider
     if @appointment.save
       Notifier.new(@appointment).call
-      redirect_to search_appointments_path, success: 'Appointment has been rescheduled'
+      redirect_to edit_appointment_path(@appointment), success: 'Appointment has been rescheduled'
     else
       render :reschedule
     end
@@ -66,10 +66,17 @@ class AppointmentsController < ApplicationController
       search_params[:q],
       search_params[:date_range]
     )
+
+    return redirect_on_exact_match(@search.results.first) if @search.results.one?
+
     @results = @search.results.page(params[:page])
   end
 
   private
+
+  def redirect_on_exact_match(result)
+    redirect_to(edit_appointment_path(result))
+  end
 
   def appointment_scope
     if scoped_to_me?

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -3,8 +3,22 @@
   { title: "Edit appointment for #{@appointment.name}" }
 ) %>
 
-<h1>Edit appointment for <%= @appointment.name %> <span class="text-muted"><span class="sr-only">Booking reference </span>#<%= @appointment.id %></span></h1>
-<%= rebooked_from_heading(@appointment) %>
+<div class="row">
+  <div class="col-md-9">
+    <h1>Edit appointment for <%= @appointment.name %> <span class="text-muted"><span class="sr-only">Booking reference </span>#<%= @appointment.id %></span></h1>
+    <%= rebooked_from_heading(@appointment) %>
+  </div>
+  <div class="col-md-3 action-buttons">
+    <%= link_to appointment_reschedule_path(@appointment), title: 'Reschedule appointment', class: 'btn btn-info' do %>
+      <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span>
+      <span>Reschedule</span>
+    <% end %>
+    <%= link_to new_appointment_path(copy_from: @appointment), title: 'Rebook appointment', class: 'btn btn-info t-rebook' do %>
+      <span class="glyphicon glyphicon-copy" aria-hidden="true"></span>
+      <span>Rebook</span>
+    <% end %>
+  </div>
+</div>
 
 <%=
   render(

--- a/app/views/appointments/search.html.erb
+++ b/app/views/appointments/search.html.erb
@@ -43,10 +43,10 @@
   <tbody class="list">
     <% @results.each do |result| %>
       <% result = AppointmentPresenter.new(result) %>
-      <tr class='t-result'>
-        <td class='t-id'><span class="id">#<%= result.id %></span></td>
+      <tr class="t-result">
+        <td class="t-id"><span class="id">#<%= result.id %></span></td>
         <td><%= result.created_at %></td>
-        <td><%= result.first_name %></td>
+        <td class="t-first-name"><%= result.first_name %></td>
         <td><%= result.last_name %></td>
         <td><%= result.guider_name %></td>
         <td><%= result.date %></td>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,47 +5,7 @@
 <% end %>
 
 <% content_for :navbar_items do %>
-  <li class="dropdown">
-    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Appointments <span class="caret"></span></a>
-    <ul class="dropdown-menu">
-      <%= active_link_to 'Search', search_appointments_path, wrap_tag: :li %>
-      <%= active_link_to 'Book appointment', new_appointment_path, wrap_tag: :li %>
-
-      <% if current_user.resource_manager? %>
-        <%= active_link_to 'Allocations', allocations_path, wrap_tag: :li %>
-      <% end %>
-
-      <% if current_user.guider? %>
-        <%= active_link_to 'My appointments', my_appointments_path, wrap_tag: :li %>
-        <%= active_link_to 'Company appointments', company_calendar_path, wrap_tag: :li %>
-      <% end %>
-    </ul>
-  </li>
-
-  <% if current_user.guider? %>
-    <%= active_link_to 'My activity', activities_path, wrap_tag: :li %>
-  <% end %>
-
-  <% if current_user.resource_manager? %>
-    <li class="dropdown">
-      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Guiders <span class="caret"></span></a>
-      <ul class="dropdown-menu">
-        <%= active_link_to 'Groups & schedules', users_path, wrap_tag: :li, active: :exclusive %>
-        <%= active_link_to 'Holidays & unavailability', holidays_path, wrap_tag: :li %>
-        <%= active_link_to 'Display order', sort_users_path, wrap_tag: :li %>
-      </ul>
-    </li>
-  <% end %>
-
-  <% if current_user.resource_manager? || current_user.contact_centre_team_leader? %>
-    <li class="dropdown">
-      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Reports <span class="caret"></span></a>
-      <ul class="dropdown-menu">
-        <%= active_link_to 'Appointment report', new_appointment_report_path, wrap_tag: :li %>
-        <%= active_link_to 'Utilisation report', new_utilisation_report_path, wrap_tag: :li %>
-      </ul>
-    </li>
-  <% end %>
+  <% render 'shared/navigation' %>
 <% end %>
 
 <% content_for :body_end do %>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -1,0 +1,59 @@
+<li class="dropdown">
+  <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Appointments <span class="caret"></span></a>
+  <ul class="dropdown-menu">
+    <%= active_link_to 'Search', search_appointments_path, wrap_tag: :li %>
+    <%= active_link_to 'Book appointment', new_appointment_path, wrap_tag: :li %>
+
+    <% if current_user.resource_manager? %>
+      <%= active_link_to 'Allocations', allocations_path, wrap_tag: :li %>
+    <% end %>
+
+    <% if current_user.guider? %>
+      <%= active_link_to 'My appointments', my_appointments_path, wrap_tag: :li %>
+      <%= active_link_to 'Company appointments', company_calendar_path, wrap_tag: :li %>
+    <% end %>
+  </ul>
+</li>
+
+<% if current_user.guider? %>
+  <%= active_link_to 'My activity', activities_path, wrap_tag: :li %>
+<% end %>
+
+<% if current_user.resource_manager? %>
+  <li class="dropdown">
+    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Guiders <span class="caret"></span></a>
+    <ul class="dropdown-menu">
+      <%= active_link_to 'Groups & schedules', users_path, wrap_tag: :li, active: :exclusive %>
+      <%= active_link_to 'Holidays & unavailability', holidays_path, wrap_tag: :li %>
+      <%= active_link_to 'Display order', sort_users_path, wrap_tag: :li %>
+    </ul>
+  </li>
+<% end %>
+
+<% if current_user.resource_manager? || current_user.contact_centre_team_leader? %>
+  <li class="dropdown">
+    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Reports <span class="caret"></span></a>
+    <ul class="dropdown-menu">
+      <%= active_link_to 'Appointment report', new_appointment_report_path, wrap_tag: :li %>
+      <%= active_link_to 'Utilisation report', new_utilisation_report_path, wrap_tag: :li %>
+    </ul>
+  </li>
+<% end %>
+
+<li class="dropdown quick-search" data-module="quick-search">
+  <a href="#" class="dropdown-toggle js-quick-search-button" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+    <span class="sr-only">Quick Search</span>
+    <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
+    <span class="caret"></span>
+  </a>
+  <div class="dropdown-menu quick-search__dropdown">
+    <form method="get" action="/appointments/search" class="form-inline">
+      <div class="form-group quick-search__form-group">
+        <label for="quick-search-input" class="quick-search__label"><span class="sr-only">Appointment ID or keyword</span>
+          <input type="text" id="quick-search-input" class="quick-search__input js-quick-search-input" name="search[q]" placeholder="Search">
+        </label>
+      </div>
+      <input type="submit" class="quick-search__button btn btn-primary btn-xs" value="Search">
+    </form>
+  </div>
+</li>

--- a/spec/support/pages/search.rb
+++ b/spec/support/pages/search.rb
@@ -9,6 +9,7 @@ module Pages
 
     sections :results, '.t-result' do
       element :id, '.t-id'
+      element :first_name, '.t-first-name'
     end
   end
 end


### PR DESCRIPTION
<img width="315" alt="screen shot 2016-11-24 at 13 45 36" src="https://cloud.githubusercontent.com/assets/6049076/20600582/46e15c1c-b24c-11e6-96cf-9cc68d33e6da.png">

- Altered search to redirect to an appointment edit page
  if it's the only result returned
- Added quick search form in the site navigation which
  submits directly to the appointment search page
- Added reschedule and rebook buttons to appointment edit
  page, so search results page isn't the only place to access
  these actions