### PR TITLE
Show BugMuncher on all environments and use environment variable

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,10 +20,10 @@
   <% end %>
   </script>
 
-  <% if Rails.env.development? || Rails.env.staging? %>
+  <% if ENV['BUGMUNCHER_KEY'] %>
     <script type="text/javascript">
       var bugmuncher_options = {
-        api_key: "fe678532af029a3c85a2"
+        api_key: '<%= ENV['BUGMUNCHER_KEY'] %>'
       };
       (function(){
         var e = document.createElement("script");


### PR DESCRIPTION
Requires `BUGMUNCHER_KEY` to be an environment variable.

This is part of the change to show BugMuncher across all relevant environments, including production as we would like to get direct feedback from the users at TP and TPAS.