### PR TITLE
Allow users to add groups from an existing list or create a new one

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ source 'https://rubygems.org' do
     gem 'faker'
     gem 'launchy'
     gem 'parallel_tests'
+    gem 'phantomjs-binaries'
     gem 'pry-byebug'
     gem 'pusher-fake'
     gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,8 @@ GEM
     parser (2.3.3.1)
       ast (~> 2.2)
     pg (0.19.0)
+    phantomjs-binaries (2.1.1.1)
+      sys-uname (= 0.9.0)
     plek (1.12.0)
     poltergeist (1.11.0)
       capybara (~> 2.1)
@@ -373,6 +375,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sys-uname (0.9.0)
+      ffi (>= 1.0.0)
     term-ansicolor (1.4.0)
       tins (~> 1.0)
     thin (1.7.0)
@@ -429,6 +433,7 @@ DEPENDENCIES
   newrelic_rpm!
   parallel_tests!
   pg (~> 0.18)!
+  phantomjs-binaries!
   plek!
   poltergeist (= 1.11.0)!
   postgres-copy!

--- a/app/assets/javascripts/modules/advanced-select.es6
+++ b/app/assets/javascripts/modules/advanced-select.es6
@@ -7,7 +7,9 @@
       this.config = {
         theme: 'bootstrap',
         templateResult: this.renderTemplate.bind(this),
-        allowClear: true
+        allowClear: true,
+        placeholder: $(el).data('placeholder'),
+        tags: $(el).data('tags') ? true : false
       };
 
       super.start(el);
@@ -39,13 +41,14 @@
     renderTemplate(state) {
       if (!state.id) { return state.text; }
 
-      const icon = $(state.element).data('icon');
+      const icon = $(state.element).data('icon'),
+      text = state.element ? state.element.text : state.text;
 
       if (icon) {
-        return $(`<i class="glyphicon ${icon}"></i> <span>${state.element.text}</span>`);
+        return $(`<i class="glyphicon ${icon}"></i> <span>${text}</span>`);
       }
 
-      return state.element.text;
+      return text;
     }
   }
 

--- a/app/assets/stylesheets/helper/_vertical-align.scss
+++ b/app/assets/stylesheets/helper/_vertical-align.scss
@@ -1,0 +1,3 @@
+.v-middle {
+  vertical-align: middle;
+}

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -4,10 +4,15 @@ class GroupsController < ApplicationController
   def index
     @guiders = User.find(user_ids)
     @groups  = Group.assigned_to(user_ids)
+    @all_groups = Group.pluck(:name)
   end
 
   def create
-    CreateGroupAssignments.new(user_ids, group_params[:name]).call
+    CreateGroupAssignments.new(
+      user_ids,
+      group_params[:name].select(&:present?)
+    ).call
+
     go_back_with_success('assigned to')
   end
 
@@ -26,7 +31,7 @@ class GroupsController < ApplicationController
   end
 
   def group_params
-    params.require(:group).permit(:name)
+    params.require(:group).permit(name: [])
   end
 
   def user_ids

--- a/app/forms/create_group_assignments.rb
+++ b/app/forms/create_group_assignments.rb
@@ -1,23 +1,27 @@
 class CreateGroupAssignments
-  def initialize(user_ids, name)
+  def initialize(user_ids, names)
     @user_ids = user_ids
-    @name = name
+    @names = names
   end
 
   def call
-    @group = Group.find_or_create_by(name: name)
-
     users.each do |user|
-      user.group_assignments.find_or_create_by(group: @group)
+      groups.each do |group|
+        user.group_assignments.find_or_create_by(group: group)
+      end
     end
   end
 
   private
+
+  def groups
+    @groups ||= names.map { |name| Group.find_or_create_by(name: name) }
+  end
 
   def users
     User.find(user_ids)
   end
 
   attr_reader :user_ids
-  attr_reader :name
+  attr_reader :names
 end

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -4,57 +4,59 @@
 )
 %>
 
-<h1>Manage groups</h1>
-
-<h2>Add/remove guider groups</h2>
-<p class="lead">Add or remove from the list below to set the group memberships for these guiders.</p>
+<h1>Add/remove guider groups</h1>
 
 <div class="panel panel-warning">
   <div class="panel-heading">
-    <h4>Guiders affected by this change:</h4>
+    <h2 class="h4">Guiders affected by this change</h2>
   </div>
   <div class="panel-body">
     The guiders affected will be: <strong class="t-affected"><%= @guiders.pluck(:name).to_sentence %></strong>.
   </div>
 </div>
 
-<div class="row">
-  <div class="col-md-6 border-bottom">
-    <table class="table">
-      <tr class="well">
-        <td colspan="2">
-          <div class="row">
-            <div class="col-lg-12">
-              <%= form_for Group.new, url: groups_path(user_ids: params[:user_ids]), class: 'js-form' do |f| %>
-                <div class="input-group">
-                  <%= f.text_field :name, class: 'form-control js-group-input t-name', placeholder: 'Add a new group' %>
-                  <span class="input-group-btn">
-                    <%= f.button class: 'btn btn-primary js-button t-add-group' do %>
-                      <span class="glyphicon glyphicon-plus"></span>
-                      Add group
-                    <% end %>
-                  </span>
-                </div>
-              <% end %>
-            </div>
-          </div>
-        </td>
-      </tr>
-      <% @groups.each do |group| %>
-        <tr class="t-group">
-          <td class="lead">
-            <span class="label label-info"><%= group.name %></span>
-          </td>
-          <td class="lead">
-            <%= link_to group_path(group, user_ids: params[:user_ids]),
-              class: 'js-remove pull-right t-remove',
-              method: :delete,
-              data: { confirm: "Are you sure you want to remove the group #{group.name} from these guiders?" } do %>
-              <span class="glyphicon glyphicon-remove"></span>
+
+<div class="well">
+  <div class="row">
+    <div class="col-md-12">
+      <%= form_for Group.new, url: groups_path(user_ids: params[:user_ids]), class: 'js-form' do |f| %>
+        <div class="input-group">
+          <%=
+            f.select(
+              :name,
+              @all_groups,
+              {},
+              multiple: 'multiple',
+              class: 'form-control t-name',
+              data: {
+                module: 'advanced-select',
+                tags: true,
+                placeholder: 'Add a group'
+              }
+            )
+          %>
+          <span class="input-group-btn">
+            <%= f.button class: 'btn btn-primary js-button t-add-group' do %>
+              <span class="glyphicon glyphicon-plus"></span>
+              Add group(s)
             <% end %>
-          </td>
-        </tr>
+          </span>
+        </div>
       <% end %>
-    </table>
+    </div>
   </div>
 </div>
+
+<ul class="list-group">
+  <% @groups.each do |group| %>
+    <li class="list-group-item clearfix lead t-group">
+      <span class="label label-info"><%= group.name %></span>
+      <%= link_to group_path(group, user_ids: params[:user_ids]),
+        class: 'js-remove t-remove v-middle',
+        method: :delete,
+        data: { confirm: "Are you sure you want to remove the group #{group.name} from these guiders?" } do %>
+        <span class="glyphicon glyphicon-remove"></span>
+      <% end %>
+    </li>
+  <% end %>
+</ul>

--- a/spec/features/resource_manager_manages_guiders_spec.rb
+++ b/spec/features/resource_manager_manages_guiders_spec.rb
@@ -80,13 +80,17 @@ RSpec.feature 'Resource manager manages guiders' do
   end
 
   def when_they_create_a_new_group
-    @page.group.set 'Trainees'
+    # simulate the select.js behaviour correctly
+    @page.group.send_keys(%i(t r a i n e e s enter))
+    # wait until the new group / tag is selected
+    @page.wait_until_chosen_group_visible
+
     @page.add_group.click
   end
 
   def then_the_group_is_assigned_to_those_guiders
     expect(@page).to have_flash_of_success
-    expect(@page).to have_text('Trainees')
+    expect(@page).to have_text('TRAINEES')
   end
 
   def and_there_are_guiders_assigned_to_groups

--- a/spec/forms/create_group_assignments_spec.rb
+++ b/spec/forms/create_group_assignments_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe CreateGroupAssignments, '#call' do
   let(:users) { create_list(:guider, 2) }
   let(:user_ids) { users.map(&:id) }
-  let(:group_params) { Hash[name: 'Another Group'] }
+  let(:group_params) { Hash[name: ['Another Group']] }
 
   subject { described_class.new(user_ids, group_params[:name]) }
 
@@ -20,7 +20,7 @@ RSpec.describe CreateGroupAssignments, '#call' do
 
   context 'when a user is already a member and the group exists' do
     before do
-      group = create(:group, group_params)
+      group = create(:group, name: 'Another Group')
 
       users.first.group_assignments.create(group: group)
     end

--- a/spec/support/pages/manage_groups.rb
+++ b/spec/support/pages/manage_groups.rb
@@ -3,7 +3,8 @@ module Pages
     set_url '/groups'
 
     element :affected, '.t-affected'
-    element :group, '.t-name'
+    element :group, '.select2-search__field'
+    element :chosen_group, '.select2-selection__choice'
     element :add_group, '.t-add-group'
     element :flash_of_success, '.alert-success'
 


### PR DESCRIPTION
Previously users have had to remember the exact spelling of a group
in order to add users to existing one - sometimes creating
problems where a typo ends up creating a new tag

This uses the select2 tags feature to allow someone to select
an existing tag or tags, or create a new one