### PR TITLE
Improve layout of review of new appointment

### DIFF
--- a/app/assets/stylesheets/components/_create_appointment.scss
+++ b/app/assets/stylesheets/components/_create_appointment.scss
@@ -1,0 +1,22 @@
+.appointment-preview__label {
+  display: block;
+  font-weight: bold;
+  float: left;
+  margin-right: 10px;
+  text-align: right;
+  width: 27%;
+}
+
+.appointment-preview__value {
+  display: block;
+  float: left;
+  width: 71%;
+}
+
+.appointment-preview__value--notes {
+  white-space: pre-wrap;
+}
+
+.appointment-preview__group {
+  overflow: hidden;
+}

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -18,7 +18,7 @@
   <%= render partial: 'personal_details_form', locals: { f: f } %>
   <div class="row form-group">
     <div class="col-md-12">
-      <%= f.submit "Preview appointment", class: 't-preview-appointment' %>
+      <%= f.submit "Continue", class: 't-preview-appointment' %>
     </div>
   </div>
 <% end %>

--- a/app/views/appointments/preview.html.erb
+++ b/app/views/appointments/preview.html.erb
@@ -1,11 +1,11 @@
 <%=
   breadcrumb(
     { title: 'Book an appointment', path: new_appointment_path },
-    { title: 'Preview' },
+    { title: 'Review appointment details' },
   )
 %>
 
-<h1>Preview appointment</h1>
+<h1>Review appointment details</h1>
 
 <%= rebooked_from_heading(@appointment) %>
 
@@ -29,59 +29,58 @@
   <%= f.hidden_field :opt_out_of_market_research %>
   <%= f.hidden_field :status %>
 
-  <div class="t-preview">
-    <ul class="list-group">
-      <li class="list-group-item">
-        <div><strong>Date:</strong></div>
-        <%= @appointment.start_at.to_date.to_s(:govuk_date) %>
-      </li>
-      <li class="list-group-item">
-        <div><strong>Start at:</strong></div>
-        <%= @appointment.start_at.to_time.to_s(:govuk_time) %>
-      </li>
-      <li class="list-group-item">
-        <div><strong>Duration:</strong></div>
-        45 minutes
-      </li>
-    </ul>
-    <ul class="list-group">
-      <li class="list-group-item">
-        <div><strong>Date of birth:</strong></div>
-        <%= @appointment.date_of_birth.to_date.to_s(:govuk_date)%>
-      </li>
-      <li class="list-group-item">
-        <div><strong>First name:</strong></div>
-        <%= @appointment.first_name %>
-      </li>
-      <li class="list-group-item">
-        <div><strong>Last name:</strong></div>
-        <%= @appointment.last_name %>
-      </li>
-      <li class="list-group-item">
-        <div><strong>Email:</strong></div>
-        <%= @appointment.email %>
-      </li>
-      <li class="list-group-item">
-        <div><strong>Phone:</strong></div>
-        <%= @appointment.phone %>
-      </li>
-      <li class="list-group-item">
-        <div><strong>Mobile:</strong></div>
-        <%= @appointment.mobile %>
-      </li>
-      <li class="list-group-item">
-        <div><strong>Memorable word:</strong></div>
-        <%= @appointment.memorable_word %>
-      </li>
-      <li class="list-group-item">
-        <div><strong>Notes:</strong></div>
-        <%= @appointment.notes %>
-      </li>
-      <li class="list-group-item">
-        <div><strong>Opt out of market research:</strong></div>
-        <%= @appointment.opt_out_of_market_research ? 'yes' : 'no' %>
-      </li>
-    </ul>
+  <div class="t-preview appointment-preview">
+    <div class="row">
+      <div class="col-md-8">
+        <div class="panel panel-primary">
+          <div class="panel-heading">Appointment Details</div>
+          <ul class="list-group">
+            <li class="list-group-item appointment-preview__group">
+              <span class="appointment-preview__label">Name</span>
+              <span class="appointment-preview__value"><%= @appointment.name %></span>
+            </li>
+            <li class="list-group-item appointment-preview__group">
+              <span class="appointment-preview__label">Date</span>
+              <span class="appointment-preview__value"><%= "#{@appointment.start_at.to_date.to_s(:govuk_date)} #{@appointment.start_at.to_time.to_s(:govuk_time)} (will last around 45 minutes)" %></span>
+            </li>
+          </ul>
+        </div>
+
+        <div class="panel panel-primary">
+          <div class="panel-heading">Customer Details</div>
+          <ul class="list-group">
+            <li class="list-group-item appointment-preview__group">
+              <span class="appointment-preview__label">Date of birth</span>
+              <span class="appointment-preview__value"><%= @appointment.date_of_birth.to_date.to_s(:govuk_date) %></span>
+            </li>
+            <li class="list-group-item appointment-preview__group">
+              <span class="appointment-preview__label">Email</span>
+              <span class="appointment-preview__value"><%= @appointment.email %></span>
+            </li>
+            <li class="list-group-item appointment-preview__group">
+              <span class="appointment-preview__label">Phone</span>
+              <span class="appointment-preview__value"><%= @appointment.phone %></span>
+            </li>
+            <li class="list-group-item appointment-preview__group">
+              <span class="appointment-preview__label">Mobile</span>
+              <span class="appointment-preview__value"><%= @appointment.mobile %></span>
+            </li>
+            <li class="list-group-item appointment-preview__group">
+              <span class="appointment-preview__label">Memorable word</span>
+              <span class="appointment-preview__value"><%= @appointment.memorable_word %></span>
+            </li>
+            <li class="list-group-item appointment-preview__group">
+              <span class="appointment-preview__label">Notes</span>
+              <span class="appointment-preview__value appointment-preview__value--notes"><%= @appointment.notes %></span>
+            </li>
+            <li class="list-group-item appointment-preview__group">
+              <span class="appointment-preview__label">Opt out of market research</span>
+              <span class="appointment-preview__value"><%= @appointment.opt_out_of_market_research ? 'Yes' : 'No' %></span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
   </div>
   <%= f.submit 'Confirm appointment', class: 't-confirm-appointment' %>
   <%= f.submit 'Edit appointment', name: :edit_appointment, class: 'btn-danger t-edit-appointment' %>

--- a/spec/features/agent_manages_appointments_spec.rb
+++ b/spec/features/agent_manages_appointments_spec.rb
@@ -159,19 +159,17 @@ RSpec.feature 'Agent manages appointments' do
     @page = Pages::PreviewAppointment.new
     expect(@page).to be_displayed
 
-    expect(@page.preview).to have_content "Date: #{day.to_date.to_s(:govuk_date)}"
-    expect(@page.preview).to have_content 'Start at: 9:30am'
-    expect(@page.preview).to have_content 'Duration: 45 minutes'
+    expect(@page.preview).to have_content "Date #{day.to_date.to_s(:govuk_date)} 9:30am"
+    expect(@page.preview).to have_content '(will last around 45 minutes)'
 
-    expect(@page.preview).to have_content 'Date of birth: 23 October 1950'
-    expect(@page.preview).to have_content 'First name: Some'
-    expect(@page.preview).to have_content 'Last name: Person'
-    expect(@page.preview).to have_content 'Email: email@example.org'
-    expect(@page.preview).to have_content 'Phone: 0000000'
-    expect(@page.preview).to have_content 'Mobile: 1111111'
-    expect(@page.preview).to have_content 'Memorable word: lozenge'
-    expect(@page.preview).to have_content 'Notes: something'
-    expect(@page.preview).to have_content 'Opt out of market research: yes'
+    expect(@page.preview).to have_content 'Date of birth 23 October 1950'
+    expect(@page.preview).to have_content 'Name Some Person'
+    expect(@page.preview).to have_content 'Email email@example.org'
+    expect(@page.preview).to have_content 'Phone 0000000'
+    expect(@page.preview).to have_content 'Mobile 1111111'
+    expect(@page.preview).to have_content 'Memorable word lozenge'
+    expect(@page.preview).to have_content 'Notes something'
+    expect(@page.preview).to have_content 'Opt out of market research Yes'
   end
 
   def and_they_fill_in_their_appointment_details_without_an_email


### PR DESCRIPTION

<img width="1190" alt="screen shot 2016-12-16 at 11 13 17" src="https://cloud.githubusercontent.com/assets/6049076/21260987/ae6b181a-c380-11e6-94b0-dbb1922a6a07.png">


- Combined certain fields so that it reads better when
  an agent is reading back details to a customer
- Make page shorter
- Improve copy (Preview -> Review)