### PR TITLE
Cache bookable slots responses

### DIFF
--- a/app/assets/javascripts/modules/calendars/company.es6
+++ b/app/assets/javascripts/modules/calendars/company.es6
@@ -37,6 +37,7 @@ class CompanyCalendar extends Calendar {
         },
         {
           url: '/bookable_slots',
+          cache: true,
           className: 'fc-bgevent--bookable-slot',
           rendering: 'background',
           eventType: 'slot'

--- a/app/assets/javascripts/modules/calendars/my-appointments.es6
+++ b/app/assets/javascripts/modules/calendars/my-appointments.es6
@@ -25,6 +25,7 @@
           },
           {
             url: '/bookable_slots?mine',
+            cache: true,
             className: 'fc-bgevent--bookable-slot',
             rendering: 'background',
             eventType: 'slot'

--- a/app/controllers/bookable_slots_controller.rb
+++ b/app/controllers/bookable_slots_controller.rb
@@ -1,10 +1,8 @@
 class BookableSlotsController < ApplicationController
   def index
-    slots = BookableSlot
-            .without_holidays
-            .within_date_range(start_at, end_at)
-    slots = slots.for_guider(current_user) if scoped_to_me?
-    render json: slots
+    @bookable_slots = bookable_slots
+
+    render json: @bookable_slots if stale?(@bookable_slots)
   end
 
   def available
@@ -20,6 +18,15 @@ class BookableSlotsController < ApplicationController
   end
 
   private
+
+  def bookable_slots
+    slots = BookableSlot
+            .without_holidays
+            .within_date_range(start_at, end_at)
+
+    slots = slots.for_guider(current_user) if scoped_to_me?
+    slots
+  end
 
   def start_at
     params[:start].to_date.beginning_of_day

--- a/db/migrate/20161209113503_add_timestamps_to_bookable_slots.rb
+++ b/db/migrate/20161209113503_add_timestamps_to_bookable_slots.rb
@@ -1,0 +1,15 @@
+class AddTimestampsToBookableSlots < ActiveRecord::Migration[5.0]
+  class BookableSlot < ApplicationRecord; end
+
+  def change
+    add_timestamps :bookable_slots, null: true
+
+    BookableSlot.update_all(
+      created_at: Time.zone.now,
+      updated_at: Time.zone.now
+    )
+
+    change_column_null :bookable_slots, :created_at, false
+    change_column_null :bookable_slots, :updated_at, false
+  end
+end

--- a/db/migrate/20161209134519_add_index_on_bookable_slots.rb
+++ b/db/migrate/20161209134519_add_index_on_bookable_slots.rb
@@ -1,0 +1,5 @@
+class AddIndexOnBookableSlots < ActiveRecord::Migration[5.0]
+  def change
+    add_index :bookable_slots, %i(start_at end_at)
+  end
+end

--- a/db/migrate/20161209134951_add_index_to_holidays.rb
+++ b/db/migrate/20161209134951_add_index_to_holidays.rb
@@ -1,0 +1,5 @@
+class AddIndexToHolidays < ActiveRecord::Migration[5.0]
+  def change
+    add_index :holidays, %i(start_at end_at)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161208205325) do
+ActiveRecord::Schema.define(version: 20161209113503) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,9 +73,11 @@ ActiveRecord::Schema.define(version: 20161208205325) do
   end
 
   create_table "bookable_slots", force: :cascade do |t|
-    t.integer  "guider_id", null: false
-    t.datetime "start_at",  null: false
-    t.datetime "end_at",    null: false
+    t.integer  "guider_id",  null: false
+    t.datetime "start_at",   null: false
+    t.datetime "end_at",     null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["guider_id"], name: "index_bookable_slots_on_guider_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161209113503) do
+ActiveRecord::Schema.define(version: 20161209134951) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define(version: 20161209113503) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["guider_id"], name: "index_bookable_slots_on_guider_id", using: :btree
+    t.index ["start_at", "end_at"], name: "index_bookable_slots_on_start_at_and_end_at", using: :btree
   end
 
   create_table "group_assignments", id: false, force: :cascade do |t|
@@ -103,6 +104,7 @@ ActiveRecord::Schema.define(version: 20161209113503) do
     t.datetime "updated_at",                   null: false
     t.boolean  "bank_holiday",                 null: false
     t.boolean  "all_day",      default: false, null: false
+    t.index ["start_at", "end_at"], name: "index_holidays_on_start_at_and_end_at", using: :btree
     t.index ["user_id"], name: "index_holidays_on_user_id", using: :btree
   end
 

--- a/spec/support/sections/calendar.rb
+++ b/spec/support/sections/calendar.rb
@@ -13,6 +13,8 @@ module Sections
     end
 
     def guiders
+      wait_until_resource_cells_visible
+
       resource_cells.map(&:text)
     end
 


### PR DESCRIPTION
Use conditional GETs for bookable slot responses. In order to generate the
cache digests, Rails needs timestamps on the models so I added those.

The changes surfaced a timing issue on guiders / resources so I also
addressed this issue.

Adding indexes on the start and end dates for both holidays and
bookable slots lends quite an improvement in querying response times across
the board since most queries require these clauses in unison.