### PR TITLE
Add autoApply: true to any date pickers without time selection

### DIFF
--- a/app/views/appointment_reports/new.html.erb
+++ b/app/views/appointment_reports/new.html.erb
@@ -27,6 +27,7 @@
             module: 'date-range-picker',
             config: {
               autoUpdateInput: false,
+              autoApply: true,
               locale: {
                 cancelLabel: 'Clear',
                 format: 'DD/MM/YYYY'

--- a/app/views/appointments/search.html.erb
+++ b/app/views/appointments/search.html.erb
@@ -19,6 +19,7 @@
           module: 'date-range-picker',
           config: {
             autoUpdateInput: false,
+            autoApply: true,
             locale: {
               cancelLabel: 'Clear',
               format: 'DD/MM/YYYY'

--- a/app/views/utilisation_reports/new.html.erb
+++ b/app/views/utilisation_reports/new.html.erb
@@ -13,6 +13,7 @@
           data: {
             module: 'date-range-picker',
             config: {
+              autoApply: true,
               locale: {
                 format: 'DD/MM/YYYY'
               }


### PR DESCRIPTION
<img width="567" alt="screen shot 2016-11-30 at 12 17 42" src="https://cloud.githubusercontent.com/assets/6049076/20752034/05dda2ca-b6f7-11e6-9fa3-d38142dc5d63.png">


- When you select a date range it's nicer to close the date
  input dialog automatically so you can complete the form quicker