### PR TITLE
Wait for appointments explicitly

### DIFF
--- a/spec/features/guider_views_appointments_spec.rb
+++ b/spec/features/guider_views_appointments_spec.rb
@@ -90,6 +90,8 @@ RSpec.feature 'Guider views appointments' do
   def and_they_assign_the_appointment_to_another_guider
     @page = Pages::Allocations.new.tap(&:load)
     expect(@page).to be_displayed
+    @page.wait_until_appointments_visible
+
     @page.reassign(@page.appointments.first, guider: @other_guider)
     @page.wait_until_action_panel_visible
     @page.action_panel.save.click


### PR DESCRIPTION
We need to wait for the appointments to appear before we can interact
with them in the specs. This ensures that happens explicitly.