### PR TITLE
Pass singular arguments to this job

### DIFF
--- a/app/jobs/generate_bookable_slots_for_user_job.rb
+++ b/app/jobs/generate_bookable_slots_for_user_job.rb
@@ -1,9 +1,7 @@
 class GenerateBookableSlotsForUserJob < ApplicationJob
   queue_as :default
 
-  def perform(*guiders)
-    guiders.each do |guider|
-      BookableSlot.generate_for_guider(guider)
-    end
+  def perform(guider)
+    BookableSlot.generate_for_guider(guider)
   end
 end

--- a/spec/jobs/generate_bookable_slots_for_user_job_spec.rb
+++ b/spec/jobs/generate_bookable_slots_for_user_job_spec.rb
@@ -1,16 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe GenerateBookableSlotsForUserJob, '#perform' do
-  let(:guiders) do
-    create_list(:guider, 2)
-  end
+  let(:guider) { create(:guider) }
 
-  it 'generates bookable slots for guiders' do
-    allow(BookableSlot).to receive(:generate_for_guider)
-    described_class.new.perform(*guiders)
+  it 'generates bookable slots for the given guider' do
+    expect(BookableSlot).to receive(:generate_for_guider).with(guider)
 
-    guiders.each do |guider|
-      expect(BookableSlot).to have_received(:generate_for_guider).with(guider)
-    end
+    described_class.new.perform(guider)
   end
 end


### PR DESCRIPTION
This was using variadic arguments needlessly since at each callsite we
pass a singular instance of a guider.