### PR TITLE
Adding a (C) after the text of an appointment in 'my appointments'

### DIFF
--- a/app/assets/javascripts/modules/calendars/my-appointments.es6
+++ b/app/assets/javascripts/modules/calendars/my-appointments.es6
@@ -69,14 +69,20 @@
         return;
       }
 
+      const cancelled = event.status.indexOf('cancelled') > -1 ? true : false;
+
       if (view.type === 'agendaDay') {
         element.find('.fc-title').html(`
-            <span class="glyphicon glyphicon-phone-alt" aria-hidden="true"></span>
-            ${event.title} | Phone: ${event.phone} | Memorable word: ${event.memorable_word}
-            `);
+          <span class="glyphicon glyphicon-phone-alt" aria-hidden="true"></span>
+          ${event.title} | Phone: ${event.phone} | Memorable word: ${event.memorable_word}
+          `);
       }
 
-      if (event.status.indexOf('cancelled') > -1) {
+      if (cancelled) {
+        element.find('.fc-title, .fc-list-item-title').append(`
+          ${cancelled ? '<span aria-hidden="true">(C)</span><span class="sr-only">Cancelled</span>' : ''}
+        `);
+
         element.addClass('fc-event--cancelled');
       }
     }

--- a/app/assets/stylesheets/components/_calendars.scss
+++ b/app/assets/stylesheets/components/_calendars.scss
@@ -15,6 +15,12 @@ $calendar-loading-view-background: transparentize($color-white, .2);
 
 $guider-row-height: 120px;
 
+.fc {
+  a:visited {
+    color: $color-black;
+  }
+}
+
 .fc-view-container {
   position: relative;
 
@@ -209,6 +215,10 @@ $guider-row-height: 120px;
 
 .fc-event--cancelled {
   @include striped($calendar-appointment-cancelled-background);
+
+  &:hover td {
+    @include striped($calendar-appointment-cancelled-background);
+  }
 }
 
 .fc-event--moved {


### PR DESCRIPTION
<img width="555" alt="screen shot 2016-12-01 at 15 53 31" src="https://cloud.githubusercontent.com/assets/6049076/20800719/5754922a-b7de-11e6-9618-f8ecc71c4f07.png">


- forcing visited link colour for the list view to be black and
  not purple, which is hard to see on the cancelled event bg