### PR TITLE
Show booking details on the edit appointment page

### DIFF
--- a/app/views/appointments/_personal_details_form.html.erb
+++ b/app/views/appointments/_personal_details_form.html.erb
@@ -1,6 +1,6 @@
 <div class="row form-group">
   <div class="col-md-12">
-    <h2>Personal Details</h2>
+    <h2>Customer details</h2>
     <%= render 'shared/required_fields_note' %>
   </div>
   <div class="col-md-6">

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -27,6 +27,35 @@
   )
 %>
 
+<hr>
+<div class="row">
+  <div class="col-md-12">
+    <h2>Booking details</h2>
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-12">
+    <table class="table table-striped table-bordered">
+      <caption><span class="sr-only">Booking details</span></caption>
+      <thead>
+        <tr>
+          <th>Guider</th>
+          <th>Appointment date/time</th>
+          <th>Appointment created</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><span class="glyphicon glyphicon-user" aria-hidden="true"></span> <span class="t-guider"><%= @appointment.guider.name %></span></td>
+          <td><span class="glyphicon glyphicon-calendar" aria-hidden="true"></span> <span class="t-appointment-date-time"><%= @appointment.start_at.to_date.to_s(:govuk_date_short) %>, <%= @appointment.start_at.to_s(:govuk_time) %> - <%= @appointment.end_at.to_s(:govuk_time) %></span></td>
+          <td><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span> <span class="t-created-date"><%= @appointment.created_at.to_s(:govuk_date_short) %></span></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+<hr>
+
 <%= form_for @appointment, layout: :basic do |f| %>
   <%= render partial: 'personal_details_form', locals: { f: f, edit: true } %>
   <div class="row form-group">

--- a/spec/features/guider_edits_an_appointment_spec.rb
+++ b/spec/features/guider_edits_an_appointment_spec.rb
@@ -23,6 +23,13 @@ RSpec.feature 'Guider edits an appointment' do
   end
 
   def then_they_see_the_existing_details
+    start_date = @appointment.start_at.to_date.to_s(:govuk_date_short)
+    start_at_time = @appointment.start_at.to_s(:govuk_time)
+    end_at_time = @appointment.end_at.to_s(:govuk_time)
+
+    expect(@page.guider.text).to eq(@appointment.guider.name)
+    expect(@page.date_time.text).to eq("#{start_date}, #{start_at_time} - #{end_at_time}")
+    expect(@page.created_date.text).to eq(@appointment.created_at.to_s(:govuk_date_short))
     expect(@page.first_name.value).to eq(@appointment.first_name)
     expect(@page.last_name.value).to eq(@appointment.last_name)
     expect(@page.email.value).to eq(@appointment.email)

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -3,7 +3,9 @@ module Pages
     set_url '/appointments/{id}/edit'
 
     element :flash_of_success, '.alert-success'
-
+    element :guider,                                '.t-guider'
+    element :date_time,                             '.t-appointment-date-time'
+    element :created_date,                          '.t-created-date'
     element :first_name,                            '.t-first-name'
     element :last_name,                             '.t-last-name'
     element :email,                                 '.t-email'


### PR DESCRIPTION

<img width="1286" alt="screen shot 2016-11-28 at 15 51 45" src="https://cloud.githubusercontent.com/assets/6049076/20674945/9676e9f2-b582-11e6-9611-184faa82b1df.png">


- Displays appointment created date, appointment date/time
  and the current guider it is assigned to