### PR TITLE
Permit unauthenticated access to this API

### DIFF
--- a/app/controllers/api/v1/bookable_slots_controller.rb
+++ b/app/controllers/api/v1/bookable_slots_controller.rb
@@ -1,10 +1,6 @@
 module Api
   module V1
     class BookableSlotsController < ActionController::Base
-      include GDS::SSO::ControllerMethods
-
-      before_action { authorise_user!(User::PENSION_WISE_API_PERMISSION) }
-
       def index
         render json: BookableSlot.grouped
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,6 @@ class User < ApplicationRecord
   include GDS::SSO::User
 
   ALL_PERMISSIONS = [
-    PENSION_WISE_API_PERMISSION = 'pension_wise_api'.freeze,
     RESOURCE_MANAGER_PERMISSION = 'resource_manager'.freeze,
     GUIDER_PERMISSION           = 'guider'.freeze,
     AGENT_PERMISSION            = 'agent'.freeze,

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -31,9 +31,5 @@ FactoryGirl.define do
     factory :contact_centre_team_leader do
       permissions { Array(User::CONTACT_CENTRE_TEAM_LEADER_PERMISSION) }
     end
-
-    factory :pension_wise_api do
-      permissions { Array(User::PENSION_WISE_API_PERMISSION) }
-    end
   end
 end

--- a/spec/requests/bookable_slots_api_spec.rb
+++ b/spec/requests/bookable_slots_api_spec.rb
@@ -3,15 +3,13 @@ require 'rails_helper'
 RSpec.describe 'GET /api/v1/bookable_slots' do
   scenario 'retrieving slots for the booking window' do
     travel_to '2017-01-10 12:00' do
-      given_the_user_is_a_pension_wise_api_user do
-        and_bookable_slots_for_the_booking_window_exist
-        when_they_request_bookable_slots
-        then_the_response_contains_unique_slots_for_the_booking_window
-      end
+      given_bookable_slots_for_the_booking_window_exist
+      when_the_client_requests_bookable_slots
+      then_the_response_contains_unique_slots_for_the_booking_window
     end
   end
 
-  def and_bookable_slots_for_the_booking_window_exist
+  def given_bookable_slots_for_the_booking_window_exist
     # three slots combined for one day
     create(:bookable_slot, start_at: Time.zone.parse('2017-01-12 15:00'))
     create_list(:bookable_slot, 2, start_at: Time.zone.parse('2017-01-12 12:00'))
@@ -26,7 +24,7 @@ RSpec.describe 'GET /api/v1/bookable_slots' do
     create(:bookable_slot, start_at: 7.weeks.from_now)
   end
 
-  def when_they_request_bookable_slots
+  def when_the_client_requests_bookable_slots
     get api_v1_bookable_slots_path, as: :json
   end
 

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -21,10 +21,6 @@ module UserHelpers
     GDS::SSO.test_user = nil
   end
 
-  def given_the_user_is_a_pension_wise_api_user(&block)
-    given_the_user(:pension_wise_api, &block)
-  end
-
   def given_the_user_is_a_contact_centre_team_leader(&block)
     given_the_user(:contact_centre_team_leader, &block)
   end


### PR DESCRIPTION
This is public information once it gets bound to the slot picker so
there is really no need to require authentication.