### PR TITLE
Accept opt-out preference in appointments API

### DIFF
--- a/app/controllers/api/v1/appointments_controller.rb
+++ b/app/controllers/api/v1/appointments_controller.rb
@@ -18,7 +18,7 @@ module Api
 
       private
 
-      def appointment_params
+      def appointment_params # rubocop:disable Metrics/MethodLength
         params.permit(
           :start_at,
           :first_name,
@@ -27,7 +27,8 @@ module Api
           :phone,
           :memorable_word,
           :date_of_birth,
-          :dc_pot_confirmed
+          :dc_pot_confirmed,
+          :opt_out_of_market_research
         ).merge(agent: current_user)
       end
     end

--- a/app/forms/api/v1/appointment.rb
+++ b/app/forms/api/v1/appointment.rb
@@ -11,6 +11,7 @@ module Api
       attr_accessor :memorable_word
       attr_accessor :date_of_birth
       attr_accessor :dc_pot_confirmed
+      attr_accessor :opt_out_of_market_research
       attr_accessor :agent
 
       attr_reader :model
@@ -45,6 +46,7 @@ module Api
           date_of_birth: date_of_birth,
           memorable_word: memorable_word,
           dc_pot_confirmed: dc_pot_confirmed,
+          opt_out_of_market_research: opt_out_of_market_research,
           agent: agent
         }
       end

--- a/spec/requests/appointments_api_spec.rb
+++ b/spec/requests/appointments_api_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe 'POST /api/v1/appointments' do
       'phone'            => '02082524729',
       'memorable_word'   => 'snootboop',
       'date_of_birth'    => '1950-02-02',
-      'dc_pot_confirmed' => true
+      'dc_pot_confirmed' => true,
+      'opt_out_of_market_research' => true
     }
 
     post api_v1_appointments_path, params: @payload, as: :json
@@ -62,7 +63,8 @@ RSpec.describe 'POST /api/v1/appointments' do
       'phone'            => '02082524729',
       'memorable_word'   => 'snootboop',
       'date_of_birth'    => '1950-02-02',
-      'dc_pot_confirmed' => true
+      'dc_pot_confirmed' => true,
+      'opt_out_of_market_research' => true
     }
 
     post api_v1_appointments_path, params: @payload, as: :json
@@ -86,7 +88,8 @@ RSpec.describe 'POST /api/v1/appointments' do
         email: 'rick@example.com',
         phone: '02082524729',
         memorable_word: 'snootboop',
-        dc_pot_confirmed: true
+        dc_pot_confirmed: true,
+        opt_out_of_market_research: true
       )
     end
   end


### PR DESCRIPTION
Permit clients to send a customer's marketing preferences as part of the
API payload. This is then persisted in the appointment record.