### PR TITLE
Ensure the action buttons on edit appointment page don't wrap

### DIFF
--- a/app/assets/stylesheets/components/_action-buttons.scss
+++ b/app/assets/stylesheets/components/_action-buttons.scss
@@ -1,4 +1,5 @@
 .action-buttons {
   margin-top: 1.4em;
   text-align: right;
+  white-space: nowrap;
 }


### PR DESCRIPTION
**Before**
<img width="438" alt="screen shot 2016-11-30 at 10 30 40" src="https://cloud.githubusercontent.com/assets/6049076/20748922/0ae1fbd6-b6e8-11e6-9c68-995925a7784e.png">


**After**
<img width="985" alt="screen shot 2016-11-30 at 10 26 11" src="https://cloud.githubusercontent.com/assets/6049076/20748895/f79cf4ea-b6e7-11e6-8aba-38901e6cfcf2.png">
