### PR TITLE
Only search for guider slots with start_at

### DIFF
--- a/app/forms/api/v1/appointment.rb
+++ b/app/forms/api/v1/appointment.rb
@@ -31,14 +31,9 @@ module Api
 
       private
 
-      def end_at
-        Time.zone.parse(start_at) + 1.hour
-      end
-
       def to_params # rubocop:disable Metrics/MethodLength
         {
           start_at: start_at,
-          end_at: end_at,
           first_name: first_name,
           last_name: last_name,
           email: email,

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -83,9 +83,11 @@ class Appointment < ApplicationRecord
   end
 
   def assign_to_guider
-    slot = BookableSlot.find_available_slot(start_at, end_at)
+    slot = BookableSlot.find_available_slot(start_at)
     self.guider = nil
-    self.guider = slot.guider if slot
+    return unless slot
+    self.end_at = slot.end_at
+    self.guider = slot.guider
   end
 
   def date_of_birth=(value)

--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -19,9 +19,9 @@ class BookableSlot < ApplicationRecord
     BusinessDays.from_now(2)
   end
 
-  def self.find_available_slot(start_at, end_at)
+  def self.find_available_slot(start_at)
     bookable
-      .where(start_at: start_at, end_at: end_at)
+      .where(start_at: start_at)
       .limit(1)
       .order('RANDOM()')
       .first


### PR DESCRIPTION
Don't search for `end_at` too, because it doesn't really matter if we do
or don't. This also means we can search for a slot if we only know the
`start_at`, like in the case of the `appointments` `create` API.