### PR TITLE
Introduce bookings API

### DIFF
--- a/app/controllers/api/v1/appointments_controller.rb
+++ b/app/controllers/api/v1/appointments_controller.rb
@@ -6,10 +6,14 @@ module Api
       before_action { authorise_user!(User::PENSION_WISE_API_PERMISSION) }
 
       def create
-        @appointment = Appointment.new(appointment_params).create
-        AppointmentMailer.confirmation(@appointment).deliver_later
+        @appointment = Appointment.new(appointment_params)
 
-        head :created
+        if @appointment.create
+          AppointmentMailer.confirmation(@appointment.model).deliver_later
+          head :created
+        else
+          render json: @appointment.errors, status: :unprocessable_entity
+        end
       end
 
       private

--- a/app/controllers/api/v1/appointments_controller.rb
+++ b/app/controllers/api/v1/appointments_controller.rb
@@ -1,0 +1,31 @@
+module Api
+  module V1
+    class AppointmentsController < ActionController::Base
+      include GDS::SSO::ControllerMethods
+
+      before_action { authorise_user!(User::PENSION_WISE_API_PERMISSION) }
+
+      def create
+        @appointment = Appointment.new(appointment_params).create
+        AppointmentMailer.confirmation(@appointment).deliver_later
+
+        head :created
+      end
+
+      private
+
+      def appointment_params
+        params.permit(
+          :start_at,
+          :first_name,
+          :last_name,
+          :email,
+          :phone,
+          :memorable_word,
+          :date_of_birth,
+          :dc_pot_confirmed
+        ).merge(agent: current_user)
+      end
+    end
+  end
+end

--- a/app/forms/api/v1/appointment.rb
+++ b/app/forms/api/v1/appointment.rb
@@ -13,20 +13,20 @@ module Api
       attr_accessor :dc_pot_confirmed
       attr_accessor :agent
 
-      attr_reader :appointment
+      attr_reader :model
 
       def initialize(*)
         super
 
-        @appointment = Models::Appointment.new(to_params)
+        @model = Models::Appointment.new(to_params)
       end
 
       def create
-        appointment.tap do |a|
-          a.assign_to_guider
-          a.save!
-        end
+        model.assign_to_guider
+        model.save
       end
+
+      delegate :errors, to: :model
 
       private
 

--- a/app/forms/api/v1/appointment.rb
+++ b/app/forms/api/v1/appointment.rb
@@ -1,0 +1,53 @@
+module Api
+  module V1
+    class Appointment
+      include ActiveModel::Model
+
+      attr_accessor :start_at
+      attr_accessor :first_name
+      attr_accessor :last_name
+      attr_accessor :email
+      attr_accessor :phone
+      attr_accessor :memorable_word
+      attr_accessor :date_of_birth
+      attr_accessor :dc_pot_confirmed
+      attr_accessor :agent
+
+      attr_reader :appointment
+
+      def initialize(*)
+        super
+
+        @appointment = Models::Appointment.new(to_params)
+      end
+
+      def create
+        appointment.tap do |a|
+          a.assign_to_guider
+          a.save!
+        end
+      end
+
+      private
+
+      def end_at
+        Time.zone.parse(start_at) + 1.hour
+      end
+
+      def to_params # rubocop:disable Metrics/MethodLength
+        {
+          start_at: start_at,
+          end_at: end_at,
+          first_name: first_name,
+          last_name: last_name,
+          email: email,
+          phone: phone,
+          date_of_birth: date_of_birth,
+          memorable_word: memorable_word,
+          dc_pot_confirmed: dc_pot_confirmed,
+          agent: agent
+        }
+      end
+    end
+  end
+end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -144,3 +144,7 @@ class Appointment < ApplicationRecord
     agent.present? && agent.resource_manager?
   end
 end
+
+module Models
+  Appointment = ::Appointment
+end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -44,12 +44,14 @@ class Appointment < ApplicationRecord
   validates :phone, presence: true
   validates :date_of_birth, presence: true
   validates :memorable_word, presence: true
+  validates :dc_pot_confirmed, presence: true
   validates :status, presence: true
   validates :guider, presence: true
 
   validate :not_within_two_business_days, unless: :agent_is_resource_manager?
   validate :not_more_than_thirty_business_days_in_future
   validate :date_of_birth_valid
+  validate :email_valid, if: :agent_is_pension_wise_api?
 
   has_many :activities, -> { order('created_at DESC') }
 
@@ -136,12 +138,25 @@ class Appointment < ApplicationRecord
     errors.add(:date_of_birth, 'must be at least 1900') if date_of_birth_pre_cut_off?
   end
 
+  def email_valid
+    unless /.+@.+\..+/ === email.to_s # rubocop:disable Style/CaseEquality, Style/GuardClause
+      errors.add(
+        :email,
+        'must be valid'
+      )
+    end
+  end
+
   def date_of_birth_pre_cut_off?
     date_of_birth? && date_of_birth < FAKE_DATE_OF_BIRTH
   end
 
   def agent_is_resource_manager?
     agent.present? && agent.resource_manager?
+  end
+
+  def agent_is_pension_wise_api?
+    agent && agent.pension_wise_api?
   end
 end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   include GDS::SSO::User
 
   ALL_PERMISSIONS = [
+    PENSION_WISE_API_PERMISSION = 'pension_wise_api'.freeze,
     RESOURCE_MANAGER_PERMISSION = 'resource_manager'.freeze,
     GUIDER_PERMISSION           = 'guider'.freeze,
     AGENT_PERMISSION            = 'agent'.freeze,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,4 +38,8 @@ class User < ApplicationRecord
   def contact_centre_team_leader?
     has_permission?(CONTACT_CENTRE_TEAM_LEADER_PERMISSION)
   end
+
+  def pension_wise_api?
+    has_permission?(PENSION_WISE_API_PERMISSION)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   namespace :api, constraints: { format: :json } do
     namespace :v1 do
       resources :bookable_slots, only: :index
+
+      resources :appointments, only: :create
     end
   end
 

--- a/db/migrate/20170113163304_add_dc_pot_confirmed_to_appointments.rb
+++ b/db/migrate/20170113163304_add_dc_pot_confirmed_to_appointments.rb
@@ -1,0 +1,5 @@
+class AddDcPotConfirmedToAppointments < ActiveRecord::Migration[5.0]
+  def change
+    add_column :appointments, :dc_pot_confirmed, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161221152514) do
+ActiveRecord::Schema.define(version: 20170113163304) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,8 @@ ActiveRecord::Schema.define(version: 20161221152514) do
     t.datetime "updated_at",                                 null: false
     t.integer  "agent_id",                                   null: false
     t.integer  "rebooked_from_id"
+    t.boolean  "dc_pot_confirmed",           default: true,  null: false
+    t.index ["start_at", "end_at"], name: "index_appointments_on_start_at_and_end_at", using: :btree
     t.index ["start_at"], name: "index_appointments_on_start_at", using: :btree
   end
 

--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -10,6 +10,7 @@ FactoryGirl.define do
     mobile '07715 930 444'
     notes 'This customer is very nice.'
     opt_out_of_market_research true
+    dc_pot_confirmed true
     memorable_word 'lozenge'
     date_of_birth '1945-01-01'
     guider { create(:guider) }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -31,5 +31,9 @@ FactoryGirl.define do
     factory :contact_centre_team_leader do
       permissions { Array(User::CONTACT_CENTRE_TEAM_LEADER_PERMISSION) }
     end
+
+    factory :pension_wise_api_user do
+      permissions { Array(User::PENSION_WISE_API_PERMISSION) }
+    end
   end
 end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -35,13 +35,34 @@ RSpec.describe Appointment, type: :model do
       :memorable_word,
       :guider,
       :agent,
-      :date_of_birth
+      :date_of_birth,
+      :dc_pot_confirmed
     ]
     required.each do |field|
       it "validate presence of #{field}" do
         subject.public_send("#{field}=", nil)
         subject.validate
         expect(subject.errors[field]).to_not be_empty
+      end
+    end
+
+    context 'when created by an API agent' do
+      it 'requires a reasonably valid email' do
+        appointment = build_stubbed(
+          :appointment,
+          email: 'a.com',
+          agent: build(:pension_wise_api_user)
+        )
+
+        expect(appointment).to_not be_valid
+      end
+    end
+
+    context 'when created by a non-API agent' do
+      it 'does not require an email' do
+        subject.email = ''
+
+        expect(subject).to be_valid
       end
     end
 

--- a/spec/requests/appointments_api_spec.rb
+++ b/spec/requests/appointments_api_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe 'POST /api/v1/appointments' do
+  scenario 'create a valid appointment' do
+    travel_to '2017-01-10 12:00' do
+      given_the_user_is_a_pension_wise_api_user do
+        and_a_bookable_slot_exists_for_the_given_appointment_date
+        when_the_client_posts_a_valid_appointment_request
+        then_the_service_responds_with_a_201
+        and_the_appointment_is_created
+        and_the_customer_receives_a_confirmation_email
+      end
+    end
+  end
+
+  def and_a_bookable_slot_exists_for_the_given_appointment_date
+    @bookable_slot = create(:bookable_slot, start_at: Time.zone.parse('2017-01-13 12:10'))
+  end
+
+  def when_the_client_posts_a_valid_appointment_request
+    @payload = {
+      'start_at'         => '2017-01-13T12:10:00.000Z',
+      'first_name'       => 'Rick',
+      'last_name'        => 'Sanchez',
+      'email'            => 'rick@example.com',
+      'phone'            => '02082524729',
+      'memorable_word'   => 'snootboop',
+      'date_of_birth'    => '1950-02-02',
+      'dc_pot_confirmed' => true
+    }
+
+    post api_v1_appointments_path, params: @payload, as: :json
+  end
+
+  def then_the_service_responds_with_a_201
+    expect(response).to be_created
+  end
+
+  def and_the_appointment_is_created
+    Appointment.last.tap do |appointment|
+      expect(appointment.guider).to be_present
+      expect(appointment.agent).to  be_present
+
+      expect(appointment).to have_attributes(
+        start_at: Time.zone.parse('2017-01-13 12:10'),
+        end_at: Time.zone.parse('2017-01-13 13:10'),
+        date_of_birth: Date.parse('1950-02-02'),
+        first_name: 'Rick',
+        last_name: 'Sanchez',
+        email: 'rick@example.com',
+        phone: '02082524729',
+        memorable_word: 'snootboop',
+        dc_pot_confirmed: true
+      )
+    end
+  end
+
+  def and_the_customer_receives_a_confirmation_email
+    expect(ActionMailer::Base.deliveries.map(&:to)).to include(%w(rick@example.com))
+  end
+end

--- a/spec/requests/appointments_api_spec.rb
+++ b/spec/requests/appointments_api_spec.rb
@@ -13,6 +13,42 @@ RSpec.describe 'POST /api/v1/appointments' do
     end
   end
 
+  scenario 'attempting to create an invalid appointment' do
+    travel_to '2017-01-10 12:00' do
+      given_the_user_is_a_pension_wise_api_user do
+        and_a_bookable_slot_exists_for_the_given_appointment_date
+        when_the_client_posts_an_invalid_appointment_request
+        then_the_service_responds_with_a_422
+        and_the_errors_are_serialized_in_the_response
+      end
+    end
+  end
+
+  def when_the_client_posts_an_invalid_appointment_request
+    @payload = {
+      'start_at'         => '2017-01-13T12:10:00.000Z',
+      'first_name'       => '',
+      'last_name'        => '',
+      'email'            => 'rick@example.com',
+      'phone'            => '02082524729',
+      'memorable_word'   => 'snootboop',
+      'date_of_birth'    => '1950-02-02',
+      'dc_pot_confirmed' => true
+    }
+
+    post api_v1_appointments_path, params: @payload, as: :json
+  end
+
+  def then_the_service_responds_with_a_422
+    expect(response).to be_unprocessable
+  end
+
+  def and_the_errors_are_serialized_in_the_response
+    JSON.parse(response.body).tap do |json|
+      expect(json.keys).to eq(%w(first_name last_name))
+    end
+  end
+
   def and_a_bookable_slot_exists_for_the_given_appointment_date
     @bookable_slot = create(:bookable_slot, start_at: Time.zone.parse('2017-01-13 12:10'))
   end

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -21,6 +21,10 @@ module UserHelpers
     GDS::SSO.test_user = nil
   end
 
+  def given_the_user_is_a_pension_wise_api_user(&block)
+    given_the_user(:pension_wise_api_user, &block)
+  end
+
   def given_the_user_is_a_contact_centre_team_leader(&block)
     given_the_user(:contact_centre_team_leader, &block)
   end


### PR DESCRIPTION
This provides the basis for the bookings API at:

`POST /api/v1/appointments`

Callers will need the `pension_wise_api` permission from signon.

The form object is versioned using the same scheme as the API but since
the model and form classes are the same and Rails scoping is stupid,
I've had to dud alias the model class under a `Models` namespace so we
can qualify the scoping when calling the model `Appointment` from the
API `Appointment`.