### PR TITLE
Calculate grace period from close of play

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -144,7 +144,7 @@ class Appointment < ApplicationRecord
   def not_within_two_business_days
     return unless new_record? && start_at?
 
-    too_soon = start_at < BusinessDays.from_now(2)
+    too_soon = start_at < BookableSlot.next_valid_start_date
     errors.add(:start_at, 'must be more than two business days from now') if too_soon
   end
 

--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -14,9 +14,10 @@ class BookableSlot < ApplicationRecord
     where("#{quoted_table_name}.start_at > ? AND #{quoted_table_name}.end_at < ?", from, to)
   end
 
-  def self.next_valid_start_date(user)
-    return Time.zone.now if user.resource_manager?
-    BusinessDays.from_now(2)
+  def self.next_valid_start_date(user = nil)
+    return Time.zone.now if user && user.resource_manager?
+
+    BusinessDays.from_now(2).change(hour: 18, min: 30)
   end
 
   def self.find_available_slot(start_at)
@@ -33,7 +34,7 @@ class BookableSlot < ApplicationRecord
   end
 
   def self.grouped # rubocop:disable Metrics/AbcSize
-    from = BusinessDays.from_now(2).beginning_of_day
+    from = next_valid_start_date
     to   = 6.weeks.from_now.end_of_day
 
     bookable(from, to)

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -1,6 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe Appointment, type: :model do
+  describe 'Grace period bug regression' do
+    it 'does not permit bookings inside the grace period' do
+      travel_to '2017-03-26 11:05 UTC' do
+        # force new_record? to evaluate truthily
+        appointment = Appointment.new(
+          attributes_for(:appointment, start_at: Time.zone.parse('2017-03-28 11:20 UTC'))
+        )
+
+        expect(appointment).to be_invalid
+      end
+    end
+  end
+
   describe 'formatting' do
     it 'title-cases first and last name' do
       appointment = build_stubbed(:appointment, first_name: 'bob', last_name: 'carolgees')

--- a/spec/requests/bookable_slots_api_spec.rb
+++ b/spec/requests/bookable_slots_api_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe 'GET /api/v1/bookable_slots' do
     create(:bookable_slot, start_at: Time.zone.parse('2017-01-13 14:00'))
 
     # three slots combined for one day
-    create(:bookable_slot, start_at: Time.zone.parse('2017-01-12 15:00'))
-    create_list(:bookable_slot, 2, start_at: Time.zone.parse('2017-01-12 12:00'))
+    create(:bookable_slot, start_at: Time.zone.parse('2017-01-16 15:00'))
+    create_list(:bookable_slot, 2, start_at: Time.zone.parse('2017-01-16 12:00'))
 
     # falls before the booking window
     create(:bookable_slot, start_at: 1.day.from_now)
@@ -32,11 +32,11 @@ RSpec.describe 'GET /api/v1/bookable_slots' do
     expect(response).to be_ok
 
     JSON.parse(response.body).tap do |json|
-      expect(json['2017-01-12']).to eq(%w(2017-01-12T12:00:00.000Z 2017-01-12T15:00:00.000Z))
+      expect(json['2017-01-16']).to eq(%w(2017-01-16T12:00:00.000Z 2017-01-16T15:00:00.000Z))
 
       expect(json['2017-01-13']).to eq(%w(2017-01-13T14:00:00.000Z))
 
-      expect(json.keys).to eq(%w(2017-01-12 2017-01-13))
+      expect(json.keys).to eq(%w(2017-01-13 2017-01-16))
     end
   end
 end


### PR DESCRIPTION
We were previously calculating the two business days grace period from
the current date and time. We should have calculated this from the close
of play and appointments have inadvertently been created.