### PR TITLE
Stop multiple unload event alerts on allocations calendar

### DIFF
--- a/app/assets/javascripts/modules/calendars/allocations.es6
+++ b/app/assets/javascripts/modules/calendars/allocations.es6
@@ -309,20 +309,6 @@
       });
     }
 
-    clearUnloadEvent() {
-      $(window).off('beforeunload unload');
-    }
-
-    setUnloadEvent() {
-      $(window).on('beforeunload', () => {
-        return this.saveWarningMessage;
-      });
-
-      $(window).on('unload', () => {
-        alert(this.saveWarningMessage);
-      });
-    }
-
     uniqueEventsChanged() {
       let unique = {};
 

--- a/app/assets/javascripts/modules/calendars/guider-slot-picker.es6
+++ b/app/assets/javascripts/modules/calendars/guider-slot-picker.es6
@@ -50,16 +50,6 @@
       this.generateJSON();
     }
 
-    setUnloadEvent() {
-      $(window).on('beforeunload', () => {
-        return this.saveWarningMessage;
-      });
-    }
-
-    clearUnloadEvent() {
-      $(window).off('beforeunload');
-    }
-
     select(start) {
       const event = {
         start: start,

--- a/app/assets/javascripts/modules/sortable_guiders.es6
+++ b/app/assets/javascripts/modules/sortable_guiders.es6
@@ -45,16 +45,6 @@
         this.actionPanel.fadeOut();
       }
     }
-
-    setUnloadEvent() {
-      $(window).on('beforeunload', () => {
-        return this.saveWarningMessage;
-      });
-    }
-
-    clearUnloadEvent() {
-      $(window).off('beforeunload');
-    }
   }
 
   window.GOVUKAdmin.Modules.SortableGuiders = SortableGuiders;

--- a/app/assets/javascripts/tap-base.es6
+++ b/app/assets/javascripts/tap-base.es6
@@ -30,4 +30,14 @@ class TapBase {
 
     return {};
   }
+
+  clearUnloadEvent() {
+    $(window).off('beforeunload');
+  }
+
+  setUnloadEvent() {
+    $(window).on('beforeunload', () => {
+      return this.saveWarningMessage;
+    });
+  }
 }


### PR DESCRIPTION
<img width="1091" alt="screen shot 2016-11-28 at 14 19 34" src="https://cloud.githubusercontent.com/assets/6049076/20671556/ae50c4e2-b575-11e6-9359-1873d1b8f441.png">

- removed window.unload event as beforeunload is enough
  to work in Chrome/Firefox/IE11
- moved clear and set unload methods into TapBase