### PR TITLE
Fix bug where all day holidays were showing up as 1 day less in length

### DIFF
--- a/app/models/holiday.rb
+++ b/app/models/holiday.rb
@@ -3,6 +3,8 @@ class Holiday < ApplicationRecord
 
   validates :user, presence: true, unless: :bank_holiday?
   validates :all_day, inclusion: [true, false]
+  validates :start_at, presence: true
+  validates :end_at, presence: true
 
   def self.merged_for_calendar_view
     select(

--- a/app/serializers/holiday_serializer.rb
+++ b/app/serializers/holiday_serializer.rb
@@ -5,7 +5,9 @@ class HolidaySerializer < ActiveModel::Serializer
   attribute :title
   attribute :all_day, key: :allDay
   attribute :start_at, key: :start
-  attribute :end_at, key: :end
+  attribute :end do
+    object.all_day? ? object.end_at + 1.day : object.end_at
+  end
   attribute :holiday_ids
   attribute :user_id, key: :resourceId
   attribute :resourceId do

--- a/spec/factories/holidays.rb
+++ b/spec/factories/holidays.rb
@@ -4,6 +4,8 @@ FactoryGirl.define do
     user { create(:guider) }
     bank_holiday false
     all_day false
+    start_at { Time.zone.now.at_midday }
+    end_at { Time.zone.now.at_midday + 1.hour }
 
     factory :bank_holiday do
       user nil

--- a/spec/features/resource_manager_manages_holidays_spec.rb
+++ b/spec/features/resource_manager_manages_holidays_spec.rb
@@ -148,7 +148,7 @@ RSpec.feature 'Resource manager manages holidays' do
         {
           title: 'Christmas',
           start_at: '2016-10-25',
-          end_at: '2016-10-27'
+          end_at: '2016-10-28'
         }
       ]
     )
@@ -210,7 +210,7 @@ RSpec.feature 'Resource manager manages holidays' do
     expect_holidays_to_match(
       title:    'Holiday Title',
       start_at: '2016-10-18',
-      end_at:   '2016-10-20'
+      end_at:   '2016-10-21'
     )
   end
 
@@ -283,7 +283,7 @@ RSpec.feature 'Resource manager manages holidays' do
     expect_holidays_to_match(
       title:    'Some other holiday title',
       start_at: '2016-10-18',
-      end_at:   '2016-10-20'
+      end_at:   '2016-10-21'
     )
   end
 

--- a/spec/models/holiday_spec.rb
+++ b/spec/models/holiday_spec.rb
@@ -7,6 +7,16 @@ RSpec.describe Holiday, type: :model do
       expect(holiday).to_not be_valid
     end
 
+    it 'requires start_at' do
+      holiday = build_stubbed(:holiday, start_at: nil)
+      expect(holiday).to_not be_valid
+    end
+
+    it 'requires end_at' do
+      holiday = build_stubbed(:holiday, end_at: nil)
+      expect(holiday).to_not be_valid
+    end
+
     context 'bank holiday' do
       it 'is valid with valid attributes' do
         holiday = build_stubbed(:holiday)


### PR DESCRIPTION
FullCalendar shows all day events exclusive of the end date, so
that means if we have a two day holiday, it will always show up as one
day in the all day slot.
To get around this we add one day to all holidays that are "all day".
Also see: http://stackoverflow.com/questions/27604359/fullcalendar-event-spanning-all-day-are-one-day-too-short