### PR TITLE
Fix broken appointment seeding

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -46,6 +46,7 @@ if Rails.env.development?
   print "Adding #{APPOINTMENT_COUNT} appointments"
   slots = BookableSlot
           .within_date_range(BusinessDays.from_now(3), BusinessDays.from_now(20))
+          .without_holidays
           .sample(APPOINTMENT_COUNT)
           .cycle(1)
   slots.each do |slot|


### PR DESCRIPTION
Appointments were failing to be assigned to guiders because we were
using appointments that were obscured by holidays.