### PR TITLE
Don't create activities when importing

### DIFF
--- a/app/lib/appointment_importer.rb
+++ b/app/lib/appointment_importer.rb
@@ -8,23 +8,25 @@ class AppointmentImporter
   def call # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     return if Appointment.exists?(row.booking_reference)
 
-    Appointment.new(
-      id: row.booking_reference,
-      start_at: row.start_at,
-      end_at: row.end_at,
-      first_name: row.first_name,
-      last_name: row.last_name,
-      email: row.email,
-      phone: row.phone,
-      mobile: row.mobile,
-      date_of_birth: FAKE_DATE_OF_BIRTH,
-      memorable_word: row.memorable_word,
-      status: row.pension_wise_status,
-      opt_out_of_market_research: row.opt_out_of_market_research,
-      notes: row.notes,
-      agent: agent,
-      guider: guider
-    ).save(validate: false)
+    Appointment.without_auditing do
+      Appointment.new(
+        id: row.booking_reference,
+        start_at: row.start_at,
+        end_at: row.end_at,
+        first_name: row.first_name,
+        last_name: row.last_name,
+        email: row.email,
+        phone: row.phone,
+        mobile: row.mobile,
+        date_of_birth: FAKE_DATE_OF_BIRTH,
+        memorable_word: row.memorable_word,
+        status: row.pension_wise_status,
+        opt_out_of_market_research: row.opt_out_of_market_research,
+        notes: row.notes,
+        agent: agent,
+        guider: guider
+      ).save(validate: false)
+    end
   end
 
   private

--- a/spec/features/pension_wise_imports_historical_data_spec.rb
+++ b/spec/features/pension_wise_imports_historical_data_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Pension Wise imports historical data' do
     given_a_valid_csv_to_import
     when_the_csv_is_imported
     the_appointments_are_imported_successfully
+    and_no_activities_are_created
   end
 
   def given_a_valid_csv_to_import
@@ -40,5 +41,9 @@ RSpec.feature 'Pension Wise imports historical data' do
         opt_out_of_market_research: true
       )
     end
+  end
+
+  def and_no_activities_are_created
+    expect(Appointment.first.activities).to be_empty
   end
 end


### PR DESCRIPTION
This massively speeds up the import process plus it stops pusher
notifications being triggered unnecessarily during import.