### PR TITLE
Display timestamps respective of DST

### DIFF
--- a/app/presenters/appointment_search_result_presenter.rb
+++ b/app/presenters/appointment_search_result_presenter.rb
@@ -8,7 +8,7 @@ class AppointmentSearchResultPresenter < SimpleDelegator
   end
 
   def created_at
-    super.strftime(DATE_FORMAT)
+    super.in_time_zone('London').strftime(DATE_FORMAT)
   end
 
   def date

--- a/app/views/activities/_activity.html.erb
+++ b/app/views/activities/_activity.html.erb
@@ -8,7 +8,7 @@
       <%= render('activities/details', appointment: activity.appointment) if details %>
     </div>
     <div class="activity-badge">
-      <em class="badge"><%= activity.created_at.to_s(:govuk_date_short) %> (<%= time_ago_in_words(activity.created_at)%> ago)</em>
+      <em class="badge"><%= activity.created_at.in_time_zone('London').to_s(:govuk_date_short) %> (<%= time_ago_in_words(activity.created_at.in_time_zone('London'))%> ago)</em>
     </div>
 <% if details %>
   </a>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -69,7 +69,7 @@
         <tr class="booking-details__row">
           <td class="booking-details__item"><b class="visible-xs-block">Guider</b><span class="glyphicon glyphicon-user" aria-hidden="true"></span> <span class="t-guider"><%= @appointment.guider.name %></span></td>
           <td class="booking-details__item"><b class="visible-xs-block">Appointment date/time</b><span class="glyphicon glyphicon-calendar" aria-hidden="true"></span> <span class="t-appointment-date-time"><%= @appointment.start_at.to_date.to_s(:govuk_date_short) %>, <%= @appointment.start_at.to_s(:govuk_time) %> - <%= @appointment.end_at.to_s(:govuk_time) %></span></td>
-          <td class="booking-details__item"><b class="visible-xs-block">Appointment created</b><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span> <span class="t-created-date"><%= @appointment.created_at.to_s(:govuk_date_short) %></span></td>
+          <td class="booking-details__item"><b class="visible-xs-block">Appointment created</b><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span> <span class="t-created-date"><%= @appointment.created_at.in_time_zone('London').to_s(:govuk_date_short) %></span></td>
         </tr>
       </tbody>
     </table>

--- a/spec/features/guider_edits_an_appointment_spec.rb
+++ b/spec/features/guider_edits_an_appointment_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature 'Guider edits an appointment' do
 
     expect(@page.guider.text).to eq(@appointment.guider.name)
     expect(@page.date_time.text).to eq("#{start_date}, #{start_at_time} - #{end_at_time}")
-    expect(@page.created_date.text).to eq(@appointment.created_at.to_s(:govuk_date_short))
+    expect(@page.created_date.text).to eq(@appointment.created_at.in_time_zone('London').to_s(:govuk_date_short))
     expect(@page.first_name.value).to eq(@appointment.first_name)
     expect(@page.last_name.value).to eq(@appointment.last_name)
     expect(@page.email.value).to eq(@appointment.email)


### PR DESCRIPTION
This ensures timestamps are formatted with the correct offset for
'London'. Start and end timestamps for appointments, holidays, slots and
such are unaffected by this change as they're expressed in UTC without
an offset.