### PR TITLE
Ensure activities are only created when necessary

### DIFF
--- a/app/lib/notifier.rb
+++ b/app/lib/notifier.rb
@@ -23,6 +23,8 @@ class Notifier
   end
 
   def notify_customer
+    return unless appointment.email?
+
     if appointment_cancelled?
       CustomerUpdateJob.perform_later(appointment, CustomerUpdateActivity::CANCELLED_MESSAGE)
     elsif appointment_missed?

--- a/spec/lib/notifier_spec.rb
+++ b/spec/lib/notifier_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Notifier, '#call' do
         subject.call
       end
 
-      it 'creates a CustomerUpdateActvity' do
+      it 'does not create a CustomerUpdateActvity' do
         expect(CustomerUpdateActivity).not_to receive(:from)
         subject.call
       end

--- a/spec/lib/notifier_spec.rb
+++ b/spec/lib/notifier_spec.rb
@@ -16,6 +16,19 @@ RSpec.describe Notifier, '#call' do
     allow(PusherActivityCreatedJob).to receive(:perform_later)
   end
 
+  context 'when the appointment is without an associated email' do
+    before do
+      stub_const('AppointmentMailer', double)
+      stub_const('CustomerUpdateActivity', double)
+    end
+
+    it 'does not notify the customer' do
+      appointment.update_attribute(:email, '')
+
+      subject.call
+    end
+  end
+
   context 'and I update a core detail' do
     before { appointment.update_attribute(:first_name, 'Jean Ralphio') }
 


### PR DESCRIPTION
While the actual email was a noop thanks to the absence of a customer email
address on the associated appointment we were incorrectly creating
activities. This change ensures activities are only created (and skips a
heap of other machinery) when a customer email address is present.