### PR TITLE
Display a message if there is no activity on the 'My activity' page

### DIFF
--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -9,6 +9,13 @@
         <%= render(@activities, details: true) %>
       </div>
     </div>
+    <% if @activities.empty? %>
+      <div class="panel panel-default">
+        <div class="panel-body t-no-activity">
+          You have no activity
+        </div>
+      </div>
+    <% end %>
   </div>
 </div>
 

--- a/spec/features/guider_views_their_activities_spec.rb
+++ b/spec/features/guider_views_their_activities_spec.rb
@@ -9,6 +9,14 @@ RSpec.feature 'Guider views their activities' do
     create(:guider)
   end
 
+  scenario 'No activities' do
+    given_a_browser_session_for guider do
+      and_they_have_no_appointments
+      when_they_view_their_activity
+      then_they_see_a_no_activity_message
+    end
+  end
+
   scenario 'Activies are loaded in realtime', js: true do
     given_a_browser_session_for guider do
       and_they_have_some_appointments
@@ -27,6 +35,10 @@ RSpec.feature 'Guider views their activities' do
 
   def and_they_have_some_appointments
     @appointments = create_list(:appointment, 2, guider: guider)
+  end
+
+  def and_they_have_no_appointments
+    @appointments = []
   end
 
   def when_they_view_their_activity
@@ -54,5 +66,9 @@ RSpec.feature 'Guider views their activities' do
     expect(@page.activities.first.text).to include(
       "#{someone.name} said Hello mate appointment \##{@appointments.first.id}"
     )
+  end
+
+  def then_they_see_a_no_activity_message
+    expect(@page).to have_no_activity
   end
 end

--- a/spec/support/pages/activities.rb
+++ b/spec/support/pages/activities.rb
@@ -3,5 +3,7 @@ module Pages
     set_url '/activities'
 
     elements :activities, '.t-activity'
+
+    element :no_activity, '.t-no-activity'
   end
 end


### PR DESCRIPTION

<img width="1193" alt="screen shot 2016-11-29 at 10 00 24" src="https://cloud.githubusercontent.com/assets/6049076/20705391/aa4107f4-b61a-11e6-8297-0b507161ae94.png">


- Previously if there was no activity, the page was looking rather
  empty