### PR TITLE
Alter cursor to 'move' icon when hovering over sortable guiders

### DIFF
--- a/app/assets/stylesheets/components/_sortable-guiders.scss
+++ b/app/assets/stylesheets/components/_sortable-guiders.scss
@@ -1,0 +1,3 @@
+.sortable-guiders__guider {
+  cursor: move;
+}

--- a/app/views/users/sort.html.erb
+++ b/app/views/users/sort.html.erb
@@ -9,7 +9,7 @@
 <%= form_for :order_users, layout: :basic do |f| %>
   <div class="list-group sortable-guiders t-sortable-guiders" data-module="sortable-guiders">
     <% @guiders.each do |guider| %>
-      <button type="button" class="list-group-item t-guider">
+      <button type="button" class="sortable-guiders__guider list-group-item t-guider">
         <span class="glyphicon glyphicon-option-vertical"></span>
         <%= guider.name %>
         <% guider.groups.each do |group| %>


### PR DESCRIPTION
I would show a screenshot, but it's proving tricky to screenshot with the right cursor on the screen!!