### PR TITLE
Fix bug where slots with cancelled+pending appointments weren't excluded

### DIFF
--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -31,25 +31,20 @@ class BookableSlot < ApplicationRecord
       .without_holidays
   end
 
-  # rubocop:disable Metrics/MethodLength
   def self.without_appointments
     joins(<<-SQL
             LEFT JOIN appointments ON
               appointments.guider_id = #{quoted_table_name}.guider_id AND
               appointments.start_at = #{quoted_table_name}.start_at AND
-              appointments.end_at = #{quoted_table_name}.end_at
-            SQL
-         )
-      .where(<<-SQL
-              appointments.start_at IS NULL OR
+              appointments.end_at = #{quoted_table_name}.end_at AND NOT
               appointments.status IN (
                 #{Appointment.statuses['cancelled_by_customer']},
                 #{Appointment.statuses['cancelled_by_pension_wise']}
               )
-              SQL
-            )
+            SQL
+         )
+      .where('appointments.start_at IS NULL')
   end
-  # rubocop:enable Metrics/MethodLength
 
   # rubocop:disable Metrics/MethodLength
   def self.without_holidays

--- a/spec/models/bookable_slot_spec.rb
+++ b/spec/models/bookable_slot_spec.rb
@@ -84,6 +84,24 @@ RSpec.describe BookableSlot, type: :model do
       expect(subject).to_not include slot
     end
 
+    it 'excludes slots with both a cancelled and a pending appointment' do
+      create(
+        :appointment,
+        guider: guider,
+        start_at: make_time(10, 30),
+        end_at: make_time(11, 30),
+        status: :cancelled_by_customer
+      )
+      create(
+        :appointment,
+        guider: guider,
+        start_at: make_time(10, 30),
+        end_at: make_time(11, 30),
+        status: :pending
+      )
+      expect(subject).to_not include slot
+    end
+
     it 'includes slots with cancelled appointments' do
       create(
         :appointment,


### PR DESCRIPTION
When a slot had both a cancelled and a pending appointment assigned to
them, then the slot still showed as available.