### PR TITLE
Don't redefine `#no_show?`

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -53,10 +53,6 @@ class Appointment < ApplicationRecord
     status.start_with?('cancelled')
   end
 
-  def no_show?
-    status == 'no_show'
-  end
-
   def assign_to_guider
     slot = BookableSlot
            .without_appointments


### PR DESCRIPTION
This is defined for free with Rails enums. You also get the
bang-equivalent for transitioning to that particular state. FYI.