### PR TITLE
Guard against rebooked pending appointments

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
-  add_flash_types :success
+  add_flash_types :success, :warning
 
   def self.store_previous_page_on(actions)
     before_action only: actions do |controller|

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -48,6 +48,12 @@ class AppointmentsController < ApplicationController
 
   def new
     @appointment = Appointment.copy_or_new_by(params[:copy_from])
+
+    if @appointment
+      render :new
+    else
+      redirect_back warning: I18n.t('appointments.rebooking'), fallback_location: search_appointments_path
+    end
   end
 
   def preview

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -64,6 +64,8 @@ class Appointment < ApplicationRecord
     return new unless id
 
     find(id).dup.tap do |appointment|
+      break if appointment.pending?
+
       appointment.start_at = nil
       appointment.end_at   = nil
       appointment.rebooked_from_id = id

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,8 @@ en:
   time:
     formats:
       date_range_picker: "%e/%m/%Y %H:%M"
+  appointments:
+    rebooking: "You can't rebook this appointment while it's pending. Please go back and change the status."
   users:
     deactivate_confirm: |
       Deactivate this guider?

--- a/spec/features/agent_rebooks_appointments_spec.rb
+++ b/spec/features/agent_rebooks_appointments_spec.rb
@@ -11,8 +11,33 @@ RSpec.feature 'Agent rebooks appointments' do
     end
   end
 
-  def and_there_is_an_appointment
+  scenario 'Agent attempts to rebook a pending appointment' do
+    given_the_user_is_an_agent do
+      and_there_is_a_pending_appointment
+      when_they_attempt_to_rebook_an_appointment
+      then_they_are_told_to_change_the_original_appointment_status
+    end
+  end
+
+  def and_there_is_a_pending_appointment
     @appointment = create(:appointment)
+  end
+
+  def when_they_attempt_to_rebook_an_appointment
+    @page = Pages::EditAppointment.new
+    @page.load(id: @appointment.id)
+    @page.rebook.click
+  end
+
+  def then_they_are_told_to_change_the_original_appointment_status
+    # redirected back
+    expect(@page).to be_displayed
+
+    expect(@page).to have_content(I18n.t('appointments.rebooking'))
+  end
+
+  def and_there_is_an_appointment
+    @appointment = create(:appointment, status: :cancelled_by_customer)
   end
 
   def and_they_rebook_an_appointment

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -17,6 +17,7 @@ module Pages
     element :opt_out_of_market_research,            '.t-opt-out-of-market-research'
     element :status, '.t-status'
     element :submit, '.t-save'
+    element :rebook, '.t-rebook'
 
     section :activity_feed, '.t-activity-feed' do
       elements :activities, '.t-activity'


### PR DESCRIPTION
We must ensure bookable slots are returned to the pool when an
appointment is rebooked.

![screen shot 2017-02-09 at 12 14 43](https://cloud.githubusercontent.com/assets/41963/22782967/77e9b3a2-eec1-11e6-9fbc-ef6878039e95.png)

![screen shot 2017-02-09 at 12 15 06](https://cloud.githubusercontent.com/assets/41963/22782972/7cbaa31e-eec1-11e6-955f-ba15a835ee39.png)
