### PR TITLE
Correct pusher asset blacklisting during specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,8 +35,4 @@ RSpec.configure do |config|
   config.include ActionView::Helpers::DateHelper
 
   config.before(:each) { ActionMailer::Base.deliveries.clear }
-
-  config.before(:each, js: true) do
-    page.driver.browser.url_blacklist = %w(http://stats.pusher.com)
-  end
 end

--- a/spec/support/poltergeist.rb
+++ b/spec/support/poltergeist.rb
@@ -1,4 +1,8 @@
 require 'capybara/poltergeist'
 
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(app, url_blacklist: %w(/timeline/v2))
+end
+
 Capybara.javascript_driver = :poltergeist
 Capybara.default_max_wait_time = 10 if ENV['TRAVIS']


### PR DESCRIPTION
This yields a good improvement as the specs aren't unnecessarily
waiting around for pusher's analytics assets. It does however highlight
even more timing issues in our specs that were being masked by the long
wait times for these assets.