### PR TITLE
Validate that dc_pot_confirmed is not nil correctly

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -44,7 +44,8 @@ class Appointment < ApplicationRecord
   validates :phone, presence: true
   validates :date_of_birth, presence: true
   validates :memorable_word, presence: true
-  validates :dc_pot_confirmed, presence: true
+  validates :dc_pot_confirmed, inclusion: [true, false]
+
   validates :status, presence: true
   validates :guider, presence: true
 

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -46,6 +46,18 @@ RSpec.describe Appointment, type: :model do
       end
     end
 
+    it 'is valid when dc_pot_confirmed is true' do
+      subject.dc_pot_confirmed = true
+      subject.validate
+      expect(subject.errors[:dc_pot_confirmed]).to be_empty
+    end
+
+    it 'is valid when dc_pot_confirmed is false' do
+      subject.dc_pot_confirmed = false
+      subject.validate
+      expect(subject.errors[:dc_pot_confirmed]).to be_empty
+    end
+
     context 'when created by an API agent' do
       it 'requires a reasonably valid email' do
         appointment = build_stubbed(


### PR DESCRIPTION
'presence: true' validations don't work for booleans because:

`false.present? => false`