### PR TITLE
Ensure notifications are directed accurately

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -64,7 +64,6 @@ class Activity < ApplicationRecord
 
   after_commit if: :high_priority? do
     PusherHighPriorityCountChangedJob.perform_later(owner)
-    PusherHighPriorityCountChangedJob.perform_later(user) if user
 
     unless appointment.agent == owner
       PusherHighPriorityCountChangedJob.perform_later(appointment.agent)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -61,12 +61,4 @@ class Activity < ApplicationRecord
       PusherActivityCreatedJob.perform_later(user_id, id)
     end
   end
-
-  after_commit if: :high_priority? do
-    PusherHighPriorityCountChangedJob.perform_later(owner)
-
-    unless appointment.agent == owner
-      PusherHighPriorityCountChangedJob.perform_later(appointment.agent)
-    end
-  end
 end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -147,6 +147,10 @@ class Appointment < ApplicationRecord
     age >= 55 ? 'standard' : '50-54'
   end
 
+  def agent_is_pension_wise_api?
+    agent && agent.pension_wise_api?
+  end
+
   private
 
   def format_name
@@ -193,10 +197,6 @@ class Appointment < ApplicationRecord
 
   def agent_is_resource_manager?
     agent.present? && agent.resource_manager?
-  end
-
-  def agent_is_pension_wise_api?
-    agent && agent.pension_wise_api?
   end
 end
 

--- a/app/models/drop_activity.rb
+++ b/app/models/drop_activity.rb
@@ -1,4 +1,12 @@
 class DropActivity < Activity
+  after_commit do
+    PusherHighPriorityCountChangedJob.perform_later(owner)
+
+    unless appointment.agent_is_pension_wise_api?
+      PusherHighPriorityCountChangedJob.perform_later(appointment.agent)
+    end
+  end
+
   def self.from(event, description, appointment)
     create!(
       message: "#{event.humanize} - #{description}",

--- a/app/models/dropped_summary_document_activity.rb
+++ b/app/models/dropped_summary_document_activity.rb
@@ -1,6 +1,10 @@
 class DroppedSummaryDocumentActivity < Activity
   MESSAGE = 'fail'.freeze
 
+  after_commit do
+    PusherHighPriorityCountChangedJob.perform_later(owner)
+  end
+
   def self.from(appointment)
     create!(
       appointment: appointment,

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -57,7 +57,7 @@
 <% if current_user.guider? || current_user.agent? %>
   <li class="dropdown" data-module="high-priority-activity" data-config='{"event": "user_<%= current_user.id %>_high_priority_count"}'>
     <%= active_link_to activities_path, class: 'dropdown-toggle js-high-priority-dropdown-trigger t-high-priority-dropdown-trigger', data: { toggle: 'dropdown' }, role: 'button', aria: { haspopup: true, expanded: false } do %>
-      <span class="sr-only">My activity</span><span aria-hidden="true" class="glyphicon glyphicon-bell"></span><span class="js-high-priority-badge t-high-priority-badge badge badge-danger"<% if high_priority_activity_count == 0 %> style="display: none;"<% end %>><span class="sr-only">You have </span><span class="js-high-priority-count"><%= high_priority_activity_count %></span> <span class="sr-only">unread activity <%= 'message'.pluralize(high_priority_activity_count) %></span></span>
+      <span class="sr-only">My activity</span><span aria-hidden="true" class="glyphicon glyphicon-bell"></span><span class="js-high-priority-badge t-high-priority-badge badge badge-danger"<% if high_priority_activity_count == 0 %> style="display: none;"<% end %>><span class="sr-only">You have </span><span class="js-high-priority-count t-high-priority-count"><%= high_priority_activity_count %></span> <span class="sr-only">unread activity <%= 'message'.pluralize(high_priority_activity_count) %></span></span>
       <span class="caret"></span>
     <% end %>
     <ul class="activity-dropdown-menu dropdown-menu js-high-priority-dropdown">

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -79,7 +79,7 @@ def and_they_click_on_the_high_priority_activity_badge
 end
 
 def then_they_see_there_is_a_notification
-  @page.high_priority_alert_badge.text == '1'
+  expect(@page.high_priority_count.text).to eq('1')
 end
 
 def and_they_can_see_their_high_priority_alerts

--- a/spec/support/pages/base.rb
+++ b/spec/support/pages/base.rb
@@ -4,6 +4,7 @@ module Pages
     element :high_priority_alert_badge, '.t-high-priority-badge'
     element :high_priority_toggle, '.t-high-priority-dropdown-trigger'
     element :high_priority_activities, '.activity-dropdown-menu'
+    element :high_priority_count, '.t-high-priority-count'
     element :no_activities, '.t-no-activities'
   end
 end


### PR DESCRIPTION
In the case of dropped summary documents these are always the guider's
responsibility to action, so only they will receive the high-priority
notifications.

In the case of other dropped emails - for now we will notify both the
guider and the agent - so long as the agent is not the Pension Wise website
API agent. This is despite the `owner` of the activity always being the
guider.

Since these two activities are always considered 'high priority' we can do
away with the guard and move the event hooks into the concrete activity
classes.