### PR TITLE
Fix timezone discrepancy for past appointments

### DIFF
--- a/app/assets/javascripts/modules/calendar.es6
+++ b/app/assets/javascripts/modules/calendar.es6
@@ -165,8 +165,10 @@ class Calendar extends TapBase {
 
   eventRender(event, element) {
     const now = moment();
+    let end = event.end.clone();
 
-    if (event.end < now) {
+    // account for timezone weirdness
+    if (end.subtract(1, 'h') < now) {
       element.addClass('fc--past');
     }
   }


### PR DESCRIPTION
The `moment` or `now` is local time but the appointment end is UTC.
A comparison was made to highlight past appointments during the
course of the day.

This resolves the discrepancy (using an ugly hack) until we can put
proper timezone handling in place. We clone the end date so we don't
mutate the actual underlying time.