### PR TITLE
Reduce build queue times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+group: beta
 sudo: false
 language: ruby
 addons:


### PR DESCRIPTION
In theory, using the lesser-used trusty distribution routing should
reduce time spent in the build queue. This won't have any further,
noticeable effect on our test runs.