### PR TITLE
Parallelise specs across multiple processes

### DIFF
--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,0 +1,3 @@
+--format progress
+--format ParallelTests::RSpec::RuntimeLogger  --out tmp/parallel_runtime_rspec.log
+--format ParallelTests::RSpec::SummaryLogger  --out tmp/parallel_spec_summary.log

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ source 'https://rubygems.org' do
     gem 'factory_girl_rails', '~> 4.0'
     gem 'faker'
     gem 'launchy'
+    gem 'parallel_tests'
     gem 'pry-byebug'
     gem 'pusher-fake'
     gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,9 @@ GEM
     omniauth-oauth2 (1.3.1)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
+    parallel (1.10.0)
+    parallel_tests (2.10.0)
+      parallel
     parser (2.3.3.1)
       ast (~> 2.2)
     pg (0.19.0)
@@ -417,6 +420,7 @@ DEPENDENCIES
   lograge!
   momentjs-rails!
   newrelic_rpm!
+  parallel_tests!
   pg (~> 0.18)!
   phantomjs-binaries!
   plek!

--- a/config/database.yml
+++ b/config/database.yml
@@ -57,7 +57,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: telephone_appointment_planner_test
+  database: telephone_appointment_planner_test<%= ENV['TEST_ENV_NUMBER'] %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
Run specs in parallel across your multiple cores / processes. On my
machine this drops the spec runs to around 35 seconds.

You can still run `rake` as normal or `rspec` if you want to run specs
serially so this is opt-in for now. To get this setup on your machine
first pull this branch, then:

        $ bundle exec rake parallel:create

This creates multiple databases to run against.

        $ bundle exec rake parallel:prepare

This ensures each database is at the same version, migration-wise. You
should run this after running migrations as normal too.

Run the specs:

        $ bundle exec parallel_rspec

You can choose how many processes to run against by exporting
`PARALLEL_TEST_PROCESSORS=X` where `X` is the number of processes. A
good rule of thumb is to use the same number as physical cores.

I've not set this up in CI yet as I'm not entirely convinced it would make a
huge difference over there. I'll probably give it a try soon, to check.