### PR TITLE
Combine customer first/last name on search results

### DIFF
--- a/app/views/appointments/search.html.erb
+++ b/app/views/appointments/search.html.erb
@@ -39,11 +39,10 @@
   <thead>
     <tr>
       <th>Reference</th>
-      <th>Created</th>
-      <th>First Name</th>
-      <th>Last Name</th>
+      <th>Customer</th>
       <th>Guider</th>
       <th>Appointment Date/Time</th>
+      <th>Created</th>
       <th>Status</th>
       <th width="1%">Actions</th>
     </tr>
@@ -53,11 +52,10 @@
       <% result = AppointmentSearchResultPresenter.new(result) %>
       <tr class="t-result">
         <td class="t-id"><span class="id js-allow-highlighting">#<%= result.id %></span></td>
-        <td><%= result.created_at %></td>
-        <td class="t-first-name js-allow-highlighting"><%= result.first_name %></td>
-        <td class="js-allow-highlighting"><%= result.last_name %></td>
+        <td class="t-name js-allow-highlighting"><%= result.name %></td>
         <td class="js-allow-highlighting"><%= result.guider_name %></td>
         <td><%= result.date %></td>
+        <td><%= result.created_at %></td>
         <td><%= result.status %></td>
         <td nowrap="true">
           <%= link_to edit_appointment_path(result), title: 'Edit appointment', class: 'btn btn-info' do %>

--- a/spec/features/agent_searches_for_appointments_spec.rb
+++ b/spec/features/agent_searches_for_appointments_spec.rb
@@ -9,10 +9,10 @@ RSpec.feature 'Agent searches for appointments' do
     end
   end
 
-  scenario 'searches for a first name' do
+  scenario 'searches for a name' do
     given_the_user_is_an_agent do
       and_appointments_exist
-      when_they_search_for_a_first_name
+      when_they_search_for_a_name
       then_they_see_that_appointment
     end
   end
@@ -26,10 +26,10 @@ RSpec.feature 'Agent searches for appointments' do
     end
   end
 
-  scenario 'searches for a first name with multiple results' do
+  scenario 'searches for a name with multiple results' do
     given_the_user_is_an_agent do
-      and_appointments_exist_with_the_same_first_name
-      when_they_search_for_a_first_name
+      and_appointments_exist_with_the_same_name
+      when_they_search_for_a_name
       then_they_can_see_those_filtered_appointments_only
     end
   end
@@ -44,7 +44,7 @@ RSpec.feature 'Agent searches for appointments' do
     ]
   end
 
-  def and_appointments_exist_with_the_same_first_name
+  def and_appointments_exist_with_the_same_name
     @appointments = [
       create(:appointment, first_name: 'Joe'),
       create(:appointment, first_name: 'Joe'),
@@ -63,12 +63,12 @@ RSpec.feature 'Agent searches for appointments' do
   end
 
   def then_they_can_see_those_filtered_appointments_only
-    expected = @appointments.select { |a| a.first_name == @expected_appointment.first_name }.map(&:first_name)
-    actual = @page.results.map(&:first_name).map(&:text)
+    expected = @appointments.select { |a| a.first_name == @expected_appointment.first_name }.map(&:name)
+    actual = @page.results.map(&:name).map(&:text)
     expect(actual).to eq expected
   end
 
-  def when_they_search_for_a_first_name
+  def when_they_search_for_a_name
     @page = Pages::Search.new.tap(&:load)
     @expected_appointment = @appointments.second
     @page.q.set(@expected_appointment.first_name)

--- a/spec/support/pages/search.rb
+++ b/spec/support/pages/search.rb
@@ -9,7 +9,7 @@ module Pages
 
     sections :results, '.t-result' do
       element :id, '.t-id'
-      element :first_name, '.t-first-name'
+      element :name, '.t-name'
     end
   end
 end


### PR DESCRIPTION
- Improves readability of customer name
- Moved created date to after appointment date, so dates
  are together