### PR TITLE
Improve look of quick-search across different browsers

### DIFF
--- a/app/assets/stylesheets/components/_quick-search.scss
+++ b/app/assets/stylesheets/components/_quick-search.scss
@@ -1,9 +1,7 @@
-$quick-search-panel-width: 233px;
-
 .quick-search__dropdown {
   box-sizing: border-box;
   padding: 8px;
-  width: $quick-search-panel-width;
+  white-space: nowrap;
 }
 
 .quick-search__input {

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -50,7 +50,7 @@
     <form method="get" action="/appointments/search" class="form-inline">
       <div class="form-group quick-search__form-group">
         <label for="quick-search-input" class="quick-search__label"><span class="sr-only">Appointment ID or keyword</span>
-          <input type="text" id="quick-search-input" class="quick-search__input js-quick-search-input" name="search[q]" placeholder="Search">
+          <input type="text" id="quick-search-input" class="form-control input-sm quick-search__input js-quick-search-input" name="search[q]" placeholder="Search">
         </label>
       </div>
       <input type="submit" class="quick-search__button btn btn-primary btn-xs" value="Search">


### PR DESCRIPTION

<img width="308" alt="screen shot 2016-11-28 at 11 00 51" src="https://cloud.githubusercontent.com/assets/6049076/20666002/ebd0b582-b559-11e6-8ecd-d2b992a98811.png">


- using bootstrap classes for form input