### PR TITLE
Retry jobs until activity is committed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ end
 source 'https://rubygems.org' do
   gem 'active_link_to'
   gem 'active_model_serializers'
+  gem 'activejob-retry'
   gem 'audited'
   gem 'bh'
   gem 'bootstrap-kaminari-views'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,9 @@ GEM
     activejob (5.0.0.1)
       activesupport (= 5.0.0.1)
       globalid (>= 0.3.6)
+    activejob-retry (0.6.2)
+      activejob (>= 4.2)
+      activesupport (>= 4.2)
     activemodel (5.0.0.1)
       activesupport (= 5.0.0.1)
     activerecord (5.0.0.1)
@@ -400,6 +403,7 @@ PLATFORMS
 DEPENDENCIES
   active_link_to!
   active_model_serializers!
+  activejob-retry!
   audited!
   bh!
   bootstrap-kaminari-views!

--- a/app/jobs/pusher_activity_notification_job.rb
+++ b/app/jobs/pusher_activity_notification_job.rb
@@ -1,6 +1,8 @@
 class PusherActivityNotificationJob < ApplicationJob
   queue_as :default
 
+  include ActiveJob::Retry.new(strategy: :constant, limit: 5, delay: 1.second)
+
   include Rails.application.routes.url_helpers
 
   def perform(recipient, activity)


### PR DESCRIPTION
This is a weird one. The activities should be committed synchronously
before the jobs are scheduled but somehow this isn't occurring.

This is a temporary fix to ensure they're at least being run. The jobs
are retried up to a maximum of 5 times, with a 1 second delay between
each. This should recover the `ActiveJob::DeserializationError`
failures (in most cases I'd expect it to be successful upon the first
retry).