### PR TITLE
Allow slots that start directly after or end directly before holidays

### DIFF
--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -59,9 +59,9 @@ class BookableSlot < ApplicationRecord
             (
               (holidays.start_at < #{quoted_table_name}.start_at AND holidays.end_at > #{quoted_table_name}.end_at)
               OR
-              (holidays.start_at BETWEEN #{quoted_table_name}.start_at AND #{quoted_table_name}.end_at)
+              (holidays.start_at > #{quoted_table_name}.start_at AND holidays.start_at < #{quoted_table_name}.end_at)
               OR
-              (holidays.end_at BETWEEN #{quoted_table_name}.start_at AND #{quoted_table_name}.end_at)
+              (holidays.end_at > #{quoted_table_name}.start_at AND holidays.end_at < #{quoted_table_name}.end_at)
             )
             SQL
          )

--- a/spec/models/bookable_slot_spec.rb
+++ b/spec/models/bookable_slot_spec.rb
@@ -160,6 +160,28 @@ RSpec.describe BookableSlot, type: :model do
 
       expect(subject).to_not include slot
     end
+
+    it 'does not exclude slots that start directly after a holiday' do
+      create(
+        :holiday,
+        user: guider,
+        start_at: make_time(11, 30),
+        end_at: make_time(12, 30)
+      )
+
+      expect(subject).to include slot
+    end
+
+    it 'does not exclude slots that end directly before a holiday' do
+      create(
+        :holiday,
+        user: guider,
+        start_at: make_time(9, 30),
+        end_at: make_time(10, 30)
+      )
+
+      expect(subject).to include slot
+    end
   end
 
   describe '#with_guider_count' do


### PR DESCRIPTION
For example if a slot ends at 10:30 and a holiday starts at 10:30, we
now allow that slot to be booked. Also if a slot starts at 11:30 and a
holidays ends at 11:30 we also allow that slot to be booked. Previously
none of these would work.