### PR TITLE
Show the event start time as you drag an appointment

### DIFF
--- a/app/assets/javascripts/modules/calendars/allocations.es6
+++ b/app/assets/javascripts/modules/calendars/allocations.es6
@@ -32,7 +32,8 @@
 
       super.start(el);
 
-      this.$rowHighlighter = $(`<div class="calendar-row-highlighter"/>`).insertAfter(this.$el);
+      this.$rowHighlighter = $('<div class="calendar-row-highlighter"/>').insertAfter(this.$el);
+      this.$rowHighlighterTime = $('<div class="calendar-row-highlighter-time"/>').insertAfter(this.$el);
 
       this.setCalendarToCorrectHeight();
       this.setupUndo();
@@ -170,12 +171,12 @@
 
     highlightResource(event) {
       let eventStartSelector = event.start.format('HH:mm:ss'),
-        $timeRow = this.$el.find(`[data-time="${eventStartSelector}"]`);
-
-      this.$el.find(`.fc-resource-cell`)
+        $timeRow = this.$el.find(`[data-time="${eventStartSelector}"]`),
+        $columnHeader = this.$el.find(`.fc-resource-cell`)
         .removeClass('active')
-        .filter(`[data-resource-id="${event.resourceId}"]`)
-        .addClass('active');
+        .filter(`[data-resource-id="${event.resourceId}"]`);
+
+      $columnHeader.addClass('active');
 
       this.$el.find(`tr[data-time]`)
         .find('.fc-time')
@@ -193,11 +194,19 @@
           left: eventPosition.left,
           width: $timeRow.width()
         }).addClass('active');
+
+        this.$rowHighlighterTime.css({
+          top: eventPosition.top - 35,
+          left: $columnHeader.offset().left + $columnHeader.width()
+        })
+        .addClass('active')
+        .html(event.start.format('HH:mm'));
       }
     }
 
     eventDragStop() {
       this.$rowHighlighter.removeClass('active');
+      this.$rowHighlighterTime.removeClass('active');
       $(`.fc-resource-cell`).removeClass('active');
       $(`tr[data-time]`).find('.fc-time').removeClass('active');
     }

--- a/app/assets/javascripts/modules/calendars/allocations.es6
+++ b/app/assets/javascripts/modules/calendars/allocations.es6
@@ -196,7 +196,7 @@
         }).addClass('active');
 
         this.$rowHighlighterTime.css({
-          top: eventPosition.top - 35,
+          top: eventPosition.top,
           left: $columnHeader.offset().left + $columnHeader.width()
         })
         .addClass('active')

--- a/app/assets/stylesheets/components/_calendars.scss
+++ b/app/assets/stylesheets/components/_calendars.scss
@@ -179,7 +179,6 @@ $guider-row-height: 120px;
 
 .calendar-row-highlighter-time {
   background: $calendar-dragging-highlight;
-  border: 1px solid $color-black;
   color: $color-white;
   display: none;
   pointer-events: none;

--- a/app/assets/stylesheets/components/_calendars.scss
+++ b/app/assets/stylesheets/components/_calendars.scss
@@ -2,7 +2,7 @@ $calendar-today-background: $color-white;
 $calendar-moved-background: $color-green;
 $calendar-filter-box-shadow: transparentize($color-black, .825);
 $calendar-filter-arrow-border: transparentize($color-black, .8);
-$calendar-dragging-highlight: transparentize($color-givry, .1);
+$calendar-dragging-highlight: $color-guardsman-red;
 $calendar-appointment-background: $color-boston-blue;
 $calendar-past-appointment-background: lighten($color-boston-blue, 20%);
 $calendar-appointment-cancelled-background: $color-medium-carmine;
@@ -118,6 +118,7 @@ $guider-row-height: 120px;
 
   .active {
     background-color: $calendar-dragging-highlight;
+    color: $color-white;
   }
 
   .fc-slats table {
@@ -173,6 +174,22 @@ $guider-row-height: 120px;
     width: 100%;
     height: 5px;
     background: $calendar-dragging-highlight;
+  }
+}
+
+.calendar-row-highlighter-time {
+  background: $calendar-dragging-highlight;
+  border: 1px solid $color-black;
+  color: $color-white;
+  display: none;
+  pointer-events: none;
+  position: absolute;
+  line-height: 1;
+  padding: .5em;
+  z-index: 2;
+
+  &.active {
+    display: inline-block;
   }
 }
 


### PR DESCRIPTION

![9aso81v9v0](https://cloud.githubusercontent.com/assets/6049076/22687861/b2b822c6-ed21-11e6-9aeb-1fd89df20437.gif)


Users were sometimes mistakenly changing the start time of
an appointment, because it was difficult to see what time
exactly they were dragging an appointment to.

This provides them the start time of where the item has
currently been dragged to, making it easier to spot
potential mistakes.