### PR TITLE
Rename 'Holidays & Unavailability' in navigation

### DIFF
--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -24,7 +24,7 @@
     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Guiders <span class="caret"></span></a>
     <ul class="dropdown-menu">
       <%= active_link_to 'Groups & schedules', users_path, wrap_tag: :li, active: :exclusive %>
-      <%= active_link_to 'Holidays & unavailability', holidays_path, wrap_tag: :li %>
+      <%= active_link_to 'Holidays', holidays_path, wrap_tag: :li %>
       <%= active_link_to 'Display order', sort_users_path, wrap_tag: :li %>
     </ul>
   </li>


### PR DESCRIPTION

<img width="250" alt="screen shot 2016-11-29 at 16 14 33" src="https://cloud.githubusercontent.com/assets/6049076/20717890/eed6fe12-b64e-11e6-9256-c03571b84353.png">


- Renamed to 'Holidays' to be consistant with H1 on page