### PR TITLE
Add a link to pre-populate the summary document

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -1,0 +1,11 @@
+module Api
+  module V1
+    class ApplicationController < ActionController::Base
+      include GDS::SSO::ControllerMethods
+
+      before_action { authorise_user!(User::PENSION_WISE_API_PERMISSION) }
+
+      wrap_parameters false
+    end
+  end
+end

--- a/app/controllers/api/v1/appointments_controller.rb
+++ b/app/controllers/api/v1/appointments_controller.rb
@@ -1,12 +1,6 @@
 module Api
   module V1
-    class AppointmentsController < ActionController::Base
-      include GDS::SSO::ControllerMethods
-
-      before_action { authorise_user!(User::PENSION_WISE_API_PERMISSION) }
-
-      wrap_parameters false
-
+    class AppointmentsController < Api::V1::ApplicationController
       def create
         @appointment = Api::V1::Appointment.new(appointment_params)
 

--- a/app/controllers/api/v1/summary_documents_controller.rb
+++ b/app/controllers/api/v1/summary_documents_controller.rb
@@ -1,0 +1,30 @@
+module Api
+  module V1
+    class SummaryDocumentsController < ActionController::Base
+      include GDS::SSO::ControllerMethods
+      before_action :require_signin_permission!
+
+      protect_from_forgery with: :null_session
+
+      def create
+        activity = SummaryDocumentActivity.new(summary_document_activity_params)
+        if activity.save
+          PusherActivityNotificationJob.perform_later(nil, activity.id)
+          head :created
+        else
+          render json: activity.errors, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def summary_document_activity_params
+        {
+          appointment_id: params[:appointment_id],
+          owner: User.find_by(uid: params[:owner_uid]),
+          message: params[:delivery_method]
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/summary_documents_controller.rb
+++ b/app/controllers/api/v1/summary_documents_controller.rb
@@ -1,11 +1,6 @@
 module Api
   module V1
-    class SummaryDocumentsController < ActionController::Base
-      include GDS::SSO::ControllerMethods
-      before_action :require_signin_permission!
-
-      protect_from_forgery with: :null_session
-
+    class SummaryDocumentsController < Api::V1::ApplicationController
       def create
         activity = SummaryDocumentActivity.new(summary_document_activity_params)
         if activity.save

--- a/app/jobs/pusher_activity_notification_job.rb
+++ b/app/jobs/pusher_activity_notification_job.rb
@@ -10,10 +10,10 @@ class PusherActivityNotificationJob < ApplicationJob
   end
 
   def perform(recipient_id, activity_id)
-    recipient = User.find(recipient_id)
+    recipient = User.find(recipient_id) if recipient_id
     activity  = Activity.find(activity_id)
 
-    notify_guider(recipient, activity)
+    notify_guider(recipient, activity) if recipient_id
     notify_appointment_feed(activity)
   end
 

--- a/app/lib/summary_document_link.rb
+++ b/app/lib/summary_document_link.rb
@@ -16,7 +16,7 @@ class SummaryDocumentLink
         reference_number: appointment.id,
         number_of_previous_appointments: 0,
         email: appointment.email,
-        appointment_type: (date_of_appointment - 55.years) > appointment.date_of_birth ? 'standard' : '50-54'
+        appointment_type: (date_of_appointment - 55.years) > appointment.date_of_birth ? 'standard' : '50_54'
       }.to_query(:appointment_summary)
     end
   end

--- a/app/lib/summary_document_link.rb
+++ b/app/lib/summary_document_link.rb
@@ -1,0 +1,23 @@
+class SummaryDocumentLink
+  class << self
+    attr_accessor :url
+
+    def generate(appointment)
+      "#{url}/appointment_summaries/new?#{query(appointment)}"
+    end
+
+    def query(appointment) # rubocop:disable Metrics/MethodLength
+      date_of_appointment = appointment.start_at.to_date
+      {
+        first_name: appointment.first_name,
+        last_name: appointment.last_name,
+        date_of_appointment: date_of_appointment.to_s,
+        guider_name: appointment.guider.name,
+        reference_number: appointment.id,
+        number_of_previous_appointments: 0,
+        email: appointment.email,
+        appointment_type: (date_of_appointment - 55.years) > appointment.date_of_birth ? 'standard' : '50-54'
+      }.to_query(:appointment_summary)
+    end
+  end
+end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -110,6 +110,10 @@ class Appointment < ApplicationRecord
     user.resource_manager? || start_at >= BusinessDays.from_now(2)
   end
 
+  def can_create_summary?
+    complete? || ineligible_age? || ineligible_pension_type?
+  end
+
   private
 
   def format_name

--- a/app/models/summary_document_activity.rb
+++ b/app/models/summary_document_activity.rb
@@ -1,0 +1,11 @@
+class SummaryDocumentActivity < Activity
+  validates :appointment, presence: true
+  validate :can_create_summary
+
+  private
+
+  def can_create_summary
+    return if appointment.nil? || appointment.can_create_summary?
+    errors.add(:appointment, 'is in an invalid state')
+  end
+end

--- a/app/views/activities/_summary_document_activity.html.erb
+++ b/app/views/activities/_summary_document_activity.html.erb
@@ -1,0 +1,6 @@
+<% content_for(:activity_message, flush: true) do %>
+  <span class="glyphicon glyphicon-print" aria-hidden="true"></span>
+  <strong><%= summary_document_activity.owner.name %></strong>
+  generated a <%= summary_document_activity.message %> summary document
+<% end %>
+<%= render 'activities/activity', activity: summary_document_activity, details: details, hide: hide %>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -16,11 +16,17 @@
 <% end %>
 
 <div class="row">
-  <div class="col-md-9">
+  <div class="col-md-7">
     <h1>Edit appointment for <%= @appointment.name %> <span class="text-muted"><span class="sr-only">Booking reference </span>#<%= @appointment.id %></span></h1>
     <%= rebooked_from_heading(@appointment) %>
   </div>
-  <div class="col-md-3 action-buttons">
+  <div class="col-md-5 action-buttons">
+    <% if @appointment.can_create_summary? %>
+      <%= link_to SummaryDocumentLink.generate(@appointment), title: 'Create summary', class: 'btn btn-info', target: '_blank' do %>
+        <span class="glyphicon glyphicon-print" aria-hidden="true"></span>
+        <span>Create Summary</span>
+      <% end %>
+    <% end %>
     <% if @appointment.can_be_rescheduled_by?(current_user) %>
       <%= link_to appointment_reschedule_path(@appointment), title: 'Reschedule appointment', class: 'btn btn-info' do %>
         <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span>

--- a/config/initializers/summary_document_url.rb
+++ b/config/initializers/summary_document_url.rb
@@ -1,0 +1,1 @@
+SummaryDocumentLink.url = ENV.fetch('SUMMARY_DOCUMENT_GENERATOR', 'http://localhost:3001')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
       resources :bookable_slots, only: :index
 
       resources :appointments, only: :create
+
+      resources :summary_documents, only: :create
     end
   end
 

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -302,6 +302,30 @@ RSpec.describe Appointment, type: :model do
     end
   end
 
+  describe '#can_create_summary?' do
+    let(:result) { Appointment.new(status: status).can_create_summary? }
+
+    %i(complete ineligible_age ineligible_pension_type).each do |status|
+      context "when status is #{status}" do
+        let(:status) { status }
+
+        it 'is true' do
+          expect(result).to be true
+        end
+      end
+    end
+
+    %i(pending no_show incomplete cancelled_by_customer cancelled_by_pension_wise).each do |status|
+      context "when status is #{status}" do
+        let(:status) { status }
+
+        it 'is false' do
+          expect(result).to be false
+        end
+      end
+    end
+  end
+
   describe '.needing_reminder' do
     let(:appointment) do
       create(

--- a/spec/requests/summary_documents_api_spec.rb
+++ b/spec/requests/summary_documents_api_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe 'POST /api/v1/summary_documents' do
+  scenario 'create a valid summary document activity' do
+    given_the_user_is_a_pension_wise_api_user do
+      and_a_completed_appointment_exists
+      when_the_client_posts_a_valid_summary_document_request
+      then_the_service_responds_with_a_201
+      and_the_appointment_has_a_summary_document_activity_created
+    end
+  end
+
+  scenario 'attempting to create an invalid summary document activity' do
+    given_the_user_is_a_pension_wise_api_user do
+      and_a_completed_appointment_exists
+      when_the_client_posts_an_invalid_summary_document_request
+      then_the_service_responds_with_a_422
+      and_the_errors_are_serialized_in_the_response
+    end
+  end
+
+  scenario 'attempting to create a summary document activity on a pending appointment' do
+    given_the_user_is_a_pension_wise_api_user do
+      and_a_pending_appointment_exists
+      when_the_client_posts_a_valid_summary_document_request
+      then_the_service_responds_with_a_422
+      and_the_pending_errors_are_serialized_in_the_response
+    end
+  end
+
+  def and_a_completed_appointment_exists
+    @appointment = create(:appointment, status: :complete)
+  end
+
+  def and_a_pending_appointment_exists
+    @appointment = create(:appointment)
+  end
+
+  def when_the_client_posts_a_valid_summary_document_request
+    payload = {
+      appointment_id: @appointment.id,
+      owner_uid: create(:user).uid,
+      delivery_method: 'postal'
+    }
+
+    post api_v1_summary_documents_path, params: payload, as: :json
+  end
+
+  def and_the_appointment_has_a_summary_document_activity_created
+    expect(@appointment.activities.where(type: SummaryDocumentActivity.name).count).to eq(1)
+  end
+
+  def when_the_client_posts_an_invalid_summary_document_request
+    payload = {
+      appointment_id: 0,
+      owner_uid: SecureRandom.uuid,
+      delivery_method: ''
+    }
+
+    post api_v1_summary_documents_path, params: payload, as: :json
+  end
+
+  def then_the_service_responds_with_a_422
+    expect(response).to be_unprocessable
+  end
+
+  def and_the_errors_are_serialized_in_the_response
+    JSON.parse(response.body).tap do |json|
+      expect(json.keys).to eq(%w(owner appointment))
+    end
+  end
+
+  def and_the_pending_errors_are_serialized_in_the_response
+    JSON.parse(response.body).tap do |json|
+      expect(json.keys).to eq(%w(appointment))
+    end
+  end
+
+  def then_the_service_responds_with_a_201
+    expect(response).to be_created
+  end
+end


### PR DESCRIPTION
* Allow guiders to open the summary document generator with data prepopulated
* add an endpoint so the summary document can trigger an activity entry once it has been created.

![screenshot 2017-01-17 11 09 52](https://cloud.githubusercontent.com/assets/63736/22018213/9c5df398-dca5-11e6-8b4b-be8bae77f544.png)

Need to set env variable:

```ruby
SUMMARY_DOCUMENT_GENERATOR
```