### PR TITLE
Don't rely on natural ordering

### DIFF
--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -40,6 +40,7 @@ class BookableSlot < ApplicationRecord
       .within_date_range(from, to)
       .select("#{quoted_table_name}.start_at::date as start_date")
       .select("to_char(#{quoted_table_name}.start_at, 'HH24:MI') as start_time")
+      .order('start_date asc')
       .group_by(&:start_date)
       .transform_values { |value| value.map(&:start_time).uniq.sort }
   end

--- a/spec/requests/bookable_slots_api_spec.rb
+++ b/spec/requests/bookable_slots_api_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe 'GET /api/v1/bookable_slots' do
   end
 
   def given_bookable_slots_for_the_booking_window_exist
+    # one slot for one day
+    create(:bookable_slot, start_at: Time.zone.parse('2017-01-13 14:00'))
+
     # three slots combined for one day
     create(:bookable_slot, start_at: Time.zone.parse('2017-01-12 15:00'))
     create_list(:bookable_slot, 2, start_at: Time.zone.parse('2017-01-12 12:00'))
-
-    # one slot for one day
-    create(:bookable_slot, start_at: Time.zone.parse('2017-01-13 14:00'))
 
     # falls before the booking window
     create(:bookable_slot, start_at: 1.day.from_now)
@@ -32,11 +32,11 @@ RSpec.describe 'GET /api/v1/bookable_slots' do
     expect(response).to be_ok
 
     JSON.parse(response.body).tap do |json|
-      expect(json.count).to eq(2)
-
       expect(json['2017-01-12']).to eq(%w(12:00 15:00))
 
       expect(json['2017-01-13']).to eq(%w(14:00))
+
+      expect(json.keys).to eq(%w(2017-01-12 2017-01-13))
     end
   end
 end


### PR DESCRIPTION
Ordering was busted since we weren't explicitly ordering before doing
the necessary transformations. We now order by the sliced up / grouped
start date for the bookable slot.