### PR TITLE
Don't wrap appointment parameters in appointments api

### DIFF
--- a/app/controllers/api/v1/appointments_controller.rb
+++ b/app/controllers/api/v1/appointments_controller.rb
@@ -5,8 +5,10 @@ module Api
 
       before_action { authorise_user!(User::PENSION_WISE_API_PERMISSION) }
 
+      wrap_parameters false
+
       def create
-        @appointment = Appointment.new(appointment_params)
+        @appointment = Api::V1::Appointment.new(appointment_params)
 
         if @appointment.create
           AppointmentMailer.confirmation(@appointment.model).deliver_later


### PR DESCRIPTION
We pass params to the API without wrapping them, so rails normally will
wrap the JSON in { "appointments" : JSON }. Disable this, so that
the data we receive looks like the data we send.