### PR TITLE
Altered way jquery finds DOM elements across different modules

### DIFF
--- a/app/assets/javascripts/modules/calendars/allocations.es6
+++ b/app/assets/javascripts/modules/calendars/allocations.es6
@@ -23,7 +23,7 @@
 
       this.eventChanges = [];
       this.isFullscreen = false;
-      this.$actionPanel = $('[data-action-panel]');
+      this.$actionPanel = $('.js-action-panel');
       this.$savedChanges = $('.js-saved-changes');
       this.$form = $('.js-changes-form');
       this.$holidayForm = $('.js-holiday-form');
@@ -203,9 +203,9 @@
     }
 
     setupUndo() {
-      this.$actionPanel.find('[data-action-panel-undo-all]').on('click', this.undoAllChanges.bind(this));
-      this.$actionPanel.find('[data-action-panel-undo-one]').on('click', this.undoOneChange.bind(this));
-      this.$actionPanel.find('[data-action-panel-save]').on('click', this.save.bind(this));
+      this.$actionPanel.find('.js-action-panel-undo-all').on('click', this.undoAllChanges.bind(this));
+      this.$actionPanel.find('.js-action-panel-undo-one').on('click', this.undoOneChange.bind(this));
+      this.$actionPanel.find('.js-action-panel-save').on('click', this.save.bind(this));
     }
 
     handleEventChange(event, revertFunc) {
@@ -303,7 +303,7 @@
       let fadeAction = 'fadeIn';
 
       if (eventsChanged > 0) {
-        this.$actionPanel.find('[data-action-panel-event-count]').html(
+        this.$actionPanel.find('.js-action-panel-event-count').html(
           `${eventsChanged} event${eventsChanged == 1 ? '':'s'}`
         );
         this.setUnloadEvent();

--- a/app/assets/javascripts/modules/calendars/appointment-availability.es6
+++ b/app/assets/javascripts/modules/calendars/appointment-availability.es6
@@ -38,8 +38,8 @@
     }
 
     init() {
-      this.$selectedStart = $('[data-selected-start]');
-      this.$selectedEnd = $('[data-selected-end]');
+      this.$selectedStart = $('.js-selected-start');
+      this.$selectedEnd = $('.js-selected-end');
       this.selectedEventColour = 'green';
     }
 

--- a/app/assets/javascripts/modules/guiders-multi-action.es6
+++ b/app/assets/javascripts/modules/guiders-multi-action.es6
@@ -6,9 +6,9 @@
     start(el) {
       super.start(el);
 
-      this.$actionPanel = this.$el.find('[data-action-panel]');
-      this.$actionsSelect = this.$actionPanel.find('[data-action-panel-actions]');
-      this.$goButton = this.$actionPanel.find('[data-action-panel-go]');
+      this.$actionPanel = this.$el.find('.js-action-panel');
+      this.$actionsSelect = this.$actionPanel.find('.js-action-panel-actions');
+      this.$goButton = this.$actionPanel.find('.js-action-panel-go');
 
       this.bindEvents();
       this.hideActionPanel();
@@ -21,7 +21,7 @@
     }
 
     handleSearchComplete(event, list) {
-      this.handleSelection(event, ...$(list.list).find('[data-multi-checkbox="item"]'));
+      this.handleSelection(event, ...$(list.list).find('.js-multi-checkbox-item'));
     }
 
     hideActionPanel() {
@@ -37,8 +37,8 @@
 
       const selectedCheckboxCount = this.checkboxSelectedLength();
 
-      this.$el.find('[data-action-panel-selected-count]').html(selectedCheckboxCount);
-      this.$el.find('[data-action-panel-selected-guiders]').html(selectedCheckboxCount === 1 ? 'guider' : 'guiders');
+      this.$el.find('.js-action-panel-selected-count').html(selectedCheckboxCount);
+      this.$el.find('.js-action-panel-selected-guiders').html(selectedCheckboxCount === 1 ? 'guider' : 'guiders');
 
       if (selectedCheckboxCount === 0) {
         this.hideActionPanel();

--- a/app/assets/javascripts/modules/multi-checkbox.es6
+++ b/app/assets/javascripts/modules/multi-checkbox.es6
@@ -6,8 +6,8 @@
     start(el) {
       super.start(el);
 
-      this.$allCheckbox = this.$el.find('[data-multi-checkbox="all"]');
-      this.$itemCheckboxes = this.$el.find('[data-multi-checkbox="item"]');
+      this.$allCheckbox = this.$el.find('.js-multi-checkbox-all');
+      this.$itemCheckboxes = this.$el.find('.js-multi-checkbox-item');
 
       this.bindEvents();
     }
@@ -46,7 +46,7 @@
     }
 
     addRemoveClass($el, checked) {
-      $el.parents('[data-multi-checkbox-group]')[checked ? 'addClass' : 'removeClass'](this.config.selectedClassName);
+      $el.parents('.js-multi-checkbox-group')[checked ? 'addClass' : 'removeClass'](this.config.selectedClassName);
     }
 
     areAllItemsChecked() {

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -27,20 +27,20 @@
   <%= f.hidden_field :end_at, class: 'js-end-at' %>
 <% end %>
 
-<div class="action-panel t-action-panel" data-action-panel>
+<div class="action-panel t-action-panel js-action-panel">
   <%= form_tag batch_update_appointments_path, method: :patch, remote: true, class: 'js-changes-form' do %>
-    <button class="btn btn-primary t-save" data-action-panel-save>
+    <button class="btn btn-primary t-save js-action-panel-save">
       <span class="glyphicon glyphicon-save" aria-hidden="true"></span> Save changes to
       <b>
-        <span data-action-panel-event-count>0 events</span>
+        <span class="js-action-panel-event-count">0 events</span>
       </b>
     </button>
 
-    <button class="btn btn-warning" data-action-panel-undo-one>
+    <button class="btn btn-warning js-action-panel-undo-one">
       <span class="glyphicon glyphicon-step-backward" aria-hidden="true"></span> Undo last change
     </button>
 
-    <button class="btn btn-danger" data-action-panel-undo-all>
+    <button class="btn btn-danger js-action-panel-undo-all">
       <span class="glyphicon glyphicon-erase" aria-hidden="true"></span> Undo <b>all</b> changes
     </button>
     <input type="hidden" name="changes" id="event-changes">

--- a/app/views/appointments/_availability_calendar.html.erb
+++ b/app/views/appointments/_availability_calendar.html.erb
@@ -10,5 +10,5 @@
   data-default-date="<%= BookableSlot.next_valid_start_date %>"
 ></div>
 <input type="hidden" name="available-slots-json" class="slots-data" value="<%= @available_slots_json %>">
-<%= form.hidden_field :start_at, data: { 'selected-start': true }, class: 't-start-at' %>
-<%= form.hidden_field :end_at, data: { 'selected-end': true }, class: 't-end-at' %>
+<%= form.hidden_field :start_at, class: 't-start-at js-selected-start' %>
+<%= form.hidden_field :end_at, class: 't-end-at js-selected-end' %>

--- a/app/views/shared/_date_of_birth_form_field.html.erb
+++ b/app/views/shared/_date_of_birth_form_field.html.erb
@@ -4,7 +4,7 @@
   form_element_year_id = "#{form.object_name}_date_of_birth_1i"
 %>
 
-<div class="form-dob clearfix" data-module="customer-age" data-output-id="js-customer-age">
+<div class="form-dob clearfix" data-module="customer-age" data-output-id="customer-age">
   <%= field_with_errors_wrapper(form, :date_of_birth, 'form-dob__inputs-container') do %>
     <label for="<%= form_element_day_id %>">
       <span class="sr-only">Date of birth</span> <%= required_label(:day) %>
@@ -62,6 +62,6 @@
       <div class="text-danger"><%= message %></div>
     <% end %>
   <% end %>
-  <span class="bg-info form-dob__age" id="js-customer-age"></span>
+  <span class="bg-info form-dob__age" id="customer-age"></span>
 </div>
 <div class="help-block" id="dob-hint">For example, 31 3 1950</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -20,7 +20,7 @@
       </colgroup>
       <thead>
         <tr>
-          <th><label for="select-all"><input type="checkbox" id="select-all" class="select-all" data-multi-checkbox="all"> <span class="sr-only">Select All</span></label></th>
+          <th><label for="select-all"><input type="checkbox" id="select-all" class="select-all js-multi-checkbox-all"> <span class="sr-only">Select All</span></label></th>
           <th><span class="sort" data-sort="name">Name</span></th>
           <th>Groups</th>
           <th>Actions</th>
@@ -28,10 +28,10 @@
       </thead>
       <tbody class="list">
         <% @guiders.each do |guider| %>
-          <tr data-multi-checkbox-group class="t-guider guider">
+          <tr class="t-guider guider js-multi-checkbox-group">
             <td>
               <label for="guider_<%= guider.id %>">
-                <input data-multi-checkbox="item" type="checkbox" name="guider_<%= guider.id %>" id="guider_<%= guider.id %>" value="<%= guider.id %>" class="guider__checkbox t-checkbox">
+                <input type="checkbox" name="guider_<%= guider.id %>" id="guider_<%= guider.id %>" value="<%= guider.id %>" class="guider__checkbox t-checkbox js-multi-checkbox-item">
                 <span class="sr-only">Select <%= guider.name %></span>
               </label>
             </td>
@@ -47,14 +47,14 @@
       </tbody>
     </table>
   </div>
-  <div class="action-panel t-action-panel" data-action-panel>
-    With the <span class="guider__number-selected t-selected" data-action-panel-selected-count>0</span> <span data-action-panel-selected-guiders></span> selected
+  <div class="js-action-panel action-panel t-action-panel">
+    With the <span class="guider__number-selected t-selected js-action-panel-selected-count">0</span> <span class="js-action-panel-selected-guiders"></span> selected
     <label for="action-panel-select">
       <span class="sr-only">Action to perform</span>
-      <select name="action" id="action-panel-select" class="t-action" data-action-panel-actions>
+      <select name="action" id="action-panel-select" class="js-action-panel-actions t-action">
         <option value="/groups">Add/remove groups</option>
       </select>
     </label>
-    <button class="btn btn-primary t-go" data-action-panel-go>Go</button>
+    <button class="btn btn-primary t-go js-action-panel-go">Go</button>
   </div>
 </div>


### PR DESCRIPTION
- GOVUK Admin standard is to use classes with .js- prefix
https://github.com/alphagov/govuk_admin_template/blob/master/JAVASCRIPT.md
- altered any finding of DOM elements with $('[data-X]') to
  $('.js-X') to be consistent