### PR TITLE
Ensure hooks only respond to production requests

### DIFF
--- a/app/controllers/mail_gun/drops_controller.rb
+++ b/app/controllers/mail_gun/drops_controller.rb
@@ -14,6 +14,7 @@ module MailGun
         :event,
         :description,
         :appointment_id,
+        :environment,
         :timestamp,
         :token,
         :signature

--- a/app/forms/drop_form.rb
+++ b/app/forms/drop_form.rb
@@ -8,6 +8,7 @@ class DropForm
   attr_accessor :event
   attr_accessor :description
   attr_accessor :appointment_id
+  attr_accessor :environment
   attr_accessor :timestamp
   attr_accessor :token
   attr_accessor :signature
@@ -17,6 +18,7 @@ class DropForm
   validates :signature, presence: true
   validates :event, presence: true
   validates :appointment_id, presence: true
+  validates :environment, inclusion: { in: %w(production) }
 
   def create_activity
     return unless valid?

--- a/spec/forms/drop_form_spec.rb
+++ b/spec/forms/drop_form_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe DropForm, '#create_activity' do
       'event'          => 'dropped',
       'description'    => 'the reasoning',
       'appointment_id' => appointment.to_param,
+      'environment'    => 'production',
       'timestamp'      => '1474638633',
       'token'          => 'secret',
       'signature'      => 'abf02bef01e803bea52213cb092a31dc2174f63bcc2382ba25732f4c84e084c1'
@@ -36,6 +37,12 @@ RSpec.describe DropForm, '#create_activity' do
   end
 
   context 'when the signature is verified' do
+    it 'requires production environment' do
+      params['environment'] = 'staging'
+
+      expect(subject).not_to be_valid
+    end
+
     it 'requires an event' do
       params.delete('event')
 


### PR DESCRIPTION
This stops staging hooks firing and clobbering production records.
Having hooks running in the staging isn't important as drops are not
actioned in this environment. This matches the planner behaviour for
processing drop hooks.