### PR TITLE
Allow management of appointment type

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -130,7 +130,8 @@ class AppointmentsController < ApplicationController
       :memorable_word,
       :notes,
       :opt_out_of_market_research,
-      :status
+      :status,
+      :type_of_appointment
     ]
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/lib/summary_document_link.rb
+++ b/app/lib/summary_document_link.rb
@@ -16,7 +16,7 @@ class SummaryDocumentLink
         reference_number: appointment.id,
         number_of_previous_appointments: 0,
         email: appointment.email,
-        appointment_type: (date_of_appointment - 55.years) > appointment.date_of_birth ? 'standard' : '50_54'
+        appointment_type: appointment.type_of_appointment == '50-54' ? '50_54' : appointment.type_of_appointment
       }.to_query(:appointment_summary)
     end
   end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -12,6 +12,7 @@ class Appointment < ApplicationRecord
     status
     dc_pot_confirmed
     updated_at
+    type_of_appointment
   ).freeze
 
   belongs_to :agent, class_name: 'User'
@@ -55,6 +56,7 @@ class Appointment < ApplicationRecord
   validates :date_of_birth, presence: true
   validates :memorable_word, presence: true
   validates :dc_pot_confirmed, inclusion: [true, false]
+  validates :type_of_appointment, inclusion: %w(standard 50-54)
 
   validates :status, presence: true
   validates :guider, presence: true

--- a/app/views/appointments/_personal_details_form.html.erb
+++ b/app/views/appointments/_personal_details_form.html.erb
@@ -23,5 +23,11 @@
         { class: 't-status' }
       ) if defined?(edit) && edit
     %>
+
+    <div class="form-group">
+      <p><strong>Type of appointment</strong></p>
+      <%= f.radio_button :type_of_appointment, 'standard', label: 'Appointment for customers aged 55+', class: 't-type-of-appointment-standard' %>
+      <%= f.radio_button :type_of_appointment, '50-54', label: 'Appointment for customers aged 50-54', class: 't-type-of-appointment-50-54' %>
+    </div>
   </div>
 </div>

--- a/app/views/appointments/preview.html.erb
+++ b/app/views/appointments/preview.html.erb
@@ -26,6 +26,7 @@
   <%= f.hidden_field :notes %>
   <%= f.hidden_field :opt_out_of_market_research %>
   <%= f.hidden_field :status %>
+  <%= f.hidden_field :type_of_appointment %>
 
   <div class="t-preview appointment-preview">
     <div class="row">
@@ -76,6 +77,10 @@
             <tr>
               <td class="active"><b>Opt out of market research</b></td>
               <td><%= @appointment.opt_out_of_market_research ? 'Opted out' : 'Not opted out' %></td>
+            </tr>
+            <tr>
+              <td class="active"><b>Type of appointment</b></td>
+              <td><%= @appointment.type_of_appointment.humanize %></td>
             </tr>
           </tbody>
         </table>

--- a/db/migrate/20170330154903_add_type_of_appointment_to_appointments.rb
+++ b/db/migrate/20170330154903_add_type_of_appointment_to_appointments.rb
@@ -1,0 +1,5 @@
+class AddTypeOfAppointmentToAppointments < ActiveRecord::Migration[5.0]
+  def change
+    add_column :appointments, :type_of_appointment, :string, null: false, default: 'standard'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,7 +19,7 @@ ActiveRecord::Schema.define(version: 20170330173341) do
   create_table "activities", force: :cascade do |t|
     t.integer  "appointment_id",              null: false
     t.integer  "user_id"
-    t.string   "message",        default: ""
+    t.string   "message",        default: "", null: false
     t.string   "type",                        null: false
     t.datetime "created_at",                  null: false
     t.datetime "updated_at",                  null: false
@@ -32,24 +32,25 @@ ActiveRecord::Schema.define(version: 20170330173341) do
   end
 
   create_table "appointments", force: :cascade do |t|
-    t.integer  "guider_id",                                  null: false
-    t.datetime "start_at",                                   null: false
-    t.datetime "end_at",                                     null: false
-    t.string   "first_name",                                 null: false
-    t.string   "last_name",                                  null: false
+    t.integer  "guider_id",                                       null: false
+    t.datetime "start_at",                                        null: false
+    t.datetime "end_at",                                          null: false
+    t.string   "first_name",                                      null: false
+    t.string   "last_name",                                       null: false
     t.string   "email"
-    t.string   "phone",                                      null: false
+    t.string   "phone",                                           null: false
     t.string   "mobile",                     default: ""
-    t.string   "memorable_word",                             null: false
+    t.string   "memorable_word",                                  null: false
     t.text     "notes",                      default: ""
-    t.boolean  "opt_out_of_market_research", default: false, null: false
+    t.boolean  "opt_out_of_market_research", default: false,      null: false
     t.date     "date_of_birth"
-    t.integer  "status",                     default: 0,     null: false
-    t.datetime "created_at",                                 null: false
-    t.datetime "updated_at",                                 null: false
-    t.integer  "agent_id",                                   null: false
+    t.integer  "status",                     default: 0,          null: false
+    t.datetime "created_at",                                      null: false
+    t.datetime "updated_at",                                      null: false
+    t.integer  "agent_id",                                        null: false
     t.integer  "rebooked_from_id"
-    t.boolean  "dc_pot_confirmed",           default: true,  null: false
+    t.boolean  "dc_pot_confirmed",           default: true,       null: false
+    t.string   "type_of_appointment",        default: "standard", null: false
     t.index ["start_at"], name: "index_appointments_on_start_at", using: :btree
   end
 

--- a/spec/features/agent_manages_appointments_spec.rb
+++ b/spec/features/agent_manages_appointments_spec.rb
@@ -167,6 +167,7 @@ RSpec.feature 'Agent manages appointments' do
     @page.opt_out_of_market_research.set true
     @page.start_at.set day.change(hour: 9, min: 30).to_s
     @page.end_at.set day.change(hour: 10, min: 40).to_s
+    @page.type_of_appointment_standard.set true
 
     @page.preview_appointment.click
   end
@@ -190,6 +191,7 @@ RSpec.feature 'Agent manages appointments' do
     expect(@page.preview).to have_content 'lozenge'
     expect(@page.preview).to have_content 'something'
     expect(@page.preview).to have_content 'Opted out'
+    expect(@page.preview).to have_content 'Standard'
   end
 
   def and_they_fill_in_their_appointment_details_without_an_email
@@ -215,6 +217,7 @@ RSpec.feature 'Agent manages appointments' do
     expect(appointment.start_at).to eq day.change(hour: 9, min: 30).to_s
     expect(appointment.status).to eq 'pending'
     expect(appointment.end_at).to eq day.change(hour: 10, min: 40).to_s
+    expect(appointment.type_of_appointment).to eq('standard')
   end
 
   def and_the_customer_gets_an_email_confirmation
@@ -270,6 +273,7 @@ RSpec.feature 'Agent manages appointments' do
     @page.opt_out_of_market_research.set false
     @page.start_at.set day.change(hour: 9, min: 30).to_s
     @page.end_at.set day.change(hour: 10, min: 40).to_s
+    @page.type_of_appointment_50_54.set true
 
     @page.preview_appointment.click
   end
@@ -300,6 +304,7 @@ RSpec.feature 'Agent manages appointments' do
     expect(appointment.start_at).to eq day.change(hour: 9, min: 30).to_s
     expect(appointment.status).to eq 'pending'
     expect(appointment.end_at).to eq day.change(hour: 10, min: 40).to_s
+    expect(appointment.type_of_appointment).to eq('50-54')
   end
 
   def and_there_is_an_appointment

--- a/spec/support/pages/new_appointment.rb
+++ b/spec/support/pages/new_appointment.rb
@@ -18,5 +18,7 @@ module Pages
     element :preview_appointment,                   '.t-preview-appointment'
     element :slot_unavailable_message,              '.t-slot-unavailable-message'
     element :original_appointment,                  '.t-original-appointment'
+    element :type_of_appointment_standard,          '.t-type-of-appointment-standard'
+    element :type_of_appointment_50_54,             '.t-type-of-appointment-50-54'
   end
 end


### PR DESCRIPTION
This gives agents and others the ability to specify the type of appointment
they expect the customer to have. This will be fed to the summary document
generator so TAP then becomes the canonical source for this piece of
information.

![screen shot 2017-03-31 at 12 50 26](https://cloud.githubusercontent.com/assets/41963/24549529/9e277b68-1611-11e7-9f9e-3adf54b55194.png)
