### PR TITLE
Don't wait so long for failing JS specs

### DIFF
--- a/spec/support/poltergeist.rb
+++ b/spec/support/poltergeist.rb
@@ -1,4 +1,4 @@
 require 'capybara/poltergeist'
 
 Capybara.javascript_driver = :poltergeist
-Capybara.default_max_wait_time = 10
+Capybara.default_max_wait_time = 10 if ENV['TRAVIS']


### PR DESCRIPTION
We don't need to wait so long when the specs fail to find elements that
appear via JS. We still do in travis however.