### PR TITLE
Speed up appointments JSON responses

### DIFF
--- a/app/assets/javascripts/modules/calendars/company.es6
+++ b/app/assets/javascripts/modules/calendars/company.es6
@@ -26,7 +26,8 @@ class CompanyCalendar extends Calendar {
       eventTextColor: '#fff',
       eventSources: [
         {
-          url: '/appointments'
+          url: '/appointments',
+          cache: true
         },
         {
           url: '/holidays',

--- a/app/assets/javascripts/modules/calendars/my-appointments.es6
+++ b/app/assets/javascripts/modules/calendars/my-appointments.es6
@@ -20,7 +20,8 @@
         eventDataTransform: this.eventDataTransform,
         eventSources: [
           {
-            url: '/appointments?mine'
+            url: '/appointments?mine',
+            cache: true
           },
           {
             url: '/bookable_slots?mine',

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -11,7 +11,7 @@ class AppointmentsController < ApplicationController
   def index
     @appointments = appointment_scope.where(start_at: date_range_params)
 
-    render json: @appointments
+    render json: @appointments if stale?(@appointments)
   end
 
   def edit

--- a/db/migrate/20161208205325_add_start_at_index_on_appointments.rb
+++ b/db/migrate/20161208205325_add_start_at_index_on_appointments.rb
@@ -1,0 +1,5 @@
+class AddStartAtIndexOnAppointments < ActiveRecord::Migration[5.0]
+  def change
+    add_index :appointments, :start_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161202164324) do
+ActiveRecord::Schema.define(version: 20161208205325) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 20161202164324) do
     t.datetime "updated_at",                                 null: false
     t.integer  "agent_id",                                   null: false
     t.integer  "rebooked_from_id"
+    t.index ["start_at"], name: "index_appointments_on_start_at", using: :btree
   end
 
   create_table "audits", force: :cascade do |t|


### PR DESCRIPTION
Let the browser cache the responses based on the given etags. These
responses are trivially cacheable and testing locally shows that paging
back and forth through days that trigger conditional 304s drops the
response times for this endpoint down to ~100ms from ~500ms.

The recent `#stale?` addition performs checks to determine the freshness
of the given model / model collection instance by counting the elements
and retrieving the `MAX("appointments"."updated_at")`, merging the
same `where` clauses for the given model / model collection.

Since we had no index on this column this query was very slow (at least
in postgresql terms) in the order of `~100ms`. Adding this index drops
this down to `~1ms` which is quite some gain.
