### PR TITLE
Correct email presence check

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -27,7 +27,7 @@ class Appointment < ApplicationRecord
       .includes(:activities)
       .where(start_at: Time.zone.now..24.hours.from_now)
       .where.not(
-        email: nil,
+        email: '',
         activities: {
           type: 'ReminderActivity', created_at: 12.hours.ago..12.hours.from_now
         }

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -296,7 +296,7 @@ RSpec.describe Appointment, type: :model do
 
       context 'appointment has no email address' do
         it 'does not need a reminder' do
-          appointment.update!(email: nil)
+          appointment.update!(email: '')
           expect(result).to_not include(appointment)
         end
       end


### PR DESCRIPTION
We default a missing email to an empty string, so our reminder guard
should check for the same criterion.