### PR TITLE
Restore missing flash message

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -40,7 +40,7 @@ class AppointmentsController < ApplicationController
     @appointment = Appointment.find(params[:id])
     if @appointment.update_attributes(update_params)
       Notifier.new(@appointment).call
-      render :edit, success: 'Appointment has been modified'
+      redirect_to edit_appointment_path(@appointment), success: 'Appointment has been modified'
     else
       render :edit
     end

--- a/spec/features/guider_edits_an_appointment_spec.rb
+++ b/spec/features/guider_edits_an_appointment_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature 'Guider edits an appointment' do
       when_they_modify_the_appointment
       then_the_appointment_is_changed
       and_the_customer_is_not_notified
+      and_they_see_a_success_message
     end
   end
 
@@ -44,5 +45,9 @@ RSpec.feature 'Guider edits an appointment' do
 
   def and_the_customer_is_not_notified
     expect(ActionMailer::Base.deliveries).to be_empty
+  end
+
+  def and_they_see_a_success_message
+    expect(@page).to have_flash_of_success
   end
 end

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -2,6 +2,8 @@ module Pages
   class EditAppointment < Base
     set_url '/appointments/{id}/edit'
 
+    element :flash_of_success, '.alert-success'
+
     element :first_name,                            '.t-first-name'
     element :last_name,                             '.t-last-name'
     element :email,                                 '.t-email'


### PR DESCRIPTION
We shouldn't be rendering the edit action after a successful update
Instead we should be following the POST / redirect / GET rule.
Consequently this means the expected flash message is displayed again.