### PR TITLE
Don't allow holidays with backwards date ranges

### DIFF
--- a/app/assets/javascripts/modules/holiday-types.es6
+++ b/app/assets/javascripts/modules/holiday-types.es6
@@ -17,8 +17,8 @@
 
     toggleVisibility() {
       if (this.$multiDayCheckbox.prop('checked')) {
-        this.show(this.$multiDay);
         this.hide(this.$singleDay);
+        this.show(this.$multiDay);
       } else {
         this.hide(this.$multiDay);
         this.show(this.$singleDay);

--- a/app/assets/stylesheets/components/_holiday.scss
+++ b/app/assets/stylesheets/components/_holiday.scss
@@ -1,0 +1,9 @@
+.holiday-single-day-group {
+  .field_with_errors { // scss-lint:disable SelectorFormat
+    display: inline;
+  }
+
+  .holiday-single-day-group__label {
+    display: inline-block;
+  }
+}

--- a/app/controllers/holidays_controller.rb
+++ b/app/controllers/holidays_controller.rb
@@ -17,7 +17,10 @@ class HolidaysController < ApplicationController
   end
 
   def new
-    @holiday = BatchUpsertHolidays.new
+    @holiday = BatchUpsertHolidays.new(
+      start_at: Time.zone.now,
+      end_at: Time.zone.now
+    )
   end
 
   def create
@@ -79,20 +82,22 @@ class HolidaysController < ApplicationController
       .merge(bank_holiday: false)
   end
 
-  def batch_create_params
+  def batch_create_params # rubocop:disable Metrics/MethodLength
     params
       .require(:holiday)
       .permit(
         :title,
         :all_day,
-        :start_at,
-        :end_at
+        :single_day_start_at,
+        :single_day_end_at,
+        :multi_day_start_at,
+        :multi_day_end_at
       )
       .merge(users: user_ids)
   end
 
   def user_ids
-    params[:holiday][:users] || []
+    params[:holiday][:users].select(&:present?)
   end
 
   def starts

--- a/app/views/holidays/_form.html.erb
+++ b/app/views/holidays/_form.html.erb
@@ -23,14 +23,14 @@
       <%= form.check_box :all_day, label: 'This holiday lasts for multiple days', value: 'true', class: 'js-multi-day t-multi-day' %>
     </div>
   </div>
-  <div class="row js-multi-day-container t-multi-day-container">
+  <div class="row js-multi-day-container t-multi-day-container" style="display: none;">
     <div class="col-md-6">
       <%=
         form.text_field(
-          :start_at,
+          :multi_day_start_at,
           label: 'Date from',
           class: 't-start-at',
-          value: build_date_range_picker_date(holiday.start_at),
+          value: build_date_range_picker_date(holiday.multi_day_start_at),
           data: {
             module: 'date-range-picker',
             config: {
@@ -45,10 +45,10 @@
       %>
       <%=
         form.text_field(
-          :end_at,
+          :multi_day_end_at,
           label: 'Date to',
           class: 't-end-at',
-          value: build_date_range_picker_date(holiday.end_at),
+          value: build_date_range_picker_date(holiday.multi_day_end_at),
           data: {
             module: 'date-range-picker',
             config: {
@@ -64,13 +64,13 @@
     </div>
   </div>
 
-  <div class="row js-single-day-container t-single-day-container">
+  <div class="row js-single-day-container t-single-day-container" style="display: none;">
     <div class="col-md-6">
       <%=
         form.text_field(
-          :start_at,
+          :single_day_start_at,
           label: 'Date',
-          value: build_date_range_picker_date(holiday.start_at),
+          value: build_date_range_picker_date(holiday.single_day_start_at),
           class: 't-date',
           data: {
             module: 'date-range-picker',
@@ -86,15 +86,19 @@
       %>
     </div>
     <div class="col-md-12">
-      <div class="form-group">
-        <label>Start</label>
-        <!-- TODO: fix these labels -->
-        <%= form.time_select :start_at, { minute_step: 5 }, class: 'form-control', style: 'width: 65px; display: inline-block;' %>
+      <div class="form-group holiday-single-day-group">
+        <%= form.label :single_day_start_at, 'Start', class: 'holiday-single-day-group__label' %>
+        <%= form.time_select :single_day_start_at, { minute_step: 5 }, class: 'form-control', style: 'width: 65px; display: inline-block;' %>
 
-        <!-- TODO: fix these labels -->
-        <label style="margin-left: 10px">End</label>
-        <%= form.time_select :end_at, { minute_step: 5 }, class: 'form-control', style: 'width: 65px; display: inline-block;' %>
+        <%= form.label :single_day_end_at, 'End', class: 'holiday-single-day-group__label', style: 'margin-left: 10px' %>
+        <%= form.time_select :single_day_end_at, { minute_step: 5 }, class: 'form-control', style: 'width: 65px; display: inline-block;' %>
       </div>
+
+      <% if form.object.errors[:single_day_end_at].any? %>
+        <div class="has-error">
+          <span class="help-block text-left"><%= form.object.errors[:single_day_end_at].first %></span>
+        </div>
+      <% end %>
     </div>
   </div>
   <div class="row">

--- a/spec/support/sections/single_day.rb
+++ b/spec/support/sections/single_day.rb
@@ -1,10 +1,10 @@
 module Sections
   class SingleDay < SitePrism::Section
     element :date, '.t-date'
-    element :start_at_hour, '#holiday_start_at_4i'
-    element :start_at_minute, '#holiday_start_at_5i'
-    element :end_at_hour, '#holiday_end_at_4i'
-    element :end_at_minute, '#holiday_end_at_5i'
+    element :start_at_hour, '#holiday_single_day_start_at_4i'
+    element :start_at_minute, '#holiday_single_day_start_at_5i'
+    element :end_at_hour, '#holiday_single_day_end_at_4i'
+    element :end_at_minute, '#holiday_single_day_end_at_5i'
 
     def set_date_range(start_at, end_at)
       date.set I18n.l(start_at, format: :date_range_picker)


### PR DESCRIPTION
Needs some work:

- [x] When failing validation in one type (for example `all_day: true`), and then switching to the other type, the validation errors are still shown
- [x] Validation should fail when no users are selected

![image](https://cloud.githubusercontent.com/assets/363618/20975699/29124934-bc98-11e6-8999-bf10980d1695.png)

![image](https://cloud.githubusercontent.com/assets/363618/20975542/b564cb2e-bc97-11e6-9645-fa589cebe504.png)
