### PR TITLE
Fix flaky search spec

### DIFF
--- a/spec/features/agent_searches_for_appointments_spec.rb
+++ b/spec/features/agent_searches_for_appointments_spec.rb
@@ -63,8 +63,8 @@ RSpec.feature 'Agent searches for appointments' do
   end
 
   def then_they_can_see_those_filtered_appointments_only
-    expected = @appointments.select { |a| a.first_name == @expected_appointment.first_name }.map(&:name)
-    actual = @page.results.map(&:name).map(&:text)
+    expected = @appointments.select { |a| a.first_name == @expected_appointment.first_name }.map(&:name).sort
+    actual = @page.results.map(&:name).map(&:text).sort
     expect(actual).to eq expected
   end
 


### PR DESCRIPTION
1) Agent searches for appointments searches for a name with multiple results
   Failure/Error: expect(actual).to eq expected

     expected: ["Joe Bruen", "Joe O'kon"]
          got: ["Joe O'kon", "Joe Bruen"]