### PR TITLE
Reselect chosen slot after roundtripping

### DIFF
--- a/app/assets/javascripts/modules/calendars/appointment-availability.es6
+++ b/app/assets/javascripts/modules/calendars/appointment-availability.es6
@@ -110,7 +110,7 @@
       for (let eventIndex in events) {
         let event = events[eventIndex];
 
-        if (moment(start).isSame(event.start) && moment(end).isSame(event.end)) {
+        if (moment.utc(start).isSame(event.start.utc()) && moment.utc(end).isSame(event.end.utc())) {
           this.$el.fullCalendar('gotoDate', start);
           event.$div.trigger('click');
           return;


### PR DESCRIPTION
This ensures we parse the dates as UTC before comparison and thus
causes the originally selected slot to be highlighted after the form
roundtrips.