### PR TITLE
Bump default start date for calendars by an hour

### DIFF
--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -15,7 +15,7 @@ class BookableSlot < ApplicationRecord
   end
 
   def self.next_valid_start_date(user = nil)
-    return Time.zone.now if user && user.resource_manager?
+    return Time.zone.now.advance(hours: 1) if user && user.resource_manager?
 
     BusinessDays.from_now(2).change(hour: 18, min: 30)
   end

--- a/spec/models/bookable_slot_spec.rb
+++ b/spec/models/bookable_slot_spec.rb
@@ -45,11 +45,11 @@ RSpec.describe BookableSlot, type: :model do
         build_stubbed(:resource_manager)
       end
 
-      it 'is now' do
+      it 'is advanced an hour to accomodate TZ weirdness' do
         now = Chronic.parse('next Monday').in_time_zone
         travel_to(now) do
           actual = BookableSlot.next_valid_start_date(user)
-          expect(actual).to eq now
+          expect(actual).to eq now.advance(hours: 1)
         end
       end
     end


### PR DESCRIPTION
This will account for timezone discrepancies and is another ugly hack
(tm) however temporary, to workaround the timezone issues until we get
a proper workable solution in place.

Resource managers were seeing slots that have actually passed due to
the discrepancy between UTC and BST. This change ensures we add another
hour grace period to the first potentially available slot.