### PR TITLE
Don't use gem bundled phantomjs binaries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,6 @@ source 'https://rubygems.org' do
     gem 'chronic'
     gem 'coveralls', require: false
     gem 'database_rewinder'
-    gem 'phantomjs-binaries'
     gem 'poltergeist'
     gem 'scss_lint', require: false
   end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,8 +209,6 @@ GEM
     parser (2.3.3.1)
       ast (~> 2.2)
     pg (0.19.0)
-    phantomjs-binaries (2.1.1.1)
-      sys-uname (= 0.9.0)
     plek (1.12.0)
     poltergeist (1.11.0)
       capybara (~> 2.1)
@@ -366,8 +364,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sys-uname (0.9.0)
-      ffi (>= 1.0.0)
     term-ansicolor (1.4.0)
       tins (~> 1.0)
     thin (1.7.0)
@@ -424,7 +420,6 @@ DEPENDENCIES
   newrelic_rpm!
   parallel_tests!
   pg (~> 0.18)!
-  phantomjs-binaries!
   plek!
   poltergeist!
   pry-byebug!


### PR DESCRIPTION
Using homebrew's bottled binaries is so much faster on my local machine
when running the specs. I can only assume the `phantomjs-binaries` bundled
binary is built with weird or no optimisation flags.

This change alone yields at least a 20 second improvement on spec timings
for me and shouldn't impact anyone else. Just ensure you've the latest
phantomjs binary on your `PATH`.

Sometimes my tests were slow waiting for pusher's external asset to be served.
It has no bearing on the specs so we can blacklist it.