### PR TITLE
Move error element to page base class

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,8 @@ require 'capybara/rails'
 require 'capybara/rspec'
 require 'database_cleaner'
 require 'pusher-fake/support/rspec'
+
+require_relative 'support/pages/base'
 require_relative 'support/pages/calendar_section'
 
 if ENV['TRAVIS']

--- a/spec/support/pages/activities.rb
+++ b/spec/support/pages/activities.rb
@@ -1,12 +1,6 @@
 module Pages
-  class Activities < SitePrism::Page
+  class Activities < Base
     set_url '/activities'
-
-    element(
-      :permission_error_message,
-      'h1',
-      text: /Sorry/
-    )
 
     elements :activities, '.t-activity'
   end

--- a/spec/support/pages/allocations.rb
+++ b/spec/support/pages/allocations.rb
@@ -1,5 +1,5 @@
 module Pages
-  class Allocations < SitePrism::Page
+  class Allocations < Base
     set_url '/allocations'
 
     element :date, '.fc-left h2'

--- a/spec/support/pages/base.rb
+++ b/spec/support/pages/base.rb
@@ -1,0 +1,5 @@
+module Pages
+  class Base < SitePrism::Page
+    element :permission_error_message, 'h1', text: /Sorry/
+  end
+end

--- a/spec/support/pages/company_calendar.rb
+++ b/spec/support/pages/company_calendar.rb
@@ -1,13 +1,8 @@
 module Pages
-  class CompanyCalendar < SitePrism::Page
+  class CompanyCalendar < Base
     set_url '/company_calendar'
 
     element :next_working_day, '.fc-next-button'
     elements :appointments, '.fc-event'
-    element(
-      :permission_error_message,
-      'h1',
-      text: /Sorry/
-    )
   end
 end

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -1,5 +1,5 @@
 module Pages
-  class EditAppointment < SitePrism::Page
+  class EditAppointment < Base
     set_url '/appointments/{id}/edit'
 
     element :first_name,                            '.t-first-name'
@@ -12,11 +12,6 @@ module Pages
     element :opt_out_of_market_research,            '.t-opt-out-of-market-research'
     element :status, '.t-status'
     element :submit, '.t-save'
-    element(
-      :permission_error_message,
-      'h1',
-      text: /Sorry/
-    )
 
     section :activity_feed, '.t-activity-feed' do
       elements :activities, '.t-activity'

--- a/spec/support/pages/edit_holiday.rb
+++ b/spec/support/pages/edit_holiday.rb
@@ -1,5 +1,5 @@
 module Pages
-  class EditHoliday < SitePrism::Page
+  class EditHoliday < Base
     set_url '/holidays/{ids*}/edit'
     element :title, '.t-title'
     element :date_range, '.t-date-range'

--- a/spec/support/pages/edit_schedule.rb
+++ b/spec/support/pages/edit_schedule.rb
@@ -1,12 +1,6 @@
 module Pages
-  class EditSchedule < SitePrism::Page
+  class EditSchedule < Base
     set_url '/users/{user_id}/schedules/{id}/edit'
-
-    element(
-      :permission_error_message,
-      'h1',
-      text: /Sorry/
-    )
 
     elements :events, '.fc-event'
 

--- a/spec/support/pages/edit_user.rb
+++ b/spec/support/pages/edit_user.rb
@@ -1,11 +1,7 @@
 module Pages
-  class EditUser < SitePrism::Page
+  class EditUser < Base
     set_url '/users/{id}/edit'
-    element(
-      :permission_error_message,
-      'h1',
-      text: /Sorry/
-    )
+
     element :flash_of_success, '.alert-success'
 
     sections :schedules, '.t-schedule' do

--- a/spec/support/pages/holidays.rb
+++ b/spec/support/pages/holidays.rb
@@ -1,11 +1,6 @@
 module Pages
-  class Holidays < SitePrism::Page
+  class Holidays < Base
     set_url '/holidays'
-    element(
-      :permission_error_message,
-      'h1',
-      text: /Sorry/
-    )
 
     element :next_week, '.fc-next-button'
     element :create_holiday, '.t-create-holiday'

--- a/spec/support/pages/home.rb
+++ b/spec/support/pages/home.rb
@@ -1,5 +1,5 @@
 module Pages
-  class Home < SitePrism::Page
+  class Home < Base
     set_url '/'
   end
 end

--- a/spec/support/pages/manage_groups.rb
+++ b/spec/support/pages/manage_groups.rb
@@ -1,5 +1,5 @@
 module Pages
-  class ManageGroups < SitePrism::Page
+  class ManageGroups < Base
     set_url '/groups'
 
     element :affected, '.t-affected'

--- a/spec/support/pages/manage_guiders.rb
+++ b/spec/support/pages/manage_guiders.rb
@@ -1,5 +1,5 @@
 module Pages
-  class ManageGuiders < SitePrism::Page
+  class ManageGuiders < Base
     set_url '/users'
 
     element :search, '.t-search'

--- a/spec/support/pages/my_appointments.rb
+++ b/spec/support/pages/my_appointments.rb
@@ -1,5 +1,5 @@
 module Pages
-  class MyAppointments < SitePrism::Page
+  class MyAppointments < Base
     set_url '/my_appointments'
 
     element :next_working_day, '.fc-next-button'

--- a/spec/support/pages/new_appointment.rb
+++ b/spec/support/pages/new_appointment.rb
@@ -1,12 +1,6 @@
 module Pages
-  class NewAppointment < SitePrism::Page
+  class NewAppointment < Base
     set_url '/appointments/new'
-
-    element(
-      :permission_error_message,
-      'h1',
-      text: /Sorry/
-    )
 
     element :first_name,                            '.t-first-name'
     element :last_name,                             '.t-last-name'

--- a/spec/support/pages/new_appointment_report.rb
+++ b/spec/support/pages/new_appointment_report.rb
@@ -1,12 +1,6 @@
 module Pages
-  class NewAppointmentReport < SitePrism::Page
+  class NewAppointmentReport < Base
     set_url '/appointment_reports/new'
-
-    element(
-      :permission_error_message,
-      'h1',
-      text: /Sorry/
-    )
 
     element :where,      '.t-where'
     element :date_range, '.t-date-range'

--- a/spec/support/pages/new_holiday.rb
+++ b/spec/support/pages/new_holiday.rb
@@ -1,5 +1,5 @@
 module Pages
-  class NewHoliday < SitePrism::Page
+  class NewHoliday < Base
     set_url '/holidays/new'
 
     element :title, '.t-title'

--- a/spec/support/pages/new_schedule.rb
+++ b/spec/support/pages/new_schedule.rb
@@ -1,5 +1,5 @@
 module Pages
-  class NewSchedule < SitePrism::Page
+  class NewSchedule < Base
     set_url '/users/{user_id}/schedules/new'
 
     elements :events, '.fc-event'

--- a/spec/support/pages/new_utilisation_report.rb
+++ b/spec/support/pages/new_utilisation_report.rb
@@ -1,12 +1,6 @@
 module Pages
-  class NewUtilisationReport < SitePrism::Page
+  class NewUtilisationReport < Base
     set_url '/utilisation_reports/new'
-
-    element(
-      :permission_error_message,
-      'h1',
-      text: /Sorry/
-    )
 
     element :date_range, '.t-date-range'
     element :download,   '.t-download'

--- a/spec/support/pages/report_csv.rb
+++ b/spec/support/pages/report_csv.rb
@@ -1,5 +1,5 @@
 module Pages
-  class ReportCsv < SitePrism::Page
+  class ReportCsv < Base
     def csv
       results = CSV.parse(page.body)
       results[0] = results[0].map(&:to_sym)

--- a/spec/support/pages/reschedule_appointment.rb
+++ b/spec/support/pages/reschedule_appointment.rb
@@ -1,16 +1,9 @@
 module Pages
-  class RescheduleAppointment < SitePrism::Page
+  class RescheduleAppointment < Base
     set_url '/appointments/{id}/reschedule'
     element :start_at, '.t-start-at', visible: false
     element :end_at,   '.t-end-at', visible: false
     element :reschedule, '.t-reschedule'
-
-    element(
-      :permission_error_message,
-      'h1',
-      text: /Sorry/
-    )
-
     element :slot_unavailable_message, '.t-slot-unavailable-message'
   end
 end

--- a/spec/support/pages/search.rb
+++ b/spec/support/pages/search.rb
@@ -1,5 +1,5 @@
 module Pages
-  class Search < SitePrism::Page
+  class Search < Base
     set_url '/appointments/search'
 
     element :q,          '.t-q'

--- a/spec/support/pages/sort_guiders.rb
+++ b/spec/support/pages/sort_guiders.rb
@@ -1,12 +1,6 @@
 module Pages
-  class SortGuiders < SitePrism::Page
+  class SortGuiders < Base
     set_url '/users/sort'
-
-    element(
-      :permission_error_message,
-      'h1',
-      text: /Sorry/
-    )
 
     element :save, '.t-save'
 

--- a/spec/support/pages/users.rb
+++ b/spec/support/pages/users.rb
@@ -1,10 +1,5 @@
 module Pages
-  class Users < SitePrism::Page
+  class Users < Base
     set_url '/users'
-    element(
-      :permission_error_message,
-      'h1',
-      text: /Sorry/
-    )
   end
 end


### PR DESCRIPTION
This removes a bunch of duplication when requiring the authorisation
error message assertions. I made all the pages derive from the common
base class for consistency, whether they use this element or not.

I've had to explicitly require the base file in the spec helper since
the 'autoloading' glob loads the spec/support files in alphabetical
order, causing problems with load ordering on the pages that begin 'a*'.