### PR TITLE
Notify guiders from anywhere when appointments change

### DIFF
--- a/app/assets/javascripts/modules/calendar-events.es6
+++ b/app/assets/javascripts/modules/calendar-events.es6
@@ -1,0 +1,50 @@
+/* global TapBase, Pusher */
+{
+  'use strict';
+
+  class CalendarEvents extends TapBase {
+    start(el) {
+      this.config = {};
+
+      super.start(el);
+      this.setupPusher();
+    }
+
+
+    setupPusher() {
+      const channel = Pusher.instance.subscribe('telephone_appointment_planner');
+
+      channel.bind(`${this.config.guiderId}`, this.handlePushEvent.bind(this));
+    }
+
+    handlePushEvent(payload) {
+      const $modal = $('#calendar-event-modal'),
+            $modalBody = $modal.find('.modal-body'),
+            $customer = $('<p class="t-customer"></p>'),
+            $start = $('<p class="t-start"></p>'),
+            $guider = $('<p class="t-guider"></p>');
+
+      $modalBody.empty();
+
+      $modalBody.append($('<p><b>Appointment updated</b></p>'));
+
+      $customer.text(`Customer: ${payload['customer_name']}`);
+      $modalBody.append($customer);
+
+      $start.text(`Date/Time: ${payload['start']}`);
+      $modalBody.append($start);
+
+      $guider.text(`Guider: ${payload['guider_name']}`);
+      $modalBody.append($guider);
+
+      $('.js-calendar-reload-on-events').each(function() {
+        $(this).fullCalendar('removeEvents');
+        $(this).fullCalendar('refetchEvents');
+      });
+      $modal.modal('show');
+    }
+
+  }
+
+  window.GOVUKAdmin.Modules.CalendarEvents = CalendarEvents;
+}

--- a/app/assets/javascripts/modules/calendars/company.es6
+++ b/app/assets/javascripts/modules/calendars/company.es6
@@ -138,7 +138,27 @@ class CompanyCalendar extends Calendar {
       return;
     }
 
-    const resource = this.$el.fullCalendar('getResourceById', event.resourceId);
+    const resource = this.$el.fullCalendar('getResourceById', event.resourceId),
+          $qtipContent = $(`
+
+    <div>
+      <p class="js-qtip-start"></p>
+      <p class="js-qtip-title"><span class="glyphicon glyphicon-phone-alt" aria-hidden="true"></span></p>
+      <p class="js-qtip-guider"><span class="glyphicon glyphicon-user" aria-hidden="true"></span></p>
+    </div>
+    `);
+    let $start = $("<span></span>"),
+        $title = $("<span></span>"),
+        $guider = $("<span></span>");
+
+    $start.text(`${event.start.format('HH:mm')} - ${event.end.format('HH:mm')}`);
+    $title.text(event.title);
+
+    $guider.append(resource && resource.title ? resource.title : 'Unknown guider');
+
+    $qtipContent.find('.js-qtip-start').append($start);
+    $qtipContent.find('.js-qtip-title').append($title);
+    $qtipContent.find('.js-qtip-guider').append($guider);
 
     element.qtip({
       position: {

--- a/app/assets/javascripts/modules/calendars/company.es6
+++ b/app/assets/javascripts/modules/calendars/company.es6
@@ -27,7 +27,8 @@ class CompanyCalendar extends Calendar {
       eventSources: [
         {
           url: '/appointments',
-          cache: true
+          cache: true,
+          eventType: 'appointment'
         },
         {
           url: '/holidays',
@@ -145,13 +146,7 @@ class CompanyCalendar extends Calendar {
         my: 'top right',
         at: 'bottom left'
       },
-      content: {
-        text: `
-        <p>${event.start.format('HH:mm')} - ${event.end.format('HH:mm')}</p>
-        <p><span class="glyphicon glyphicon-phone-alt" aria-hidden="true"></span> ${event.title}</p>
-        <p><span class="glyphicon glyphicon-user" aria-hidden="true"></span> ${resource && resource.title ? resource.title : 'Unknown guider'}</p>
-        `
-      }
+      content: { text: $qtipContent }
     });
   }
 

--- a/app/assets/javascripts/modules/calendars/my-appointments.es6
+++ b/app/assets/javascripts/modules/calendars/my-appointments.es6
@@ -1,4 +1,4 @@
-/* global Calendar, Pusher */
+/* global Calendar */
 {
   'use strict';
 
@@ -40,30 +40,6 @@
       };
 
       super.start(el);
-
-      this.guiderId = this.$el.data('guider-id');
-      this.setupPusher();
-    }
-
-    setupPusher() {
-      const channel = Pusher.instance.subscribe('telephone_appointment_planner');
-
-      channel.bind(`${this.guiderId}`, this.handlePushEvent.bind(this));
-    }
-
-    handlePushEvent(payload) {
-      const $modal = $('#my-appointments-calendar-update');
-
-      $modal.find('.modal-body').html(`
-        <p><b>Appointment updated</b></p>
-        <p class="t-customer">Customer: ${payload['customer_name']}</p>
-        <p class="t-start">Date/Time: ${payload['start']}</p>
-        <p class="t-guider">Guider: ${payload['guider_name']}</p>
-      `);
-
-      this.$el.fullCalendar('removeEvents');
-      this.$el.fullCalendar('refetchEvents');
-      $modal.modal('show');
     }
 
     eventRender(event, element, view) {

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -46,4 +46,3 @@
     <input type="hidden" name="changes" id="event-changes">
   <% end %>
 </div>
-

--- a/app/views/company_calendars/show.html.erb
+++ b/app/views/company_calendars/show.html.erb
@@ -7,7 +7,7 @@
 
   <div
     id="CompanyCalendar"
-    class="company-calendar js-calendar t-calendar"
+    class="company-calendar js-calendar js-calendar-reload-on-events t-calendar"
     data-module="company-calendar"
     data-default-date="<%= Time.zone.now %>"
     data-filter-select-id="filter_guiders">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,6 +34,22 @@
       })();
     </script>
   <% end %>
+  <div data-module="calendar-events" data-config='{ "guiderId": "<%= current_user.id %>"}'>
+    <div class="modal fade t-notification" id="calendar-event-modal" tabindex="-1" role="dialog" aria-labelledby="calendar-event-modal-label">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <h4 class="modal-title" id="calendar-event-modal-label">Appointment update</h4>
+          </div>
+          <div class="modal-body"></div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 <% end %>
 
 <%= render template: 'layouts/govuk_admin_template' %>

--- a/app/views/my_appointments/show.html.erb
+++ b/app/views/my_appointments/show.html.erb
@@ -3,23 +3,8 @@
 <h1>My appointments</h1>
 
 <div
-  class="t-calendar"
+  class="js-calendar-reload-on-events t-calendar"
   data-module="my-appointments-calendar"
   data-default-date="<%= Time.zone.now %>"
   data-guider-id="<%= current_user.id %>"
 ></div>
-
-<div class="modal fade t-notification" id="my-appointments-calendar-update" tabindex="-1" role="dialog" aria-labelledby="my-appointments-calendar-update-label">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title" id="my-appointments-calendar-update-label">Appointment update</h4>
-      </div>
-      <div class="modal-body"></div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-      </div>
-    </div>
-  </div>
-</div>

--- a/spec/support/sections/calendar.rb
+++ b/spec/support/sections/calendar.rb
@@ -4,6 +4,10 @@ module Sections
     elements :events, '.fc-event'
     elements :resource_cells, '.fc-resource-cell'
 
+    def appointments
+      background_events('appointment')
+    end
+
     def holidays
       background_events('holiday')
     end


### PR DESCRIPTION
TPAs have requested that guiders can see appointment change notifications from any page, not just the My Appointments page. This change fixes that, and also ensures that the relevant calendars are updated in the process.

Also, fix [HTML injection vulnerabilities](https://en.wikipedia.org/wiki/Code_injection#HTML_script_injection) in the qtip rendering and notification modal.