### PR TITLE
Notify slack on customer bookings

### DIFF
--- a/app/controllers/api/v1/appointments_controller.rb
+++ b/app/controllers/api/v1/appointments_controller.rb
@@ -5,7 +5,7 @@ module Api
         @appointment = Api::V1::Appointment.new(appointment_params)
 
         if @appointment.create
-          AppointmentMailer.confirmation(@appointment.model).deliver_later
+          send_notifications(@appointment)
           head :created, location: @appointment.model
         else
           render json: @appointment.errors, status: :unprocessable_entity
@@ -13,6 +13,11 @@ module Api
       end
 
       private
+
+      def send_notifications(appointment)
+        WebsiteAppointmentSlackPingerJob.perform_later
+        AppointmentMailer.confirmation(appointment.model).deliver_later
+      end
 
       def appointment_params # rubocop:disable Metrics/MethodLength
         params.permit(

--- a/app/jobs/website_appointment_slack_pinger_job.rb
+++ b/app/jobs/website_appointment_slack_pinger_job.rb
@@ -1,0 +1,25 @@
+class WebsiteAppointmentSlackPingerJob < ActiveJob::Base
+  queue_as :default
+
+  def perform
+    return unless hook_uri
+
+    hook = WebHook.new(hook_uri)
+    hook.call(payload)
+  end
+
+  private
+
+  def hook_uri
+    ENV['APPOINTMENTS_SLACK_PINGER_URI']
+  end
+
+  def payload
+    {
+      username: 'dave',
+      channel: '#online-bookings',
+      text: ':tada: customer telephone booking  :tada:',
+      icon_emoji: ':mullet:'
+    }
+  end
+end


### PR DESCRIPTION
We should notify slack when a booking is received from the main Pension
Wise website, as part of the customer journey. This helps us keep track
of how many bookings are being made during the A/B test and gradual
rollout.