### PR TITLE
Add bookable slots API for customer booking

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,7 +28,9 @@ Style/FrozenStringLiteralComment:
 Metrics/MethodLength:
   Exclude:
     - 'spec/features/*'
+    - 'spec/requests/*'
 
 Metrics/AbcSize:
   Exclude:
     - 'spec/features/*'
+    - 'spec/requests/*'

--- a/app/controllers/api/v1/bookable_slots_controller.rb
+++ b/app/controllers/api/v1/bookable_slots_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module V1
+    class BookableSlotsController < ActionController::Base
+      include GDS::SSO::ControllerMethods
+
+      before_action { authorise_user!(User::PENSION_WISE_API_PERMISSION) }
+
+      def index
+        render json: BookableSlot.grouped
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   include GDS::SSO::User
 
   ALL_PERMISSIONS = [
+    PENSION_WISE_API_PERMISSION = 'pension_wise_api'.freeze,
     RESOURCE_MANAGER_PERMISSION = 'resource_manager'.freeze,
     GUIDER_PERMISSION           = 'guider'.freeze,
     AGENT_PERMISSION            = 'agent'.freeze,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,12 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
 
   root 'home#index'
 
+  namespace :api, constraints: { format: :json } do
+    namespace :v1 do
+      resources :bookable_slots, only: :index
+    end
+  end
+
   namespace :mail_gun do
     resources :drops, only: :create
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -31,5 +31,9 @@ FactoryGirl.define do
     factory :contact_centre_team_leader do
       permissions { Array(User::CONTACT_CENTRE_TEAM_LEADER_PERMISSION) }
     end
+
+    factory :pension_wise_api do
+      permissions { Array(User::PENSION_WISE_API_PERMISSION) }
+    end
   end
 end

--- a/spec/requests/bookable_slots_api_spec.rb
+++ b/spec/requests/bookable_slots_api_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /api/v1/bookable_slots' do
+  scenario 'retrieving slots for the booking window' do
+    travel_to '2017-01-10 12:00' do
+      given_the_user_is_a_pension_wise_api_user do
+        and_bookable_slots_for_the_booking_window_exist
+        when_they_request_bookable_slots
+        then_the_response_contains_unique_slots_for_the_booking_window
+      end
+    end
+  end
+
+  def and_bookable_slots_for_the_booking_window_exist
+    # three slots combined for one day
+    create(:bookable_slot, start_at: Time.zone.parse('2017-01-12 15:00'))
+    create_list(:bookable_slot, 2, start_at: Time.zone.parse('2017-01-12 12:00'))
+
+    # one slot for one day
+    create(:bookable_slot, start_at: Time.zone.parse('2017-01-13 14:00'))
+
+    # falls before the booking window
+    create(:bookable_slot, start_at: 1.day.from_now)
+
+    # falls after the booking window
+    create(:bookable_slot, start_at: 7.weeks.from_now)
+  end
+
+  def when_they_request_bookable_slots
+    get api_v1_bookable_slots_path, as: :json
+  end
+
+  def then_the_response_contains_unique_slots_for_the_booking_window
+    expect(response).to be_ok
+
+    JSON.parse(response.body).tap do |json|
+      expect(json.count).to eq(2)
+
+      expect(json['2017-01-12']).to eq(%w(12:00 15:00))
+
+      expect(json['2017-01-13']).to eq(%w(14:00))
+    end
+  end
+end

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -21,6 +21,10 @@ module UserHelpers
     GDS::SSO.test_user = nil
   end
 
+  def given_the_user_is_a_pension_wise_api_user(&block)
+    given_the_user(:pension_wise_api, &block)
+  end
+
   def given_the_user_is_a_contact_centre_team_leader(&block)
     given_the_user(:contact_centre_team_leader, &block)
   end


### PR DESCRIPTION
This adds a new JSON API endpoint at `/api/v1/bookable_slots` and
returns a payload like:

```
[
  "2017-01-01": [ "12:00", "13:00", "15:00" ],
  "2017-01-02": [ "12:10", "14:10" ]
]
```

It requires the `pension_wise_api` permission to be present for the
requesting user.

This first cut relies on grouping, de-duping and sorting in memory which
isn't ideal. The alternative turned into the beastiest SQL query I've
ever written and wasn't ideal for maintenance purposes, though a great
deal more performant.

Running this across the booking window (6 weeks) on a copy of the
production database, but in development mode yields the full response
in ~700ms.