### PR TITLE
Use the full timestamp in the slots response

### DIFF
--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -39,10 +39,10 @@ class BookableSlot < ApplicationRecord
     bookable
       .within_date_range(from, to)
       .select("#{quoted_table_name}.start_at::date as start_date")
-      .select("to_char(#{quoted_table_name}.start_at, 'HH24:MI') as start_time")
+      .select("#{quoted_table_name}.start_at")
       .order('start_date asc')
       .group_by(&:start_date)
-      .transform_values { |value| value.map(&:start_time).uniq.sort }
+      .transform_values { |value| value.map(&:start_at).uniq.sort }
   end
 
   def self.without_appointments # rubocop:disable Metrics/MethodLength

--- a/spec/requests/bookable_slots_api_spec.rb
+++ b/spec/requests/bookable_slots_api_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe 'GET /api/v1/bookable_slots' do
     expect(response).to be_ok
 
     JSON.parse(response.body).tap do |json|
-      expect(json['2017-01-12']).to eq(%w(12:00 15:00))
+      expect(json['2017-01-12']).to eq(%w(2017-01-12T12:00:00.000Z 2017-01-12T15:00:00.000Z))
 
-      expect(json['2017-01-13']).to eq(%w(14:00))
+      expect(json['2017-01-13']).to eq(%w(2017-01-13T14:00:00.000Z))
 
       expect(json.keys).to eq(%w(2017-01-12 2017-01-13))
     end


### PR DESCRIPTION
To avoid unnecessary parsing tricks on the client we now need to return
the full ISO timestamp for the individual bookable slots.