### PR TITLE
Exclude prototype branches from being run on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,6 @@ before_script:
 notifications:
   slack:
     secure: izFI8CV1BAc5Sk08/q84YijolWAY2Zm3JA4RPyilwjzfrro5v2lOM9rEX32W1fgPDu7hWq1bmqYcgxhVI+ecu2RFkI0iQklgNSe256HN7AKqRtSgtVx+3L6w8B9tBCJJ9wfj0lur/8x6oh8UwH8jExJmqtJbL3rxIq+O9N0/nJdf4jXR9vPHfFtprZwExQQTDQccqXkfyE+BqYRsFjoa/jL0utZlLt5kn8ErQPW/lDiSFvOA9OKk5o2ihQrndxkhAhZX6GbKp2aBP3xkom37aQZRyXsKIMXCz16+0IGOsTrW32j3lwLjsesb308Bp01e4q4ssp3a+2k5Hs2CKs0++b9Bb4GLpEl6Q63TGewUqK9/TXjvp7IWx5SOTQbktB5YLL6WmfR+j7MfD52VrEIHahEgJUwQQ+2+EG9MP0O8Qbs4Gek1FgGtpN7+rUS9WpOUIiGEjN7+uGd+PHTgSL7gf0kqrhtQcDHkP8KfI7KOrB1O0gO4DmdHNfJ184MXKEFlh7ULKtX08i8iB5GMVGQqsCuI7lfgR/P+u/SlIbPVu/aRoXpzo4e18UVpjBl9fR5mk6vroXqiR/5v4sHByFp5wn/QwvGszXjZcgmqTtZ7tyGGoq1IS6QdPr1Y0D/mBZT/O4N7QzG7fugPXwKOIfiktPooGt6CSVca5SHa13OkBrk=
+branches:
+  except:
+    - /^prototypes\/.*$/


### PR DESCRIPTION
This brings TAP inline with Pension Guidance where any
branch named prototypes/* will not run on travis