### PR TITLE
Reduce logging noise with lograge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,5 +66,6 @@ source 'https://rubygems.org' do
   group :staging, :production do
     gem 'bugsnag'
     gem 'rails_12factor'
+    gem 'lograge'
   end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,10 @@ GEM
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    lograge (0.4.1)
+      actionpack (>= 4, < 5.1)
+      activesupport (>= 4, < 5.1)
+      railties (>= 4, < 5.1)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -410,6 +414,7 @@ DEPENDENCIES
   kaminari!
   launchy!
   listen (~> 3.0.5)!
+  lograge!
   momentjs-rails!
   newrelic_rpm!
   pg (~> 0.18)!

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,9 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # use lograge and log in single-line heroku router style
+  config.lograge.enabled = true
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 


### PR DESCRIPTION
Lets us log in a single-line format that doesn't get interleaved,
similar to the heroku router logs.

This will affect production-like environments, not development or test.

Example:

`method=GET path=/bookable_slots format=json controller=BookableSlotsController action=index status=200 duration=341.05 view=211.14 db=70.21`