### PR TITLE
Use consistent dates in mailer templates

### DIFF
--- a/app/views/appointment_mailer/confirmation.html.erb
+++ b/app/views/appointment_mailer/confirmation.html.erb
@@ -15,7 +15,7 @@
   Date
   <br>
   <strong class="emphasize" style="font-size: 24px;">
-    <%= @appointment.start_at.to_s(:govuk_date) %>
+    <%= @appointment.start_at.to_date.to_s(:govuk_date) %>
   </strong>
 </p>
 

--- a/app/views/appointment_mailer/confirmation.text.erb
+++ b/app/views/appointment_mailer/confirmation.text.erb
@@ -5,8 +5,8 @@ Dear <%= @appointment.first_name %>,
 Thank you for booking a telephone guidance appointment with Pension Wise.
 Your appointment is confirmed for:
 
-Date
-<%= @appointment.start_at.to_s(:govuk_date) %>
+  Date
+    <%= @appointment.start_at.to_date.to_s(:govuk_date) %>
 
   Start time
     <%= @appointment.start_at.to_time.to_s(:govuk_time) %>


### PR DESCRIPTION
Prior to this change the date / time formatting was incorrect in the
confirmation email. As per other transactional emails - we split the
date and time to be displayed separately but this wasn't happening here.

Also - in the text part - we should indent the date header and value
since the whitespace here is meaningful and will be preserved by textual
clients.