### PR TITLE
Ensure no slots are generated on weekends

### DIFF
--- a/app/assets/javascripts/modules/calendars/guider-slot-picker.es6
+++ b/app/assets/javascripts/modules/calendars/guider-slot-picker.es6
@@ -168,13 +168,15 @@
         eventsToAdd = [];
 
       for (let currentDate = moment(calendarStartDate); currentDate < calendarEndDate; currentDate.add(1, 'days')) {
-        for (let eventIndex in events) {
-          let currentEvent = events[eventIndex];
+        if (currentDate.day() != 0 && currentDate.day() != 6) {
+          for (let eventIndex in events) {
+            let currentEvent = events[eventIndex];
 
-          eventsToAdd.push({
-            start: `${currentDate.format('YYYY-MM-DD')}T${currentEvent.start}`,
-            end: `${currentDate.format('YYYY-MM-DD')}T${currentEvent.end}`
-          });
+            eventsToAdd.push({
+              start: `${currentDate.format('YYYY-MM-DD')}T${currentEvent.start}`,
+              end: `${currentDate.format('YYYY-MM-DD')}T${currentEvent.end}`
+            });
+          }
         }
       }
 

--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -2,4 +2,6 @@ class Slot < ApplicationRecord
   belongs_to :schedule
 
   default_scope { order(:day_of_week) }
+
+  validates :day_of_week, inclusion: (1..5)
 end

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -40,7 +40,7 @@
           { "start": "13:30", "end": "14:40" },
           { "start": "14:50", "end": "16:00" }
         ]'>Early</button>
-        <button type="button" class="btn btn-default" data-events='[
+        <button type="button" class="btn btn-default t-mid" data-events='[
           { "start": "09:30", "end": "10:40" },
           { "start": "10:50", "end": "12:00" },
           { "start": "12:20", "end": "13:30" },

--- a/db/migrate/20170116164058_remove_slots_that_fall_on_weekends.rb
+++ b/db/migrate/20170116164058_remove_slots_that_fall_on_weekends.rb
@@ -1,0 +1,6 @@
+class RemoveSlotsThatFallOnWeekends < ActiveRecord::Migration[5.0]
+  def change
+    Slot.where(day_of_week: 0).delete_all
+    Slot.where(day_of_week: 6).delete_all
+  end
+end

--- a/spec/factories/schedules.rb
+++ b/spec/factories/schedules.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     user { build(:user) }
     start_at { Time.zone.now.beginning_of_day }
 
-    days = 1.upto(6)
+    days = 1.upto(5)
 
     trait :with_early_shift do
       slots do

--- a/spec/features/resource_manager_manages_schedules_spec.rb
+++ b/spec/features/resource_manager_manages_schedules_spec.rb
@@ -53,6 +53,19 @@ RSpec.feature 'Resource manager manages schedules' do
     end
   end
 
+  scenario 'Adds a mid shift schedule', js: true do
+    given_the_user_is_a_resource_manager do
+      and_there_is_a_guider
+      and_they_add_a_new_schedule
+      and_they_set_the_initial_start_at_date
+      and_they_add_the_default_mid_shift_slots
+      when_they_save_the_users_time_slots
+      then_they_are_told_that_the_schedule_has_been_created
+      and_the_guider_has_the_mid_shift_time_slots_available
+      and_the_guider_bookable_slots_are_regenerated
+    end
+  end
+
   def and_there_is_a_guider
     @guider = create(:guider, name: 'Davey Daverson')
   end
@@ -95,6 +108,16 @@ RSpec.feature 'Resource manager manages schedules' do
     click_on_day_and_time 'Monday', '09:00'
     click_on_day_and_time 'Tuesday', '10:30'
     expect(@page).to have_events(count: 2)
+  end
+
+  def and_they_add_the_default_mid_shift_slots
+    @page.mid.click
+  end
+
+  def and_the_guider_has_the_mid_shift_time_slots_available
+    schedule = @guider.schedules.first
+
+    expect(schedule.slots.count).to eq 25
   end
 
   def when_they_save_the_users_time_slots

--- a/spec/models/slot_spec.rb
+++ b/spec/models/slot_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Slot do
+  describe 'validations' do
+    subject do
+      Slot.new(
+        day_of_week: 3
+      )
+    end
+
+    it 'is valid with valid attributes' do
+      expect(subject).to be_valid
+    end
+
+    it 'day_of_week can not fall on a Saturday' do
+      subject.day_of_week = 6
+      expect(subject).to_not be_valid
+    end
+
+    it 'day_of_week can not fall on a Sunday' do
+      subject.day_of_week = 0
+      expect(subject).to_not be_valid
+    end
+  end
+end

--- a/spec/support/pages/new_schedule.rb
+++ b/spec/support/pages/new_schedule.rb
@@ -6,5 +6,6 @@ module Pages
 
     element :save, '.t-save'
     element :start_at, '.t-start-at'
+    element :mid, '.t-mid'
   end
 end


### PR DESCRIPTION
- Delete slots that were created on Saturdays and Sundays.
- Stop adding weekend slots in JS
- Stop adding weekend slots in db:seed

http://momentjs.com/docs/#/get-set/day/

NOTE: Whoever merges this MUST run `rake jobs:bookable_slots:generate`.