### PR TITLE
Correct boolean output for opt-in flag

### DIFF
--- a/app/forms/appointment_report.rb
+++ b/app/forms/appointment_report.rb
@@ -43,13 +43,7 @@ class AppointmentReport
       .select('appointments.first_name')
       .select('appointments.last_name')
       .select('appointments.notes')
-      .select(<<-SQL
-                CASE WHEN appointments.opt_out_of_market_research IS NOT NULL
-                  THEN 'true'
-                  ELSE 'false'
-                END AS opt_out_of_market_research
-              SQL
-             )
+      .select('appointments.opt_out_of_market_research::text')
       .select('appointments.date_of_birth')
       .select('appointments.id AS booking_reference')
       .select('appointments.memorable_word')


### PR DESCRIPTION
Since we corrected the data internally we only store these as
non-nullable booleans. Knowing this we can just cast to `text` instead
of the more complex `CASE`, reporting incorrectly.