### PR TITLE
Disallow creating holidays that overlap other holidays from allocations

### DIFF
--- a/app/assets/javascripts/modules/calendars/allocations.es6
+++ b/app/assets/javascripts/modules/calendars/allocations.es6
@@ -17,7 +17,8 @@
             click: this.fullscreenClick.bind(this)
           }
         },
-        selectable: true
+        selectable: true,
+        selectOverlap: this.selectOverlap
       };
 
       this.eventChanges = [];
@@ -49,6 +50,10 @@
       }
 
       this.$el.fullCalendar('unselect');
+    }
+
+    selectOverlap(event) {
+      return (event.source.eventType != 'holiday');
     }
 
     bindEvents() {


### PR DESCRIPTION
I'm not sure is 100% what the acceptance criteria mentioned, but might be better?