### PR TITLE
Calculate grace period from close of play

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -144,7 +144,7 @@ class Appointment < ApplicationRecord
   def not_within_two_business_days
     return unless new_record? && start_at?
 
-    too_soon = start_at < BusinessDays.from_now(2)
+    too_soon = start_at < BusinessDays.from_now(2).change(hour: 18, min: 30)
     errors.add(:start_at, 'must be more than two business days from now') if too_soon
   end
 

--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -16,7 +16,8 @@ class BookableSlot < ApplicationRecord
 
   def self.next_valid_start_date(user)
     return Time.zone.now if user.resource_manager?
-    BusinessDays.from_now(2)
+
+    BusinessDays.from_now(2).change(hour: 18, min: 30)
   end
 
   def self.find_available_slot(start_at)

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -1,6 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe Appointment, type: :model do
+  describe 'Grace period bug regression' do
+    it 'does not permit bookings inside the grace period' do
+      travel_to '2017-03-26 11:05 UTC' do
+        # force new_record? to evaluate truthily
+        appointment = Appointment.new(
+          attributes_for(:appointment, start_at: Time.zone.parse('2017-03-28 11:20 UTC'))
+        )
+
+        expect(appointment).to be_invalid
+      end
+    end
+  end
+
   describe 'formatting' do
     it 'title-cases first and last name' do
       appointment = build_stubbed(:appointment, first_name: 'bob', last_name: 'carolgees')


### PR DESCRIPTION
We were previously calculating the two business days grace period from
the current date and time. We should have calculated this from the close
of play and appointments have inadvertently been created.