### PR TITLE
Improve accessibility and display of activity feed

### DIFF
--- a/app/assets/javascripts/modules/activity-feed.es6
+++ b/app/assets/javascripts/modules/activity-feed.es6
@@ -5,7 +5,13 @@
   class ActivityFeed extends TapBase {
     start(el) {
       super.start(el);
+
+      this.$showAllButton = $('.js-activity-show-all');
+      this.hideableClass = 'activity--hideable';
+      this.hideClass = 'activity--hide';
+
       this.setupPusher();
+      this.bindEvents();
     }
 
     setupPusher() {
@@ -27,6 +33,18 @@
           .prependTo(this.$el)
           .fadeIn();
       }
+    }
+
+    bindEvents() {
+      this.$showAllButton.on('click', this.handleShowAllClick.bind(this));
+    }
+
+    handleShowAllClick(event) {
+      const $button = $(event.currentTarget),
+        $target = $(`#${$button.attr('aria-controls')}`);
+
+      $button.attr('aria-expanded', $button.attr('aria-expanded') === 'false' ? 'true' : 'false');
+      $target.find(`.${this.hideableClass}`).toggleClass(this.hideClass);
     }
 
     isUnique($element) {

--- a/app/assets/stylesheets/components/_activity.scss
+++ b/app/assets/stylesheets/components/_activity.scss
@@ -4,10 +4,16 @@
 }
 
 .activity-details {
-  flex-basis: 75%;
+  flex-basis: 73%;
 }
 
 .activity-badge {
-  flex-basis: 25%;
+  flex-basis: 27%;
   text-align: right;
+}
+
+.activity--hide {
+  .js & {
+    display: none;
+  }
 }

--- a/app/assets/stylesheets/helper/_show_hide.scss
+++ b/app/assets/stylesheets/helper/_show_hide.scss
@@ -1,0 +1,7 @@
+.show-with-js {
+  display: none;
+
+  .js & {
+    display: block;
+  }
+}

--- a/app/jobs/pusher_activity_notification_job.rb
+++ b/app/jobs/pusher_activity_notification_job.rb
@@ -21,7 +21,7 @@ class PusherActivityNotificationJob < ApplicationJob
   def render_activity(activity, details)
     ApplicationController.render(
       partial: activity,
-      locals: { details: details }
+      locals: { details: details, hide: false }
     )
   end
 end

--- a/app/views/activities/_activity.html.erb
+++ b/app/views/activities/_activity.html.erb
@@ -1,7 +1,7 @@
 <% if details %>
   <a class="activity list-group-item t-activity" href="<%= edit_appointment_path(activity.appointment) %>">
 <% else %>
-  <li class="activity list-group-item t-activity" data-activity-id="<%= activity.id %>">
+  <li class="activity list-group-item t-activity <%= 't-hidden-activity activity--hideable activity--hide' if hide %>" data-activity-id="<%= activity.id %>">
 <% end %>
     <div class="activity-details">
       <%= content_for(:activity_message) %>

--- a/app/views/activities/_activity_feed.html.erb
+++ b/app/views/activities/_activity_feed.html.erb
@@ -18,15 +18,15 @@
         <% end %>
       </div>
 
-      <ul class="list-group" data-module="activity-feed" data-config='{"event": "appointment_activity_<%= appointment.id %>"}'>
-        <%= render(appointment.activities.first, details: false) if appointment.activities.present? %>
+      <ul class="list-group" aria-live="polite" data-module="activity-feed" id="activity-list" data-config='{"event": "appointment_activity_<%= appointment.id %>"}' aria-label="Activities">
+        <%= render(appointment.activities[0..2], details: false, hide: false) if appointment.activities.present? %>
+        <% if appointment.activities.count > 3 %>
+          <%= render(appointment.activities - Array(appointment.activities[0..2]), details: false, hide: true) %>
+        <% end %>
       </ul>
 
-      <% if appointment.activities.count > 1 %>
-        <ul class="list-group t-hidden-activities collapse" id="collapse">
-          <%= render(appointment.activities - Array(appointment.activities.first), details: false) %>
-        </ul>
-        <button class="btn btn-default t-further-activities" data-target="#collapse" data-toggle="collapse" aria-expanded="false" aria-controls="collapse">
+      <% if appointment.activities.count > 3 %>
+        <button class="show-with-js js-activity-show-all btn btn-default t-further-activities" aria-expanded="false" aria-controls="activity-list">
           <span class="glyphicon glyphicon-th-list" aria-hidden="true"></span>
           All activity
         </button>

--- a/app/views/activities/_assignment_activity.html.erb
+++ b/app/views/activities/_assignment_activity.html.erb
@@ -10,4 +10,4 @@
     <strong><%= assignment_activity.owner.name %></strong>
   <% end %>
 <% end %>
-<%= render 'activities/activity', activity: assignment_activity, details: details %>
+<%= render 'activities/activity', activity: assignment_activity, details: details, hide: hide %>

--- a/app/views/activities/_audit_activity.html.erb
+++ b/app/views/activities/_audit_activity.html.erb
@@ -3,4 +3,4 @@
   <strong><%= audit_activity.user_name %></strong>
   changed the <%= audit_activity.message %>
 <% end %>
-<%= render 'activities/activity', activity: audit_activity, details: details %>
+<%= render 'activities/activity', activity: audit_activity, details: details, hide: hide %>

--- a/app/views/activities/_create_activity.html.erb
+++ b/app/views/activities/_create_activity.html.erb
@@ -3,4 +3,4 @@
   <strong><%= create_activity.user_name %></strong>
   created this appointment
 <% end %>
-<%= render 'activities/activity', activity: create_activity, details: details %>
+<%= render 'activities/activity', activity: create_activity, details: details, hide: hide %>

--- a/app/views/activities/_drop_activity.html.erb
+++ b/app/views/activities/_drop_activity.html.erb
@@ -3,4 +3,4 @@
   <strong>The system</strong>
   reported a delivery failure: <em><%= drop_activity.message %></em>
 <% end %>
-<%= render 'activities/activity', activity: drop_activity, details: details %>
+<%= render 'activities/activity', activity: drop_activity, details: details, hide: hide %>

--- a/app/views/activities/_message_activity.html.erb
+++ b/app/views/activities/_message_activity.html.erb
@@ -3,4 +3,4 @@
   <strong><%= message_activity.user_name %></strong>
   said <em><%= message_activity.message %></em>
 <% end %>
-<%= render 'activities/activity', activity: message_activity, details: details %>
+<%= render 'activities/activity', activity: message_activity, details: details, hide: hide %>

--- a/app/views/activities/_reminder_activity.html.erb
+++ b/app/views/activities/_reminder_activity.html.erb
@@ -4,4 +4,4 @@
   sent an appointment reminder email to
   <strong><%= reminder_activity.appointment.name %></strong>
 <% end %>
-<%= render 'activities/activity', activity: reminder_activity, details: details %>
+<%= render 'activities/activity', activity: reminder_activity, details: details, hide: hide %>

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -6,7 +6,7 @@
   <div class="col-md-12 border-bottom">
     <div class="activity-feed activity-feed--with-links">
       <div class="list-group" data-module="activity-feed" data-config='{"event": "guider_activity_<%= current_user.id %>"}'>
-        <%= render(@activities, details: true) %>
+        <%= render(@activities, details: true, hide: false) %>
       </div>
     </div>
     <% if @activities.empty? %>

--- a/spec/features/user_views_booking_activities_spec.rb
+++ b/spec/features/user_views_booking_activities_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'User views appointment activities' do
       and_there_is_an_appointment
       and_the_appointment_was_updated_multiple_times
       when_they_view_the_appointment
-      then_they_see_the_last_activity
+      then_they_see_the_last_three_activities
       when_they_request_further_activities
       then_they_see_all_the_activities
       when_somebody_else_adds_an_activity
@@ -53,9 +53,9 @@ RSpec.feature 'User views appointment activities' do
     @appointment.update(email: 'mortimer@example.com')
   end
 
-  def then_they_see_the_last_activity
+  def then_they_see_the_last_three_activities
     @page.activity_feed.tap do |feed|
-      expect(feed).to have_activities(count: 1)
+      expect(feed).to have_activities(count: 3)
       expect(feed.activities.first).to have_text('email')
     end
   end
@@ -66,7 +66,7 @@ RSpec.feature 'User views appointment activities' do
 
   def then_they_see_all_the_activities
     @page.activity_feed.tap do |feed|
-      feed.wait_until_hidden_activities_visible
+      feed.wait_until_hidden_activity_visible
 
       expect(feed).to have_activities(count: 4)
       expect(feed.activities.last).to have_text('created')

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -25,7 +25,7 @@ module Pages
       element :submit, '.t-submit-message'
 
       element :further_activities, '.t-further-activities'
-      element :hidden_activities, '.t-hidden-activities'
+      element :hidden_activity, '.t-hidden-activity'
     end
 
     section :breadcrumb, '.t-breadcrumb' do


### PR DESCRIPTION

<img width="1209" alt="screen shot 2016-12-23 at 13 13 28" src="https://cloud.githubusercontent.com/assets/6049076/21454591/a218dfc0-c911-11e6-82aa-81dc2f6bf780.png">


- Show all the activities when JS is disabled
- Show up to three activities on page load
- One list instead of two for displaying activities
- aria-live="polite" on activities list so changes
  get read out to screen reader users