### PR TITLE
Switch back to released GDS-SSO

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ source 'https://rubygems.org' do
   gem 'uglifier', '>= 1.3.0'
   gem 'govuk_admin_template'
   gem 'sprockets-es6'
-  gem 'gds-sso', github: 'guidance-guarantee-programme/gds-sso'
+  gem 'gds-sso'
   gem 'plek'
   gem 'momentjs-rails'
   gem 'active_link_to'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,4 @@
 GIT
-  remote: git://github.com/guidance-guarantee-programme/gds-sso.git
-  revision: ecd027238de545fc51748c36c3b0e52b4602cc12
-  specs:
-    gds-sso (13.0.0)
-      multi_json (~> 1.0)
-      oauth2 (~> 1.0)
-      omniauth (~> 1.2)
-      omniauth-gds (~> 3.2)
-      rails (>= 4.2.4)
-      warden (~> 1.2)
-      warden-oauth2 (~> 0.0.1)
-
-GIT
   remote: git://github.com/rails/rails-observers.git
   revision: 3fe157d6cbb5b5e767ded248009fc59443d63fa1
   specs:
@@ -141,6 +128,14 @@ GEM
       railties (>= 3.2, < 5.1)
     foreman (0.82.0)
       thor (~> 0.19.1)
+    gds-sso (13.1.0)
+      multi_json (~> 1.0)
+      oauth2 (~> 1.0)
+      omniauth (~> 1.2)
+      omniauth-gds (~> 3.2)
+      rails (>= 4.2.4)
+      warden (~> 1.2)
+      warden-oauth2 (~> 0.0.1)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     govuk_admin_template (4.4.1)


### PR DESCRIPTION
We can use the released version now they've cut a gem with our latest
changes.