### PR TITLE
Allow for appointments being displayed in UTC

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -127,7 +127,7 @@ class Appointment < ApplicationRecord
   end
 
   def future?
-    start_at > Time.zone.now
+    start_at.advance(hours: -1) > Time.zone.now
   end
 
   private

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -1,6 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe Appointment, type: :model do
+  describe '`#future?` does not respect timezones regression' do
+    it 'must apply the local offset when checking' do
+      appointment = build_stubbed(:appointment, start_at: Time.zone.parse('2017-03-30 12:20 UTC'))
+
+      travel_to '2017-03-30 11:41 UTC' do
+        expect(appointment).not_to be_future
+      end
+    end
+  end
+
   describe 'Phantom audits bug regression' do
     it 'defaults `mobile` and `notes` to empty strings' do
       expect(described_class.new).to have_attributes(


### PR DESCRIPTION
This is a temporary hack, please forgive me.

Appointments are stored / displayed in UTC but we're currently in BST.
An appointment scheduled for '12:20' actually takes place at '11:20'
according to the server, so when the appointment is updated after it
ends the `future?` check passes since '12:20' is greater than '11:20'.
If we substract an hour from the appointment's start time, we end up
with a true representation of time to compare with.