### PR TITLE
Improve layout for report forms

### DIFF
--- a/app/views/appointment_reports/new.html.erb
+++ b/app/views/appointment_reports/new.html.erb
@@ -3,32 +3,44 @@
 <h1>Generate an appointment report</h1>
 
 <%= form_for @appointment_report, method: 'GET', target: '_blank', 'data-disable-with': nil, layout: :basic do |f| %>
-  <%=
-    f.select(
-      :where,
-      options_for_select(@where_options),
-      {},
-      class: 't-where',
-      data: { module: 'advanced-select', config: { allowClear: false } }
-    )
-  %>
-  <%=
-    f.text_field(
-      :date_range,
-      class: 't-date-range',
-      label: 'Is in date range',
-      data: {
-	module: 'date-range-picker',
-	config: {
-	  autoUpdateInput: false,
-	  locale: {
-	    cancelLabel: 'Clear',
-	    format: 'DD/MM/YYYY'
-	  }
-	}
-      }
-    )
-  %>
-  <% # Use manual html here so that data-disable-with isn't added. %>
-  <input type="submit" name="commit" value="Download" class="t-download btn btn-primary">
+  <div class="row">
+    <div class="col-md-4">
+      <%=
+        f.select(
+          :where,
+          options_for_select(@where_options),
+          {},
+          class: 't-where',
+          data: { module: 'advanced-select', config: { allowClear: false } }
+        )
+      %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-4">
+      <%=
+        f.text_field(
+          :date_range,
+          class: 't-date-range',
+          label: 'Is in date range',
+          data: {
+            module: 'date-range-picker',
+            config: {
+              autoUpdateInput: false,
+              locale: {
+                cancelLabel: 'Clear',
+                format: 'DD/MM/YYYY'
+              }
+            }
+          }
+        )
+      %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <% # Use manual html here so that data-disable-with isn't added. %>
+      <input type="submit" name="commit" value="Download" class="t-download btn btn-primary">
+    </div>
+  </div>
 <% end %>

--- a/app/views/utilisation_reports/new.html.erb
+++ b/app/views/utilisation_reports/new.html.erb
@@ -3,21 +3,29 @@
 <h1>Generate a utilisation report</h1>
 
 <%= form_for @utilisation_report, method: 'GET', target: '_blank', 'data-disable-with': nil, layout: :basic do |f| %>
-  <%=
-    f.text_field(
-      :date_range,
-      class: 't-date-range',
-      label: 'In date range',
-      data: {
-	module: 'date-range-picker',
-	config: {
-	  locale: {
-	    format: 'DD/MM/YYYY'
-	  }
-	}
-      }
-    )
-  %>
-  <% # Use manual html here so that data-disable-with isn't added. %>
-  <input type="submit" name="commit" value="Download" class="t-download btn btn-primary">
+  <div class="row">
+    <div class="col-md-4">
+      <%=
+        f.text_field(
+          :date_range,
+          class: 't-date-range',
+          label: 'In date range',
+          data: {
+            module: 'date-range-picker',
+            config: {
+              locale: {
+                format: 'DD/MM/YYYY'
+              }
+            }
+          }
+        )
+      %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <% # Use manual html here so that data-disable-with isn't added. %>
+      <input type="submit" name="commit" value="Download" class="t-download btn btn-primary">
+    </div>
+  </div>
 <% end %>


### PR DESCRIPTION
**Before**
<img width="1173" alt="screen shot 2016-11-30 at 11 40 30" src="https://cloud.githubusercontent.com/assets/6049076/20751064/cd968fa8-b6f1-11e6-96ba-3f0971d3a081.png">
<img width="1229" alt="screen shot 2016-11-30 at 11 40 25" src="https://cloud.githubusercontent.com/assets/6049076/20751065/cd9ac352-b6f1-11e6-9e8b-b20a69397006.png">

**After**
<img width="588" alt="screen shot 2016-11-30 at 11 39 43" src="https://cloud.githubusercontent.com/assets/6049076/20751045/b53ac3fc-b6f1-11e6-8b85-639e4fbb7862.png">
<img width="536" alt="screen shot 2016-11-30 at 11 39 38" src="https://cloud.githubusercontent.com/assets/6049076/20751046/b54ed3ba-b6f1-11e6-807b-67ad6a1632d5.png">

- Placed form controls into grid columns, so that
  dropdowns don't go full width on desktop size viewports