### PR TITLE
Default fields to avoid phantom audit messages

### DIFF
--- a/db/migrate/20170330173341_set_defaults_on_appointments.rb
+++ b/db/migrate/20170330173341_set_defaults_on_appointments.rb
@@ -1,0 +1,6 @@
+class SetDefaultsOnAppointments < ActiveRecord::Migration[5.0]
+  def change
+    change_column_default :appointments, :mobile, ''
+    change_column_default :appointments, :notes, ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170317145556) do
+ActiveRecord::Schema.define(version: 20170330173341) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,9 +39,9 @@ ActiveRecord::Schema.define(version: 20170317145556) do
     t.string   "last_name",                                  null: false
     t.string   "email"
     t.string   "phone",                                      null: false
-    t.string   "mobile"
+    t.string   "mobile",                     default: ""
     t.string   "memorable_word",                             null: false
-    t.text     "notes"
+    t.text     "notes",                      default: ""
     t.boolean  "opt_out_of_market_research", default: false, null: false
     t.date     "date_of_birth"
     t.integer  "status",                     default: 0,     null: false

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -1,6 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe Appointment, type: :model do
+  describe 'Phantom audits bug regression' do
+    it 'defaults `mobile` and `notes` to empty strings' do
+      expect(described_class.new).to have_attributes(
+        mobile: '',
+        notes: ''
+      )
+    end
+  end
+
   describe 'Grace period bug regression' do
     it 'does not permit bookings inside the grace period' do
       travel_to '2017-03-26 11:05 UTC' do


### PR DESCRIPTION
These fields are usually initialised to `nil` so when a form is bound
and submitted the values change to empty strings and are thus considered
'changed'. While technically true, the generated activity messages are
confusing since no noticeable change occurs to the user.

Initialising these fields to empty strings ensures that when the
comparison is made no changes are detected.