### PR TITLE
Hide bookable slots that are partially overlapped by appointments

### DIFF
--- a/spec/models/bookable_slot_spec.rb
+++ b/spec/models/bookable_slot_spec.rb
@@ -102,6 +102,28 @@ RSpec.describe BookableSlot, type: :model do
       expect(subject).to_not include slot
     end
 
+    it 'excludes slots with appointments that start inside them' do
+      create(
+        :appointment,
+        guider: guider,
+        start_at: make_time(10, 45),
+        end_at: make_time(12, 30),
+        status: :pending
+      )
+      expect(subject).to_not include slot
+    end
+
+    it 'excludes slots with appointments that end inside them' do
+      create(
+        :appointment,
+        guider: guider,
+        start_at: make_time(9, 45),
+        end_at: make_time(10, 35),
+        status: :pending
+      )
+      expect(subject).to_not include slot
+    end
+
     it 'includes slots with cancelled appointments' do
       create(
         :appointment,


### PR DESCRIPTION
If an appointment start_at or end_at is BETWEEN the bookable slot
start_at and end_at, then hide the bookable slot.

@benbarnett @benlovell thoughts?