### PR TITLE
Add page titles across the app

### DIFF
--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: 'My activity')) %>
 <%= breadcrumb( { title: 'My activity' } ) %>
 
 <h1>My activity</h1>

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: 'Allocations')) %>
 <%= breadcrumb( { title: 'Allocations' } ) %>
 
 <h1 class="sr-only">Allocations</h1>

--- a/app/views/appointment_reports/new.html.erb
+++ b/app/views/appointment_reports/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: 'Generate an appointment report')) %>
 <%= breadcrumb( { title: 'Generate an appointment report' } ) %>
 
 <h1>Generate an appointment report</h1>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: "Edit appointment for #{@appointment.name}")) %>
 <%= breadcrumb(
   breadcrumb_part_for_previous_page,
   { title: "Edit appointment for #{@appointment.name}" }

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: 'Book an appointment')) %>
 <%= breadcrumb({ title: 'Book an appointment' }) %>
 
 <h1>Book an appointment</h1>

--- a/app/views/appointments/preview.html.erb
+++ b/app/views/appointments/preview.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: 'Confirm appointment details')) %>
 <%=
   breadcrumb(
     { title: 'Book an appointment', path: new_appointment_path },

--- a/app/views/appointments/reschedule.html.erb
+++ b/app/views/appointments/reschedule.html.erb
@@ -1,6 +1,7 @@
+<% content_for(:page_title, t('service.title', page_title: "Reschedule appointment for #{@appointment.name}")) %>
 <%= breadcrumb(
   { title: 'Appointment search', path: search_appointments_path },
-  { title: "Edit appointment for #{@appointment.name}" })
+  { title: "Reschedule appointment for #{@appointment.name}" })
 %>
 
 <h1>Reschedule an appointment for <%= @appointment.name %></h1>

--- a/app/views/appointments/search.html.erb
+++ b/app/views/appointments/search.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: 'Appointment search')) %>
 <%= breadcrumb( { title: 'Appointment search' } ) %>
 
 <h1>Appointment search</h1>

--- a/app/views/company_calendars/show.html.erb
+++ b/app/views/company_calendars/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: 'Company appointments')) %>
 <%= breadcrumb( { title: 'Company appointments' } ) %>
 
 <h1>Company appointments</h1>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: 'Manage groups')) %>
 <%= breadcrumb(
   { title: 'Manage guiders', path: users_path },
   { title: 'Manage groups' }

--- a/app/views/holidays/edit.html.erb
+++ b/app/views/holidays/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: 'Edit holiday')) %>
 <%= breadcrumb(
   { title: 'Holidays', path: holidays_path },
   { title: 'Edit holiday' }

--- a/app/views/holidays/index.html.erb
+++ b/app/views/holidays/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: 'Holidays')) %>
 <%= breadcrumb( { title: 'Holidays' } ) %>
 
 <h1>Holidays</h1>

--- a/app/views/holidays/new.html.erb
+++ b/app/views/holidays/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: 'Create a holiday')) %>
 <%= breadcrumb(
   { title: 'Holidays', path: holidays_path },
   { title: 'Create a holiday' }

--- a/app/views/my_appointments/show.html.erb
+++ b/app/views/my_appointments/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: 'My appointments')) %>
 <%= breadcrumb( { title: 'My appointments' } ) %>
 
 <h1>My appointments</h1>

--- a/app/views/schedules/edit.html.erb
+++ b/app/views/schedules/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: "Edit schedule #{@schedule.title} for #{@guider.name}")) %>
 <%= breadcrumb(
   { title: 'Manage guiders', path: users_path },
   { title: "Manage schedules for #{@guider.name}", path: edit_user_path(@guider) },

--- a/app/views/schedules/new.html.erb
+++ b/app/views/schedules/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: "New schedule for #{@guider.name}")) %>
 <%= breadcrumb(
   { title: 'Manage guiders', path: users_path },
   { title: "Manage schedules for #{@guider.name}", path: edit_user_path(@guider) },

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: "Manage schedules for #{@guider.name}")) %>
 <%= breadcrumb(
   { title: 'Manage guiders', path: users_path },
   { title: "Manage schedules for #{@guider.name}" }

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: 'Manage guiders')) %>
 <%= breadcrumb( { title: 'Manage guiders' } ) %>
 
 <h1>Manage guiders</h1>

--- a/app/views/users/sort.html.erb
+++ b/app/views/users/sort.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: 'Guider display order')) %>
 <%= breadcrumb( { title: 'Guider display order' } ) %>
 
 <h1>Guider display order</h1>

--- a/app/views/utilisation_reports/new.html.erb
+++ b/app/views/utilisation_reports/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: 'Generate a utilisation report')) %>
 <%= breadcrumb( { title: 'Generate a utilisation report' } ) %>
 
 <h1>Generate a utilisation report</h1>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,8 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  service:
+    title: '%{page_title} - Telephone Appointment Planner'
   date:
     formats:
       date_range_picker: '%e/%m/%Y'


### PR DESCRIPTION
Each page should have it's own tailored title to
aid bookmarking pages, and helping users know
which page they are on in the tab of a browser