### PR TITLE
Delay showing of ajax loader

### DIFF
--- a/app/assets/javascripts/modules/calendar.es6
+++ b/app/assets/javascripts/modules/calendar.es6
@@ -140,11 +140,16 @@ class Calendar extends TapBase {
   loading(isLoading) {
     this.insertLoadingView();
 
-    if (isLoading && this.calendarLoadingView) {
-      this.calendarLoadingView.removeClass('hide');
-    } else if(this.calendarLoadingView) {
-      this.calendarLoadingView.addClass('hide');
+    if (!isLoading && this.calendarLoadingView) {
+      clearTimeout(this.loadingTimeout);
+      return this.calendarLoadingView.addClass('hide');
     }
+
+    this.loadingTimeout = setTimeout(() => {
+      if (isLoading && this.calendarLoadingView) {
+        this.calendarLoadingView.removeClass('hide');
+      }
+    }, 200);
   }
 
   eventDrop() {


### PR DESCRIPTION

<img width="891" alt="screen shot 2016-12-14 at 11 52 36" src="https://cloud.githubusercontent.com/assets/6049076/21181040/d7cedca2-c1f3-11e6-8402-7a747d207221.png">


- When ajax responses for appointments get returned really quickly
  we were seeing a quick flash of the ajax loader graphic
- there doesn't seem any point in showing the ajax loader unless
  the user is really seeing a slow response in getting data back
- now shows the ajax loader after 0.2 of a second