### PR TITLE
Update appointment type from date of birth

### DIFF
--- a/app/assets/javascripts/modules/customer-age.es6
+++ b/app/assets/javascripts/modules/customer-age.es6
@@ -45,6 +45,8 @@
       age = Math.floor(today.diff(inputDate, 'year'));
 
       if (age) {
+        $.publish('customer-age-change', age);
+
         this.$output.html(`Customer is <b>${age}</b> years old`);
       }
     }

--- a/app/assets/javascripts/modules/type-of-appointment.es6
+++ b/app/assets/javascripts/modules/type-of-appointment.es6
@@ -1,0 +1,29 @@
+/* global TapBase */
+{
+  'use strict';
+
+  class TypeOfAppointment extends TapBase {
+    start(el) {
+      super.start(el);
+
+      this.$standard = this.$el.find('.js-type-of-appointment-standard');
+      this.$fiftyToFiftyFour = this.$el.find('.js-type-of-appointment-50-54');
+
+      this.bindEvents();
+    }
+
+    bindEvents() {
+      $.subscribe('customer-age-change', this.handleChange.bind(this));
+    }
+
+    handleChange(event, age) {
+      if (age >= 55) {
+        this.$standard.prop('checked', true);
+      } else {
+        this.$fiftyToFiftyFour.prop('checked', true);
+      }
+    }
+  }
+
+  window.GOVUKAdmin.Modules.TypeOfAppointment = TypeOfAppointment;
+}

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -132,6 +132,14 @@ class Appointment < ApplicationRecord
     start_at.advance(hours: -1) > Time.zone.now
   end
 
+  def age
+    return 0 unless date_of_birth?
+
+    age = Time.zone.today.year - date_of_birth.year
+    age -= 1 if Time.zone.today.to_date < date_of_birth + age.years
+    age
+  end
+
   private
 
   def format_name

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -140,6 +140,13 @@ class Appointment < ApplicationRecord
     age
   end
 
+  def type_of_appointment
+    return ''    if age.zero?
+    return super if super.present?
+
+    age >= 55 ? 'standard' : '50-54'
+  end
+
   private
 
   def format_name

--- a/app/views/appointments/_personal_details_form.html.erb
+++ b/app/views/appointments/_personal_details_form.html.erb
@@ -24,10 +24,18 @@
       ) if defined?(edit) && edit
     %>
 
-    <div class="form-group">
+    <div class="form-group" data-module="type-of-appointment">
       <p><strong>Type of appointment</strong></p>
-      <%= f.radio_button :type_of_appointment, 'standard', label: 'Appointment for customers aged 55+', class: 't-type-of-appointment-standard' %>
-      <%= f.radio_button :type_of_appointment, '50-54', label: 'Appointment for customers aged 50-54', class: 't-type-of-appointment-50-54' %>
+      <%= f.radio_button :type_of_appointment,
+        'standard',
+        label: 'Appointment for customers aged 55+',
+        class: 't-type-of-appointment-standard js-type-of-appointment-standard'
+      %>
+      <%= f.radio_button :type_of_appointment,
+        '50-54',
+        label: 'Appointment for customers aged 50-54',
+        class: 't-type-of-appointment-50-54 js-type-of-appointment-50-54'
+      %>
     </div>
   </div>
 </div>

--- a/db/migrate/20170405125850_default_appointment_type.rb
+++ b/db/migrate/20170405125850_default_appointment_type.rb
@@ -1,0 +1,5 @@
+class DefaultAppointmentType < ActiveRecord::Migration[5.0]
+  def change
+    change_column_default :appointments, :type_of_appointment, ''
+  end
+end

--- a/db/migrate/20170405141224_update_appointments_with_inferred_type.rb
+++ b/db/migrate/20170405141224_update_appointments_with_inferred_type.rb
@@ -1,0 +1,16 @@
+class UpdateAppointmentsWithInferredType < ActiveRecord::Migration[5.0]
+  def up
+    Appointment.without_auditing do
+      Appointment.find_each do |appointment|
+        # clear this so it's inferred again from the age / date of birth
+        appointment.type_of_appointment = ''
+
+        appointment.update_attribute(:type_of_appointment, appointment.type_of_appointment)
+      end
+    end
+  end
+
+  def down
+    # noop
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170330173341) do
+ActiveRecord::Schema.define(version: 20170405125850) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,25 +32,25 @@ ActiveRecord::Schema.define(version: 20170330173341) do
   end
 
   create_table "appointments", force: :cascade do |t|
-    t.integer  "guider_id",                                       null: false
-    t.datetime "start_at",                                        null: false
-    t.datetime "end_at",                                          null: false
-    t.string   "first_name",                                      null: false
-    t.string   "last_name",                                       null: false
+    t.integer  "guider_id",                                  null: false
+    t.datetime "start_at",                                   null: false
+    t.datetime "end_at",                                     null: false
+    t.string   "first_name",                                 null: false
+    t.string   "last_name",                                  null: false
     t.string   "email"
-    t.string   "phone",                                           null: false
+    t.string   "phone",                                      null: false
     t.string   "mobile",                     default: ""
-    t.string   "memorable_word",                                  null: false
+    t.string   "memorable_word",                             null: false
     t.text     "notes",                      default: ""
-    t.boolean  "opt_out_of_market_research", default: false,      null: false
+    t.boolean  "opt_out_of_market_research", default: false, null: false
     t.date     "date_of_birth"
-    t.integer  "status",                     default: 0,          null: false
-    t.datetime "created_at",                                      null: false
-    t.datetime "updated_at",                                      null: false
-    t.integer  "agent_id",                                        null: false
+    t.integer  "status",                     default: 0,     null: false
+    t.datetime "created_at",                                 null: false
+    t.datetime "updated_at",                                 null: false
+    t.integer  "agent_id",                                   null: false
     t.integer  "rebooked_from_id"
-    t.boolean  "dc_pot_confirmed",           default: true,       null: false
-    t.string   "type_of_appointment",        default: "standard", null: false
+    t.boolean  "dc_pot_confirmed",           default: true,  null: false
+    t.string   "type_of_appointment",        default: "",    null: false
     t.index ["start_at"], name: "index_appointments_on_start_at", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170405125850) do
+ActiveRecord::Schema.define(version: 20170405141224) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -13,6 +13,7 @@ FactoryGirl.define do
     dc_pot_confirmed true
     memorable_word 'lozenge'
     date_of_birth '1945-01-01'
+    type_of_appointment '50-54'
     guider { create(:guider) }
 
     factory :imported_appointment do

--- a/spec/features/agent_manages_appointments_spec.rb
+++ b/spec/features/agent_manages_appointments_spec.rb
@@ -3,6 +3,16 @@ require 'rails_helper'
 RSpec.feature 'Agent manages appointments' do
   let(:day) { BusinessDays.from_now(5) }
 
+  scenario 'Appointment types are inferred from date of birth', js: true do
+    given_the_user_is_an_agent do
+      when_they_want_to_book_an_appointment
+      and_they_enter_a_standard_date_of_birth
+      then_the_standard_appointment_type_is_selected
+      when_they_enter_a_50_to_54_date_of_birth
+      then_the_50_to_54_appointment_type_is_selected
+    end
+  end
+
   scenario 'Agent creates appointments' do
     given_the_user_is_an_agent do
       and_there_is_a_guider_with_available_slots
@@ -137,6 +147,24 @@ RSpec.feature 'Agent manages appointments' do
       when_they_edit_the_appointment
       then_they_see_that_the_appointment_was_imported
     end
+  end
+
+  def and_they_enter_a_standard_date_of_birth
+    @page.date_of_birth_day.set '23'
+    @page.date_of_birth_month.set '10'
+    @page.date_of_birth_year.set '1930'
+  end
+
+  def then_the_standard_appointment_type_is_selected
+    expect(@page.type_of_appointment_standard).to be_checked
+  end
+
+  def when_they_enter_a_50_to_54_date_of_birth
+    @page.date_of_birth_year.set '1970'
+  end
+
+  def then_the_50_to_54_appointment_type_is_selected
+    expect(@page.type_of_appointment_50_54).to be_checked
   end
 
   def and_there_is_a_guider_with_available_slots

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -1,6 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe Appointment, type: :model do
+  describe '#type_of_appointment' do
+    context 'without a date of birth' do
+      it 'returns an empty string' do
+        expect(
+          build_stubbed(:appointment, date_of_birth: '').type_of_appointment
+        ).to be_empty
+      end
+    end
+
+    context 'when specified' do
+      it 'returns the underlying attribute' do
+        expect(build_stubbed(:appointment).type_of_appointment).to eq('50-54')
+      end
+    end
+
+    context 'when unspecified' do
+      it 'is inferred from the date of birth' do
+        expect(
+          build_stubbed(:appointment, type_of_appointment: '').type_of_appointment
+        ).to eq('standard')
+      end
+    end
+  end
+
   describe '#age' do
     context 'without a date of birth' do
       it 'is 0' do

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -1,6 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe Appointment, type: :model do
+  describe '#age' do
+    context 'without a date of birth' do
+      it 'is 0' do
+        expect(build_stubbed(:appointment, date_of_birth: '').age).to eq(0)
+      end
+    end
+
+    context 'when a date of birth is present' do
+      it 'returns the correct age' do
+        travel_to '2017-04-05' do
+          expect(build_stubbed(:appointment, date_of_birth: '1980-02-02').age).to eq(37)
+        end
+      end
+    end
+  end
+
   describe '`#future?` does not respect timezones regression' do
     it 'must apply the local offset when checking' do
       appointment = build_stubbed(:appointment, start_at: Time.zone.parse('2017-03-30 12:20 UTC'))


### PR DESCRIPTION
This change preselects the correct appointment type from the provided date
of birth when booking / modifying an appointment. It's possible the agent,
guider or resource manager will want to override this if they spot the
appointment is within a few months of a particular range - so this is also
possible.