### PR TITLE
Relax client side valiation on date of birth fields

### DIFF
--- a/app/views/shared/_date_of_birth_form_field.html.erb
+++ b/app/views/shared/_date_of_birth_form_field.html.erb
@@ -16,7 +16,7 @@
           value: form.object.date_of_birth.try(:day),
           placeholder: 'DD',
           class: 'form-dob__input js-dob-day t-date-of-birth-day',
-          pattern: '(0?[1-9]|(1|2)[0-9]|3[0-1])',
+          pattern: '[0-9]+',
           maxlength: 2,
           required: true,
           title: 'Must be numeric eg 01',
@@ -34,7 +34,7 @@
           value: form.object.date_of_birth.try(:month),
           placeholder: 'MM',
           class: 'form-dob__input js-dob-month t-date-of-birth-month',
-          pattern: '(0?[1-9]|1[0-2])',
+          pattern: '[0-9]+',
           maxlength: 2,
           title: 'Must be numeric eg 01',
           required: true
@@ -51,7 +51,7 @@
           value: form.object.date_of_birth.try(:year),
           placeholder: 'YYYY',
           class: 'form-dob__input form-dob__input--year js-dob-year t-date-of-birth-year',
-          pattern: '(19)[0-9]{2}',
+          pattern: '[0-9]+',
           maxlength: 4,
           title: 'Must be numeric eg 1955',
           required: true


### PR DESCRIPTION
The regular expression was be interpreted incorrectly on IE,
which was stopping TPAS or TP being able to book appointments
with certain birth dates.

So as long as we're checking for a numeric input then this should
suffice.