### PR TITLE
Format first and last name for customer

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 class Appointment < ApplicationRecord
   belongs_to :agent, class_name: 'User'
 
@@ -50,6 +51,8 @@ class Appointment < ApplicationRecord
 
   audited on: %i(create update)
 
+  before_validation :format_name
+
   def self.copy_or_new_by(id)
     return new unless id
 
@@ -99,6 +102,11 @@ class Appointment < ApplicationRecord
   end
 
   private
+
+  def format_name
+    self.first_name = first_name.titleize if first_name
+    self.last_name  = last_name.titleize  if last_name
+  end
 
   def after_audit
     Activity.from(audits.last, self)

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -1,6 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe Appointment, type: :model do
+  describe 'formatting' do
+    it 'title-cases first and last name' do
+      appointment = build_stubbed(:appointment, first_name: 'bob', last_name: 'carolgees')
+      appointment.validate
+
+      expect(appointment).to have_attributes(
+        first_name: 'Bob',
+        last_name: 'Carolgees'
+      )
+    end
+  end
+
   describe 'validations' do
     let(:subject) do
       build_stubbed(:appointment)


### PR DESCRIPTION
This ensures customer names are cased correctly as the agents tend to
use a mixture of case when inputting names.