### PR TITLE
Fix HTML injection vulnerability on Appointments#search

### DIFF
--- a/app/presenters/appointment_search_result_presenter.rb
+++ b/app/presenters/appointment_search_result_presenter.rb
@@ -1,6 +1,8 @@
 class AppointmentSearchResultPresenter < SimpleDelegator
   DATE_FORMAT = '%d %B %Y %H:%M'.freeze
 
+  delegate :name, to: :guider, prefix: true
+
   def status
     super.titleize
   end
@@ -11,21 +13,5 @@ class AppointmentSearchResultPresenter < SimpleDelegator
 
   def date
     start_at.strftime(DATE_FORMAT)
-  end
-
-  def id
-    self[:highlighted_id] || super.to_s
-  end
-
-  def first_name
-    self[:highlighted_first_name] || super
-  end
-
-  def last_name
-    self[:highlighted_last_name] || super
-  end
-
-  def guider_name
-    self[:highlighted_name] || guider.name
   end
 end

--- a/app/views/appointments/search.html.erb
+++ b/app/views/appointments/search.html.erb
@@ -52,11 +52,11 @@
     <% @results.each do |result| %>
       <% result = AppointmentSearchResultPresenter.new(result) %>
       <tr class="t-result">
-        <td class="t-id"><span class="id js-allow-highlighting">#<%= result.id.html_safe %></span></td>
+        <td class="t-id"><span class="id js-allow-highlighting">#<%= result.id %></span></td>
         <td><%= result.created_at %></td>
-        <td class="t-first-name js-allow-highlighting"><%= result.first_name.html_safe %></td>
-        <td class="js-allow-highlighting"><%= result.last_name.html_safe %></td>
-        <td class="js-allow-highlighting"><%= result.guider_name.html_safe %></td>
+        <td class="t-first-name js-allow-highlighting"><%= result.first_name %></td>
+        <td class="js-allow-highlighting"><%= result.last_name %></td>
+        <td class="js-allow-highlighting"><%= result.guider_name %></td>
         <td><%= result.date %></td>
         <td><%= result.status %></td>
         <td nowrap="true">


### PR DESCRIPTION
Remove old code that was used when we handled search result highlighting
in the backend
