### PR TITLE
Improve text wrapping on activity feed items

### DIFF
--- a/app/assets/stylesheets/components/_activity.scss
+++ b/app/assets/stylesheets/components/_activity.scss
@@ -1,0 +1,13 @@
+.activity {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.activity-details {
+  flex-basis: 75%;
+}
+
+.activity-badge {
+  flex-basis: 25%;
+  text-align: right;
+}

--- a/app/views/activities/_activity.html.erb
+++ b/app/views/activities/_activity.html.erb
@@ -1,13 +1,17 @@
 <% if details %>
-  <a class="list-group-item t-activity" href="<%= edit_appointment_path(activity.appointment) %>">
+  <a class="activity list-group-item t-activity" href="<%= edit_appointment_path(activity.appointment) %>">
 <% else %>
-  <li class="list-group-item t-activity">
+  <li class="activity list-group-item t-activity">
 <% end %>
-    <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span>
-    <b><%= activity.user_name %></b>
-    <%= content_for(:activity_message) %>
-    <%= render('activities/details', appointment: activity.appointment) if details %>
-    <em class="badge"><%= activity.created_at.to_s(:govuk_date_short) %> (<%= time_ago_in_words(activity.created_at)%> ago)</em>
+    <div class="activity-details">
+      <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span>
+      <b><%= activity.user_name %></b>
+      <%= content_for(:activity_message) %>
+      <%= render('activities/details', appointment: activity.appointment) if details %>
+    </div>
+    <div class="activity-badge">
+      <em class="badge"><%= activity.created_at.to_s(:govuk_date_short) %> (<%= time_ago_in_words(activity.created_at)%> ago)</em>
+    </div>
 <% if details %>
   </a>
 <% else %>


### PR DESCRIPTION
**Before**
<img width="1152" alt="screen shot 2016-11-24 at 14 16 26" src="https://cloud.githubusercontent.com/assets/6049076/20601450/9afb8300-b250-11e6-85f2-6054dc7e2551.png">

**After**

<img width="1171" alt="screen shot 2016-11-24 at 14 15 50" src="https://cloud.githubusercontent.com/assets/6049076/20601438/80c507c2-b250-11e6-9846-2c1eaeacb16b.png">

- Activity items with a large amount of text wrapped awkardly
- This fixes this issue by laying out an individual activity feed
  item into seperate columns