### PR TITLE
Attempt to fix the spec timing issue with holiday

### DIFF
--- a/spec/features/resource_manager_manages_holidays_spec.rb
+++ b/spec/features/resource_manager_manages_holidays_spec.rb
@@ -248,7 +248,9 @@ RSpec.feature 'Resource manager manages holidays' do
   end
 
   def and_they_edit_the_multiple_day_holiday
+    @page.wait_until_events_visible
     @page.events.first.content.click
+
     @page = Pages::EditHoliday.new
     expect(@page).to be_displayed
     @page.title.set 'Some other holiday title'
@@ -261,7 +263,9 @@ RSpec.feature 'Resource manager manages holidays' do
   end
 
   def and_they_edit_the_single_day_holiday
+    @page.wait_until_events_visible
     @page.events.first.content.click
+
     @page = Pages::EditHoliday.new
     expect(@page).to be_displayed
     @page.title.set 'Some other holiday title'


### PR DESCRIPTION
This was failing intermittently due to what I suspect was a timing issue
around the presence of calendar events which are loaded asynchronously.