### PR TITLE
Change notification precedence

### DIFF
--- a/app/lib/notifier.rb
+++ b/app/lib/notifier.rb
@@ -23,12 +23,12 @@ class Notifier
   end
 
   def notify_customer
-    if appointment_details_changed? && appointment.future?
-      CustomerUpdateJob.perform_later(appointment, CustomerUpdateActivity::UPDATED_MESSAGE)
-    elsif appointment_cancelled?
+    if appointment_cancelled?
       CustomerUpdateJob.perform_later(appointment, CustomerUpdateActivity::CANCELLED_MESSAGE)
     elsif appointment_missed?
       CustomerUpdateJob.perform_later(appointment, CustomerUpdateActivity::MISSED_MESSAGE)
+    elsif appointment_details_changed? && appointment.future?
+      CustomerUpdateJob.perform_later(appointment, CustomerUpdateActivity::UPDATED_MESSAGE)
     end
   end
 


### PR DESCRIPTION
We were occasionally sending update emails when the status changes
along with other notifiable attributes. By simply changing the
precedence to check for status updates first we will always send the
correct notifications when the status changes.