### PR TITLE
Mark imported records with an obviously fake DOB

### DIFF
--- a/app/lib/appointment_importer.rb
+++ b/app/lib/appointment_importer.rb
@@ -1,5 +1,5 @@
 class AppointmentImporter
-  FAKE_DATE_OF_BIRTH = '1950-01-01'.freeze
+  FAKE_DATE_OF_BIRTH = '1900-01-01'.freeze
 
   def initialize(row)
     @row = row

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -45,6 +45,10 @@ class Appointment < ApplicationRecord
     end
   end
 
+  def imported?
+    date_of_birth == Date.parse(AppointmentImporter::FAKE_DATE_OF_BIRTH)
+  end
+
   def name
     "#{first_name} #{last_name}"
   end

--- a/spec/features/pension_wise_imports_historical_data_spec.rb
+++ b/spec/features/pension_wise_imports_historical_data_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Pension Wise imports historical data' do
         email: 'customer@email.com',
         phone: '0208 252 4729',
         mobile: '07715 930 459',
-        date_of_birth: Date.parse('1950-01-01'),
+        date_of_birth: Date.parse('1900-01-01'),
         memorable_word: 'Memorable Word',
         status: 'complete',
         notes: 'This was good.',

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -159,6 +159,21 @@ RSpec.describe Appointment, type: :model do
     end
   end
 
+  describe '#imported?' do
+    it 'is true for appointments matching the imported (fake) date of birth' do
+      appointment = build_stubbed(
+        :appointment,
+        date_of_birth: AppointmentImporter::FAKE_DATE_OF_BIRTH
+      )
+
+      expect(appointment).to be_imported
+    end
+
+    it 'is false otherwise' do
+      expect(build_stubbed(:appointment)).to_not be_imported
+    end
+  end
+
   describe '#name' do
     subject { build_stubbed(:appointment, first_name: 'Joe', last_name: 'Bloggs') }
 


### PR DESCRIPTION
Marks freshly imported records with a more obviously fake date of birth.
This is to ensure guiders don't inadvertently read back the date of birth
to their customer.