### PR TITLE
Refine allocation / assignment messages

### DIFF
--- a/app/models/assignment_activity.rb
+++ b/app/models/assignment_activity.rb
@@ -1,4 +1,18 @@
 class AssignmentActivity < Activity
+  ASSIGNED = 'assigned'.freeze
+
+  def message
+    if allocated?(super)
+      "#{owner.name} was allocated a new appointment"
+    else
+      "#{user_name} allocated this appointment to #{owner.name}"
+    end
+  end
+
+  def allocated?(type)
+    type == ASSIGNED
+  end
+
   def self.from(audit, appointment)
     if audit.action == 'create'
       create_assignment(audit, appointment)
@@ -10,7 +24,7 @@ class AssignmentActivity < Activity
   def self.create_assignment(audit, appointment)
     activity = create!(
       user_id: audit.user_id,
-      message: 'assigned',
+      message: ASSIGNED,
       appointment: appointment,
       owner: appointment.guider
     )

--- a/app/views/activities/_assignment_activity.html.erb
+++ b/app/views/activities/_assignment_activity.html.erb
@@ -1,4 +1,4 @@
 <% content_for(:activity_message, flush: true) do %>
-  <%= assignment_activity.message %> to <%= assignment_activity.owner.name %>
+  <%= assignment_activity.message %>
 <% end %>
 <%= render 'activities/activity', activity: assignment_activity, details: details %>

--- a/spec/features/guider_views_their_activities_spec.rb
+++ b/spec/features/guider_views_their_activities_spec.rb
@@ -47,8 +47,8 @@ RSpec.feature 'Guider views their activities' do
 
   def then_they_see_all_activities
     expect(@page.activities.map(&:text)).to match_array [
-      a_string_including('assigned'),
-      a_string_including('assigned'),
+      a_string_including('allocated a new'),
+      a_string_including('allocated a new'),
       a_string_including('created'),
       a_string_including('created')
     ]

--- a/spec/models/assignment_activity_spec.rb
+++ b/spec/models/assignment_activity_spec.rb
@@ -2,23 +2,23 @@ require 'rails_helper'
 
 RSpec.describe AssignmentActivity do
   describe '.from' do
-    before do
-      allow(PusherActivityNotificationJob).to receive(:perform_later)
-      @appointment = create(:appointment)
-    end
+    let(:appointment) { create(:appointment) }
+    let(:user) { create(:user) }
+    let(:audit) { appointment.audits.first }
 
-    let(:audit) { @appointment.audits.first }
-    subject { @appointment.activities.first }
+    before { allow(PusherActivityNotificationJob).to receive(:perform_later) }
+
+    subject { appointment.activities.first }
 
     context 'assignment' do
       it 'creates an assignment activity' do
         expect(subject).to be_a(described_class)
 
         expect(subject).to have_attributes(
-          appointment: @appointment,
-          owner: @appointment.guider,
+          appointment: appointment,
+          owner: appointment.guider,
           prior_owner: nil,
-          message: 'assigned'
+          message: "#{appointment.guider.name} was allocated a new appointment"
         )
       end
     end
@@ -26,37 +26,40 @@ RSpec.describe AssignmentActivity do
     it 'pushes an activity update' do
       expect(PusherActivityNotificationJob)
         .to have_received(:perform_later)
-        .with(@appointment.guider, subject)
+        .with(appointment.guider, subject)
     end
 
     context 'reassignment' do
+      let!(:prior_owner) { appointment.guider }
+
       before do
-        @prior_owner = @appointment.guider
-        @appointment.guider = create(:guider)
-        @appointment.save!
+        appointment.guider = create(:guider)
+        appointment.save!
+
+        subject.update!(user_id: user.id)
       end
 
       it 'creates an assignment activity' do
         expect(subject).to be_a(described_class)
 
         expect(subject).to have_attributes(
-          prior_owner: @prior_owner,
-          owner: @appointment.guider,
-          appointment_id: @appointment.id,
-          message: 'reassigned'
+          prior_owner: prior_owner,
+          owner: appointment.guider,
+          appointment_id: appointment.id,
+          message: "#{user.name} allocated this appointment to #{appointment.guider.name}"
         )
       end
 
       it 'pushes an activity update' do
         expect(PusherActivityNotificationJob)
           .to have_received(:perform_later)
-          .with(@appointment.guider, subject)
+          .with(appointment.guider, subject)
       end
 
       it 'pushes an activity update to the prior owner' do
         expect(PusherActivityNotificationJob)
           .to have_received(:perform_later)
-          .with(@prior_owner, subject)
+          .with(prior_owner, subject)
       end
     end
   end


### PR DESCRIPTION
The way these messages were worded prior to this change implied the
assignment was a user-driven activity. This is incorrect since
allocation is randomised and assigned via the system.

In the case of reassignment we now display richer text describing which
resource manager made the selection and which guider was selected.