### PR TITLE
Expose an API for notify-based delivery failures

### DIFF
--- a/app/controllers/api/v1/dropped_summary_documents_controller.rb
+++ b/app/controllers/api/v1/dropped_summary_documents_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  module V1
+    class DroppedSummaryDocumentsController < Api::V1::ApplicationController
+      def create
+        DroppedSummaryDocumentActivity.from(appointment)
+
+        head :created
+      end
+
+      private
+
+      def appointment
+        Models::Appointment.find(params[:appointment_id])
+      end
+    end
+  end
+end

--- a/app/models/dropped_summary_document_activity.rb
+++ b/app/models/dropped_summary_document_activity.rb
@@ -1,0 +1,11 @@
+class DroppedSummaryDocumentActivity < Activity
+  def self.from(appointment)
+    create!(
+      appointment: appointment,
+      owner: appointment.guider,
+      message: 'fail'
+    ).tap do |activity|
+      PusherActivityNotificationJob.perform_later(appointment.guider_id, activity.id)
+    end
+  end
+end

--- a/app/views/activities/_dropped_summary_document_activity.html.erb
+++ b/app/views/activities/_dropped_summary_document_activity.html.erb
@@ -1,0 +1,5 @@
+<% content_for(:activity_message, flush: true) do %>
+  <span class="glyphicon glyphicon-exclamation-sign text-danger" aria-hidden="true"></span>
+  <strong>The summary document generator</strong> reported a delivery failure
+<% end %>
+<%= render 'activities/activity', activity: dropped_summary_document_activity, details: details, hide: hide %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,9 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     namespace :v1 do
       resources :bookable_slots, only: :index
 
-      resources :appointments, only: :create
+      resources :appointments, only: :create do
+        resources :dropped_summary_documents, only: :create
+      end
 
       resources :summary_documents, only: :create
     end

--- a/spec/requests/summary_document_dropped_api_spec.rb
+++ b/spec/requests/summary_document_dropped_api_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'POST /api/v1/appointments/:id/dropped_summary_documents' do
+  scenario 'Successfully created a dropped summary document activity' do
+    given_the_user_is_a_pension_wise_api_user do
+      and_a_completed_appointment_exists
+      when_the_client_posts_a_dropped_summary_document_notification
+      then_the_service_responds_with_a_201
+      and_the_activity_is_created
+    end
+  end
+
+  def and_a_completed_appointment_exists
+    @appointment = create(:appointment, status: :complete)
+  end
+
+  def when_the_client_posts_a_dropped_summary_document_notification
+    post api_v1_appointment_dropped_summary_documents_path(@appointment), as: :json
+  end
+
+  def then_the_service_responds_with_a_201
+    expect(response).to be_created
+  end
+
+  def and_the_activity_is_created
+    DroppedSummaryDocumentActivity.first.tap do |activity|
+      expect(activity).to have_attributes(
+        appointment: @appointment,
+        owner: @appointment.guider
+      )
+    end
+  end
+end


### PR DESCRIPTION
Exposes an API endpoint at
`/api/v1/appointments/:id/dropped_summary_documents` that creates an
activity - notifying the owning guider when an attempted (GOVUK notify)
delivery failed and thus prompting them to action.

<img width="1319" alt="screen shot 2017-02-23 at 11 04 58" src="https://cloud.githubusercontent.com/assets/41963/23256669/61d3d0e6-f9b8-11e6-8dfe-56991fdb7040.png">
