### PR TITLE
Making the appointment edit and appointment search pages mobile friendly

### DIFF
--- a/app/assets/stylesheets/components/_activity-feed.scss
+++ b/app/assets/stylesheets/components/_activity-feed.scss
@@ -1,0 +1,11 @@
+.activity-feed__input {
+  @media (max-width: $screen-xs-max) {
+    display: block;
+  }
+}
+
+.activity-feed__button {
+  @media (max-width: $screen-xs-max) {
+    border-radius: 0;
+  }
+}

--- a/app/assets/stylesheets/components/_activity.scss
+++ b/app/assets/stylesheets/components/_activity.scss
@@ -1,15 +1,21 @@
 .activity {
-  display: flex;
-  flex-wrap: wrap;
+  @media (min-width: $screen-sm) {
+    display: flex;
+    flex-wrap: wrap;
+  }
 }
 
 .activity-details {
-  flex-basis: 73%;
+  @media (min-width: $screen-sm) {
+    flex-basis: 73%;
+  }
 }
 
 .activity-badge {
-  flex-basis: 27%;
-  text-align: right;
+  @media (min-width: $screen-sm) {
+    flex-basis: 27%;
+    text-align: right;
+  }
 }
 
 .activity--hide {

--- a/app/assets/stylesheets/components/_appointment_search.scss
+++ b/app/assets/stylesheets/components/_appointment_search.scss
@@ -10,6 +10,33 @@
   width: 260px;
 }
 
-.appointment-search-results tbody tr td { // scss-lint:disable SelectorDepth
-  vertical-align: middle;
+.appointment-search-results {
+  @media (max-width: $screen-xs-max) {
+    border: 0;
+  }
+
+  tbody tr td { // scss-lint:disable SelectorDepth
+    vertical-align: middle;
+  }
+}
+
+.appointment-search-results__head {
+  @media (max-width: $screen-xs-max) {
+    display: none;
+  }
+}
+
+.appointment-search-results__item {
+  @media (max-width: $screen-xs-max) {
+    display: block;
+    width: 100%;
+  }
+}
+
+.appointment-search-results__row {
+  @media (max-width: $screen-xs-max) {
+    display: block;
+    width: 100%;
+    margin-bottom: 20px;
+  }
 }

--- a/app/assets/stylesheets/components/_booking-details.scss
+++ b/app/assets/stylesheets/components/_booking-details.scss
@@ -1,0 +1,19 @@
+.booking-details__head {
+  @media (max-width: $screen-xs-max) {
+    display: none;
+  }
+}
+
+.booking-details__item {
+  @media (max-width: $screen-xs-max) {
+    display: block;
+    width: 100%;
+  }
+}
+
+.booking-details__row {
+  @media (max-width: $screen-xs-max) {
+    display: block;
+    width: 100%;
+  }
+}

--- a/app/assets/stylesheets/components/_dob-form-field.scss
+++ b/app/assets/stylesheets/components/_dob-form-field.scss
@@ -34,7 +34,14 @@
 }
 
 .form-dob__age {
-  display: inline-block;
-  float: left;
-  margin: 27px 0 0 5px;
+  display: block;
+  clear: left;
+  margin: 10px 0 0;
+
+  @media (min-width: $screen-sm) {
+    display: inline-block;
+    clear: none;
+    float: left;
+    margin: 27px 0 0 5px;
+  }
 }

--- a/app/assets/stylesheets/helper/_govuk_admin_template_overrides.scss
+++ b/app/assets/stylesheets/helper/_govuk_admin_template_overrides.scss
@@ -1,0 +1,8 @@
+.navbar-brand {
+  .navbar .container & {
+    @media (max-width: $screen-xs-max) {
+      font-size: 99%;
+      padding-left: 3.5em;
+    }
+  }
+}

--- a/app/views/activities/_activity_feed.html.erb
+++ b/app/views/activities/_activity_feed.html.erb
@@ -5,11 +5,11 @@
     <div class="activity-feed">
       <div class="well js-message-form">
         <%= form_for MessageActivity.new(appointment: appointment, owner: appointment.guider), url: activities_path(appointment_id: appointment.id), remote: true do |f| %>
-          <div class="input-group">
+          <div class="input-group activity-feed__input">
             <label for="message_activity_message"><span class="sr-only">Activity message</span></label>
             <%= f.text_field :message, placeholder: 'Add an action to keep others in the loop', class: 'form-control js-message t-message' %>
             <span class="input-group-btn">
-              <%= f.button class: 'btn btn-primary btn-block t-submit-message', data: { disable_with: 'Adding message...' } do %>
+              <%= f.button class: 'btn btn-primary btn-block t-submit-message activity-feed__button', data: { disable_with: 'Adding message...' } do %>
                 <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
                 Add message
               <% end %>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -55,9 +55,9 @@
 </div>
 <div class="row">
   <div class="col-md-12">
-    <table class="table table-striped table-bordered">
+    <table class="booking-details table table-striped table-bordered">
       <caption><span class="sr-only">Booking details</span></caption>
-      <thead>
+      <thead class="booking-details__head">
         <tr>
           <th>Guider</th>
           <th>Appointment date/time</th>
@@ -65,10 +65,10 @@
         </tr>
       </thead>
       <tbody>
-        <tr>
-          <td><span class="glyphicon glyphicon-user" aria-hidden="true"></span> <span class="t-guider"><%= @appointment.guider.name %></span></td>
-          <td><span class="glyphicon glyphicon-calendar" aria-hidden="true"></span> <span class="t-appointment-date-time"><%= @appointment.start_at.to_date.to_s(:govuk_date_short) %>, <%= @appointment.start_at.to_s(:govuk_time) %> - <%= @appointment.end_at.to_s(:govuk_time) %></span></td>
-          <td><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span> <span class="t-created-date"><%= @appointment.created_at.to_s(:govuk_date_short) %></span></td>
+        <tr class="booking-details__row">
+          <td class="booking-details__item"><b class="visible-xs-block">Guider</b><span class="glyphicon glyphicon-user" aria-hidden="true"></span> <span class="t-guider"><%= @appointment.guider.name %></span></td>
+          <td class="booking-details__item"><b class="visible-xs-block">Appointment date/time</b><span class="glyphicon glyphicon-calendar" aria-hidden="true"></span> <span class="t-appointment-date-time"><%= @appointment.start_at.to_date.to_s(:govuk_date_short) %>, <%= @appointment.start_at.to_s(:govuk_time) %> - <%= @appointment.end_at.to_s(:govuk_time) %></span></td>
+          <td class="booking-details__item"><b class="visible-xs-block">Appointment created</b><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span> <span class="t-created-date"><%= @appointment.created_at.to_s(:govuk_date_short) %></span></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/appointments/search.html.erb
+++ b/app/views/appointments/search.html.erb
@@ -36,7 +36,7 @@
 
 <table id="results" class="appointment-search-results table table-striped table-bordered table-hover">
   <caption><span class="sr-only">Appointment search results</span></caption>
-  <thead>
+  <thead class="appointment-search-results__head">
     <tr>
       <th>Reference</th>
       <th>Customer</th>
@@ -50,14 +50,14 @@
   <tbody class="list" data-module="search-highlight">
     <% @results.each do |result| %>
       <% result = AppointmentSearchResultPresenter.new(result) %>
-      <tr class="t-result">
-        <td class="t-id"><span class="id js-allow-highlighting">#<%= result.id %></span></td>
-        <td class="t-name js-allow-highlighting"><%= result.name %></td>
-        <td class="js-allow-highlighting"><%= result.guider_name %></td>
-        <td><%= result.date %></td>
-        <td><%= result.created_at %></td>
-        <td><%= result.status %></td>
-        <td nowrap="true">
+      <tr class="appointment-search-results__row t-result">
+        <td class="appointment-search-results__item"><b class="visible-xs-block">Reference</b><span class="id js-allow-highlighting t-id">#<%= result.id %></span></td>
+        <td class="appointment-search-results__item"><b class="visible-xs-block">Customer</b><span class="js-allow-highlighting t-name"><%= result.name %></span></td>
+        <td class="appointment-search-results__item"><b class="visible-xs-block">Guider</b><span class="js-allow-highlighting"><%= result.guider_name %></span></td>
+        <td class="appointment-search-results__item"><b class="visible-xs-block">Appointment Date/Time</b><%= result.date %></td>
+        <td class="appointment-search-results__item"><b class="visible-xs-block">Created</b><%= result.created_at %></td>
+        <td class="appointment-search-results__item"><b class="visible-xs-block">Status</b><%= result.status %></td>
+        <td class="appointment-search-results__item" nowrap="true">
           <%= link_to edit_appointment_path(result), title: 'Edit appointment', class: 'btn btn-info' do %>
             <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
             <span class="sr-only">Edit appointment</span>


### PR DESCRIPTION
**Top of edit screen**
<img width="321" alt="screen shot 2017-02-02 at 15 33 34" src="https://cloud.githubusercontent.com/assets/6049076/22555833/03c6ecd8-e95d-11e6-91ff-d89dfc5d833f.png">

**Booking details**
<img width="309" alt="screen shot 2017-02-02 at 15 33 28" src="https://cloud.githubusercontent.com/assets/6049076/22555834/03eaa998-e95d-11e6-8ab3-3c3c63791232.png">

**Appointment search**
<img width="301" alt="screen shot 2017-02-02 at 15 33 16" src="https://cloud.githubusercontent.com/assets/6049076/22555835/03ed70a6-e95d-11e6-8e31-6dfbe1cbcc41.png">
