### PR TITLE
Don't rely on GlobalID for these job arguments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ source 'https://rubygems.org' do
   gem 'audited'
   gem 'bh'
   gem 'bootstrap-kaminari-views'
+  gem 'bugsnag'
   gem 'font-awesome-rails'
   gem 'foreman'
   gem 'gds-sso'
@@ -66,7 +67,6 @@ source 'https://rubygems.org' do
   end
 
   group :staging, :production do
-    gem 'bugsnag'
     gem 'lograge'
     gem 'rails_12factor'
   end

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -7,7 +7,7 @@ class ActivitiesController < ApplicationController
 
   def create
     @activity = MessageActivity.create(message_params)
-    PusherActivityNotificationJob.perform_later(appointment.guider, @activity)
+    PusherActivityNotificationJob.perform_later(appointment.guider_id, @activity.id)
     respond_to do |format|
       format.js { render @activity }
     end

--- a/app/jobs/pusher_activity_notification_job.rb
+++ b/app/jobs/pusher_activity_notification_job.rb
@@ -3,20 +3,37 @@ class PusherActivityNotificationJob < ApplicationJob
 
   include Rails.application.routes.url_helpers
 
-  def perform(recipient, activity)
+  rescue_from(ActiveRecord::RecordNotFound) do |exception|
+    Bugsnag.notify(exception)
+
+    retry_job(wait: 2.seconds)
+  end
+
+  def perform(recipient_id, activity_id)
+    recipient = User.find(recipient_id)
+    activity  = Activity.find(activity_id)
+
+    notify_guider(recipient, activity)
+    notify_appointment_feed(activity)
+  end
+
+  private
+
+  def notify_guider(recipient, activity)
     Pusher.trigger(
       'telephone_appointment_planner',
       "guider_activity_#{recipient.id}",
       body: render_activity(activity, true)
     )
+  end
+
+  def notify_appointment_feed(activity)
     Pusher.trigger(
       'telephone_appointment_planner',
       "appointment_activity_#{activity.appointment.id}",
       body: render_activity(activity, false)
     )
   end
-
-  private
 
   def render_activity(activity, details)
     ApplicationController.render(

--- a/app/models/assignment_activity.rb
+++ b/app/models/assignment_activity.rb
@@ -28,7 +28,8 @@ class AssignmentActivity < Activity
       appointment: appointment,
       owner: appointment.guider
     )
-    PusherActivityNotificationJob.perform_later(appointment.guider, activity)
+
+    PusherActivityNotificationJob.perform_later(appointment.guider_id, activity.id)
   end
 
   def self.create_reassignment(audit, appointment)
@@ -40,7 +41,8 @@ class AssignmentActivity < Activity
       owner: appointment.guider,
       prior_owner_id: prior_owner.id
     )
-    PusherActivityNotificationJob.perform_later(appointment.guider, activity)
-    PusherActivityNotificationJob.perform_later(prior_owner, activity)
+
+    PusherActivityNotificationJob.perform_later(appointment.guider_id, activity.id)
+    PusherActivityNotificationJob.perform_later(prior_owner.id, activity.id)
   end
 end

--- a/app/models/audit_activity.rb
+++ b/app/models/audit_activity.rb
@@ -8,7 +8,8 @@ class AuditActivity < Activity
       message: audit.audited_changes.keys.map(&:humanize).to_sentence.downcase,
       appointment_id: appointment.id
     )
-    PusherActivityNotificationJob.perform_later(appointment.guider, activity)
+
+    PusherActivityNotificationJob.perform_later(appointment.guider_id, activity.id)
   end
 
   def self.only_the_guider_has_been_changed?(audit)

--- a/app/models/create_activity.rb
+++ b/app/models/create_activity.rb
@@ -6,6 +6,7 @@ class CreateActivity < Activity
       appointment_id: appointment.id,
       owner_id: appointment.guider.id
     )
-    PusherActivityNotificationJob.perform_later(appointment.guider, activity)
+
+    PusherActivityNotificationJob.perform_later(appointment.guider_id, activity.id)
   end
 end

--- a/app/models/drop_activity.rb
+++ b/app/models/drop_activity.rb
@@ -5,7 +5,7 @@ class DropActivity < Activity
       appointment: appointment,
       owner: appointment.guider
     ).tap do |activity|
-      PusherActivityNotificationJob.perform_later(appointment.guider, activity)
+      PusherActivityNotificationJob.perform_later(appointment.guider_id, activity.id)
     end
   end
 end

--- a/spec/models/assignment_activity_spec.rb
+++ b/spec/models/assignment_activity_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe AssignmentActivity do
     it 'pushes an activity update' do
       expect(PusherActivityNotificationJob)
         .to have_received(:perform_later)
-        .with(appointment.guider, subject)
+        .with(appointment.guider_id, subject.id)
     end
 
     context 'reassignment' do
@@ -53,13 +53,13 @@ RSpec.describe AssignmentActivity do
       it 'pushes an activity update' do
         expect(PusherActivityNotificationJob)
           .to have_received(:perform_later)
-          .with(appointment.guider, subject)
+          .with(appointment.guider_id, subject.id)
       end
 
       it 'pushes an activity update to the prior owner' do
         expect(PusherActivityNotificationJob)
           .to have_received(:perform_later)
-          .with(prior_owner, subject)
+          .with(prior_owner.id, subject.id)
       end
     end
   end

--- a/spec/models/audit_activity_spec.rb
+++ b/spec/models/audit_activity_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe AuditActivity do
       it 'pushes an activity update' do
         expect(PusherActivityNotificationJob)
           .to have_received(:perform_later)
-          .with(@appointment.guider, subject)
+          .with(@appointment.guider_id, subject.id)
       end
     end
 

--- a/spec/models/create_activity_spec.rb
+++ b/spec/models/create_activity_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe CreateActivity do
     it 'pushes an activity update' do
       expect(PusherActivityNotificationJob)
         .to have_received(:perform_later)
-        .with(@appointment.guider, subject)
+        .with(@appointment.guider_id, subject.id)
     end
   end
 end

--- a/spec/models/drop_activity_spec.rb
+++ b/spec/models/drop_activity_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe DropActivity, '.from' do
 
   it 'notifies asynchronously' do
     expect(PusherActivityNotificationJob).to have_received(:perform_later).with(
-      appointment.guider,
-      subject
+      appointment.guider_id,
+      subject.id
     )
   end
 end


### PR DESCRIPTION
Rails enlists an emplicit transaction around `save` or `update`
operations and callbacks fire within this enlisted transaction. We hook
into the audited gem's `after_audit` callback to enqueue pusher
notification jobs but this causes a race condition that in circa 20% of
the time results in the job relying on this data being dequeued before
the database transaction has committed said data.

Thanks to the unique way in which Active Job deserializes model-based
arguments to the jobs, an `ActiveJob::DeserializationError` is raised
that is not retried in the traditional sense.

Changing the job arguments to their ID references means we sidestep this
behaviour so when dependent pieces of data cannot be retrieved using
`Model.find` an `ActiveRecord::RecordNotFound` error is raised and our
retry behaviour steps in to enqueue another identical job in a few
seconds time - with almost certainty that the transaction committed in
the meantime. Each failure is also reported to bugsnag for
instrumentation.

This is a quick workaround until we can better schedule the pusher jobs
outside of `save`s enlisted transaction. We are currently seeing failed
notifications in production so this is being deployed to ensure all
notifications are eventually delivered.