### PR TITLE
Style appointments in the past in a lighter colour

### DIFF
--- a/app/assets/javascripts/modules/calendar.es6
+++ b/app/assets/javascripts/modules/calendar.es6
@@ -150,8 +150,12 @@ class Calendar extends TapBase {
 
   }
 
-  eventRender() {
+  eventRender(event, element) {
+    const now = moment();
 
+    if (event.end < now) {
+      element.addClass('fc--past');
+    }
   }
 
   eventAfterRender() {

--- a/app/assets/javascripts/modules/calendars/appointment-availability.es6
+++ b/app/assets/javascripts/modules/calendars/appointment-availability.es6
@@ -68,6 +68,8 @@
     }
 
     eventRender(event, element) {
+      super.eventRender(event, element);
+
       event.$div = $(element);
 
       element.html(`

--- a/app/assets/javascripts/modules/calendars/company.es6
+++ b/app/assets/javascripts/modules/calendars/company.es6
@@ -165,6 +165,8 @@ class CompanyCalendar extends Calendar {
   }
 
   eventRender(event, element, view) {
+    super.eventRender(event, element, view);
+
     $(element).attr('id', event.id);
 
     if (view.type === 'agendaDay') {

--- a/app/assets/javascripts/modules/calendars/guider-slot-picker.es6
+++ b/app/assets/javascripts/modules/calendars/guider-slot-picker.es6
@@ -66,6 +66,8 @@
     }
 
     eventRender(event, element) {
+      super.eventRender(event, element);
+
       if ($.inArray(event.start.format(this.initialDateTimeFormat), this.initialEventDateTimes) === -1) {
         this.setUnloadEvent();
       }

--- a/app/assets/javascripts/modules/calendars/my-appointments.es6
+++ b/app/assets/javascripts/modules/calendars/my-appointments.es6
@@ -65,6 +65,8 @@
     }
 
     eventRender(event, element, view) {
+      super.eventRender(event, element);
+
       if (event.source.rendering == 'background') {
         return;
       }

--- a/app/assets/stylesheets/components/_calendars.scss
+++ b/app/assets/stylesheets/components/_calendars.scss
@@ -1,11 +1,12 @@
 $calendar-today-background: $color-white;
-$calendar-cancelled-background: $color-guardsman-red;
 $calendar-moved-background: $color-green;
 $calendar-filter-box-shadow: transparentize($color-black, .825);
 $calendar-filter-arrow-border: transparentize($color-black, .8);
 $calendar-dragging-highlight: transparentize($color-givry, .1);
 $calendar-appointment-background: $color-boston-blue;
-$calendar-appointment-cancelled-background: $color-muddy-waters;
+$calendar-past-appointment-background: lighten($color-boston-blue, 20%);
+$calendar-appointment-cancelled-background: $color-medium-carmine;
+$calendar-past-appointment-cancelled-background: lighten($color-medium-carmine, 20%);
 $calendar-appointment-moved-background: $color-green;
 $calendar-holiday-anchor-visited: $color-white;
 $calendar-holiday-background: $color-alto;
@@ -213,16 +214,31 @@ $guider-row-height: 120px;
   z-index: 3;
 }
 
-.fc-event--cancelled {
-  @include striped($calendar-appointment-cancelled-background);
-
-  &:hover td {
-    @include striped($calendar-appointment-cancelled-background);
-  }
+.fc--past {
+  @include striped($calendar-past-appointment-background);
+  border-color: $calendar-past-appointment-background;
 }
 
 .fc-event--moved {
   @include striped($calendar-appointment-moved-background);
+}
+
+.fc-event--cancelled {
+  @include striped($calendar-appointment-cancelled-background);
+  border-color: $calendar-appointment-cancelled-background;
+
+  &:hover td {
+    @include striped($calendar-appointment-cancelled-background);
+  }
+
+  &.fc--past {
+    @include striped($calendar-past-appointment-cancelled-background);
+    border-color: $calendar-past-appointment-cancelled-background;
+
+    &:hover td {
+      @include striped($calendar-past-appointment-cancelled-background);
+    }
+  }
 }
 
 .fc-day-grid,

--- a/app/assets/stylesheets/lib/_colours.scss
+++ b/app/assets/stylesheets/lib/_colours.scss
@@ -1,6 +1,7 @@
 // Names from http://chir.ag/projects/name-that-color/
 $color-alto: #ddd;
 $color-black: #000;
+$color-medium-carmine: #ad3b3b;
 $color-boston-blue: #3a87ad;
 $color-feijoa: #8fdf82;
 $color-gallery: #ebebeb;
@@ -8,7 +9,6 @@ $color-givry: #f7f2c3;
 $color-green: #0c0;
 $color-guardsman-red: #c00;
 $color-madang: #c6f5c6;
-$color-muddy-waters: #bf886e;
 $color-roman: #d9534f;
 $color-silver: #ccc;
 $color-white: #fff;


### PR DESCRIPTION
<img width="1173" alt="screen shot 2016-12-05 at 15 22 56" src="https://cloud.githubusercontent.com/assets/6049076/20890423/bbf559b2-bafe-11e6-9571-ac498211118d.png">

- Appointments in the past get a lighter background colour
- this includes cancelled appointments which have got a
  slightly different red colour which has the same
  saturation as a non-cancelled appointment
- the lighter colour helps the user get a visual sense
  of what appointments have now happened