### PR TITLE
Hardcode appointment duration to 45 minutes

### DIFF
--- a/app/views/appointment_mailer/updated.html.erb
+++ b/app/views/appointment_mailer/updated.html.erb
@@ -30,7 +30,7 @@
   Appointment lasts
   <br>
   <strong class="emphasize" style="font-size: 24px;">
-    <%= ((@appointment.end_at - @appointment.start_at) / 1.minutes).round %> minutes
+    45 minutes
   </strong>
 </p>
 

--- a/app/views/appointment_mailer/updated.text.erb
+++ b/app/views/appointment_mailer/updated.text.erb
@@ -11,7 +11,7 @@ Start time
 <%= @appointment.start_at.to_time.to_s(:govuk_time) %>
 
 Appointment lasts
-<%= ((@appointment.end_at - @appointment.start_at) / 1.minutes).round %> minutes
+45 minutes
 
 Your contact number
 <%= @appointment.phone %>

--- a/spec/mailers/appointment_mailer_spec.rb
+++ b/spec/mailers/appointment_mailer_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe AppointmentMailer, type: :mailer do
       end
 
       it 'includes the duration' do
-        expect(body).to include('60 minutes')
+        expect(body).to include('45 minutes')
       end
 
       it 'includes the contact number' do


### PR DESCRIPTION
Although we have 70 minute appointments in the database, the customer's
appointment is only 45 minutes. We allow for more time so the guider has
time to prepare either side.