### PR TITLE
Stop users from losing changes to sortable guiders

### DIFF
--- a/app/assets/javascripts/modules/calendar.es6
+++ b/app/assets/javascripts/modules/calendar.es6
@@ -47,8 +47,6 @@ class Calendar extends TapBase {
       this.config
     );
 
-    this.saveWarningMessage = 'You have unsaved changes - Save, or undo the changes.';
-
     super.start(el);
 
     this.$el.fullCalendar(this.config);

--- a/app/assets/javascripts/modules/sortable_guiders.es6
+++ b/app/assets/javascripts/modules/sortable_guiders.es6
@@ -6,11 +6,54 @@
     start(el) {
       super.start(el);
 
+      this.actionPanel = $('.js-action-panel');
+      this.saveButton = $('.js-save');
+
       this.init();
+      this.bindEvents();
     }
 
     init() {
-      new Sortable(this.$el[0]);
+      this.sortable = new Sortable(this.$el[0], {
+        onUpdate: () => this.onListChange()
+      });
+
+      this.pageOrder = this.getOrder();
+    }
+
+    bindEvents() {
+      this.saveButton.on('click', () => {
+        this.clearUnloadEvent();
+      });
+
+      $.subscribe('sortable-guiders-update', () => this.onListChange());
+    }
+
+    getOrder() {
+      return JSON.stringify(this.sortable.toArray());
+    }
+
+    onListChange() {
+      const currentOrder = this.getOrder();
+
+      this.clearUnloadEvent();
+
+      if (this.pageOrder !== currentOrder) {
+        this.setUnloadEvent();
+        this.actionPanel.fadeIn();
+      } else {
+        this.actionPanel.fadeOut();
+      }
+    }
+
+    setUnloadEvent() {
+      $(window).on('beforeunload', () => {
+        return this.saveWarningMessage;
+      });
+    }
+
+    clearUnloadEvent() {
+      $(window).off('beforeunload');
     }
   }
 

--- a/app/assets/javascripts/tap-base.es6
+++ b/app/assets/javascripts/tap-base.es6
@@ -11,6 +11,8 @@ class TapBase {
       this.getElementConfig(),
       this.getCookieConfig()
     );
+
+    this.saveWarningMessage = 'You have unsaved changes - Save, or undo the changes.';
   }
 
   getElementConfig() {

--- a/app/views/users/sort.html.erb
+++ b/app/views/users/sort.html.erb
@@ -7,7 +7,7 @@
 </p>
 
 <%= form_for :order_users, layout: :basic do |f| %>
-  <div class="list-group sortable-guiders" data-module="sortable-guiders">
+  <div class="list-group sortable-guiders t-sortable-guiders" data-module="sortable-guiders">
     <% @guiders.each do |guider| %>
       <button type="button" class="list-group-item t-guider">
         <span class="glyphicon glyphicon-option-vertical"></span>
@@ -19,5 +19,7 @@
       </button>
     <% end %>
   </div>
-  <%= f.submit 'Save', class: 't-save' %>
+  <div class="action-panel t-action-panel js-action-panel">
+    <%= f.submit 'Save Changes', class: 't-save js-save' %>
+  </div>
 <% end %>

--- a/spec/support/pages/sort_guiders.rb
+++ b/spec/support/pages/sort_guiders.rb
@@ -11,6 +11,8 @@ module Pages
         $(".t-guider").each(function() {
           $(this).prependTo(this.parentNode);
         });
+
+        $.publish('sortable-guiders-update');
       JS
     end
   end


### PR DESCRIPTION
<img width="1197" alt="screen shot 2016-11-28 at 12 00 03" src="https://cloud.githubusercontent.com/assets/6049076/20667638/30b3d690-b562-11e6-9e08-f0c1a6b4301d.png">

- Add an action panel with the save button when ordering is changed
- If there has been a change in the ordering it sets the unload
  event to warn users about navigating away without saving changes