### PR TITLE
Log params while filtering sensitive information

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,11 @@ class ApplicationController < ActionController::Base
 
   protected
 
+  def append_info_to_payload(payload)
+    super
+    payload[:params] = request.filtered_parameters
+  end
+
   def authorise_for_guiders!
     authorise_user!(User::GUIDER_PERMISSION)
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,8 +1,15 @@
+EXCEPTIONS = %w(controller action format id).freeze
+
 Rails.application.configure do # rubocop:disable Metrics/BlockLength
   # Settings specified here will take precedence over those in config/application.rb.
 
   # use lograge and log in single-line heroku router style
   config.lograge.enabled = true
+  config.lograge.custom_options = lambda do |event|
+    {
+      params: event.payload[:params].except(*EXCEPTIONS)
+    }
+  end
 
   # Code is not reloaded between requests.
   config.cache_classes = true

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,12 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += %i(
+  first_name
+  last_name
+  email
+  phone
+  mobile
+  memorable_word
+  password
+)


### PR DESCRIPTION
Provides the necessary configuration to log params while honouring the
Rails `filter_parameters` configuration to strip sensitive information
from the logs.