### PR TITLE
Send only the guider's first name across to the summary document

### DIFF
--- a/app/lib/summary_document_link.rb
+++ b/app/lib/summary_document_link.rb
@@ -6,13 +6,13 @@ class SummaryDocumentLink
       "#{url}/appointment_summaries/new?#{query(appointment)}"
     end
 
-    def query(appointment) # rubocop:disable Metrics/MethodLength
+    def query(appointment) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       date_of_appointment = appointment.start_at.to_date
       {
         first_name: appointment.first_name,
         last_name: appointment.last_name,
         date_of_appointment: date_of_appointment.to_s,
-        guider_name: appointment.guider.name,
+        guider_name: appointment.guider.name.split.first,
         reference_number: appointment.id,
         number_of_previous_appointments: 0,
         email: appointment.email,


### PR DESCRIPTION
Previously this was taking their full name from TAP (SignOn)'s
database. As their name is stored in a single field, we need to
split that string and take the first word of it.