### PR TITLE
Hide bookable slots when holiday starts/ends at same time as the slot

### DIFF
--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -59,9 +59,9 @@ class BookableSlot < ApplicationRecord
             (
               (holidays.start_at < #{quoted_table_name}.start_at AND holidays.end_at > #{quoted_table_name}.end_at)
               OR
-              (holidays.start_at > #{quoted_table_name}.start_at AND holidays.start_at < #{quoted_table_name}.end_at)
+              (holidays.start_at >= #{quoted_table_name}.start_at AND holidays.start_at < #{quoted_table_name}.end_at)
               OR
-              (holidays.end_at > #{quoted_table_name}.start_at AND holidays.end_at < #{quoted_table_name}.end_at)
+              (holidays.end_at > #{quoted_table_name}.start_at AND holidays.end_at <= #{quoted_table_name}.end_at)
             )
             SQL
          )

--- a/spec/models/bookable_slot_spec.rb
+++ b/spec/models/bookable_slot_spec.rb
@@ -114,6 +114,40 @@ RSpec.describe BookableSlot, type: :model do
       BookableSlot.without_holidays
     end
 
+    context 'holiday starts at same time as bookable slot' do
+      # This issue was found in production:
+      # bookable slot = 8:30 to 9:40
+      # holiday       = 8:30 to 9:45
+
+      before do
+        create(
+          :holiday,
+          user: guider,
+          start_at: make_time(10, 30),
+          end_at: make_time(11, 45)
+        )
+      end
+
+      it 'excludes the slot' do
+        expect(subject).to_not include slot
+      end
+    end
+
+    context 'holiday ends at same time as bookable slot' do
+      before do
+        create(
+          :holiday,
+          user: guider,
+          start_at: make_time(9, 0),
+          end_at: make_time(11, 30)
+        )
+      end
+
+      it 'excludes the slot' do
+        expect(subject).to_not include slot
+      end
+    end
+
     it 'does not exclude everything' do
       expect(subject).to include slot
     end


### PR DESCRIPTION
In production we were having issues when holidays start at the exact same time as bookable slots, or end at the exact same time. We expected the slots to be hidden, but they were not.