### PR TITLE
Ensure that ajax loading graphic shows when calendars first load

### DIFF
--- a/app/assets/javascripts/modules/calendar.es6
+++ b/app/assets/javascripts/modules/calendar.es6
@@ -53,7 +53,6 @@ class Calendar extends TapBase {
 
     this.insertJumpToDate();
     this.addAccessibilityImprovements();
-    this.insertLoadingView();
   }
 
   insertLoadingView() {
@@ -135,6 +134,10 @@ class Calendar extends TapBase {
   }
 
   loading(isLoading) {
+    if (!this.calendarLoadingView) {
+      this.insertLoadingView();
+    }
+
     if (isLoading && this.calendarLoadingView) {
       this.calendarLoadingView.removeClass('hide');
     } else if(this.calendarLoadingView) {

--- a/app/assets/javascripts/modules/calendar.es6
+++ b/app/assets/javascripts/modules/calendar.es6
@@ -56,6 +56,10 @@ class Calendar extends TapBase {
   }
 
   insertLoadingView() {
+    if (this.calendarLoadingView) {
+      return;
+    }
+
     this.calendarLoadingView = $(`
       <div class="calendar-loading hide">
         <div class="calendar-loading-spinner">
@@ -134,9 +138,7 @@ class Calendar extends TapBase {
   }
 
   loading(isLoading) {
-    if (!this.calendarLoadingView) {
-      this.insertLoadingView();
-    }
+    this.insertLoadingView();
 
     if (isLoading && this.calendarLoadingView) {
       this.calendarLoadingView.removeClass('hide');


### PR DESCRIPTION
![loading](https://cloud.githubusercontent.com/assets/6049076/20891032/08ca9bc4-bb01-11e6-8000-0b8699d7c588.jpg)

- Altered where calendar loading view gets inserted, to ensure
  that loading graphic is shown when calendar is first rendered