### PR TITLE
Dropped summary documents are high priorities

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,5 +1,5 @@
 class Activity < ApplicationRecord
-  HIGH_PRIORITY_ACTIVITY_CLASS_NAMES = %w(DropActivity).freeze
+  HIGH_PRIORITY_ACTIVITY_CLASS_NAMES = %w(DropActivity DroppedSummaryDocumentActivity).freeze
 
   belongs_to :appointment
   belongs_to :user

--- a/spec/models/dropped_summary_document_activity_spec.rb
+++ b/spec/models/dropped_summary_document_activity_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DroppedSummaryDocumentActivity do
     let(:message) { 'message' }
     subject { described_class.from(appointment) }
 
-    it 'creates a create activity for the given appointment' do
+    it 'creates a dropped activity for the given appointment' do
       expect(subject).to be_a(described_class)
 
       expect(subject).to have_attributes(


### PR DESCRIPTION
This ensures dropped summary document mailings are prioritised activities
so people can also ignore these and do nothing about them.