### PR TITLE
Notify individuals based on the type of message

### DIFF
--- a/app/controllers/mail_gun/drops_controller.rb
+++ b/app/controllers/mail_gun/drops_controller.rb
@@ -14,6 +14,7 @@ module MailGun
         :event,
         :description,
         :appointment_id,
+        :message_type,
         :environment,
         :timestamp,
         :token,

--- a/app/forms/drop_form.rb
+++ b/app/forms/drop_form.rb
@@ -9,6 +9,7 @@ class DropForm
   attr_accessor :description
   attr_accessor :appointment_id
   attr_accessor :environment
+  attr_accessor :message_type
   attr_accessor :timestamp
   attr_accessor :token
   attr_accessor :signature
@@ -18,6 +19,7 @@ class DropForm
   validates :signature, presence: true
   validates :event, presence: true
   validates :appointment_id, presence: true
+  validates :message_type, presence: true
   validates :environment, inclusion: { in: %w(production) }
 
   def create_activity
@@ -28,6 +30,7 @@ class DropForm
     DropActivity.from(
       event,
       description,
+      message_type,
       appointment
     )
   end

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -17,8 +17,12 @@ RSpec.describe 'Activity notification alerts', js: true do
     and_they_have_an_appointment
     and_a_high_priority_activity_occurs
 
-    given_a_browser_session_for(guider, agent) do
+    given_a_browser_session_for(agent) do
       then_they_see_there_is_a_notification
+    end
+
+    given_a_browser_session_for(guider) do
+      then_they_have_no_notifications
     end
   end
 
@@ -71,7 +75,7 @@ def when_they_are_viewing_the_appointment
 end
 
 def and_a_high_priority_activity_occurs
-  DropActivity.from('an event', 'an event description', @appointment)
+  DropActivity.from('an event', 'an event description', 'booking_created', @appointment)
 end
 
 def and_they_click_on_the_high_priority_activity_badge
@@ -80,6 +84,10 @@ end
 
 def then_they_see_there_is_a_notification
   expect(@page.high_priority_count.text).to eq('1')
+end
+
+def then_they_have_no_notifications
+  expect(@page).to have_no_high_priority_count
 end
 
 def and_they_can_see_their_high_priority_alerts

--- a/spec/forms/drop_form_spec.rb
+++ b/spec/forms/drop_form_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe DropForm, '#create_activity' do
       'description'    => 'the reasoning',
       'appointment_id' => appointment.to_param,
       'environment'    => 'production',
+      'message_type'   => 'booking_created',
       'timestamp'      => '1474638633',
       'token'          => 'secret',
       'signature'      => 'abf02bef01e803bea52213cb092a31dc2174f63bcc2382ba25732f4c84e084c1'
@@ -55,11 +56,18 @@ RSpec.describe DropForm, '#create_activity' do
       expect { subject.create_activity }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
+    it 'requires a message type' do
+      params.delete('message_type')
+
+      expect(subject).not_to be_valid
+    end
+
     context 'when everything is validated' do
       it 'creates the drop activity' do
         expect(DropActivity).to receive(:from).with(
           params['event'],
           params['description'],
+          params['message_type'],
           appointment
         )
 

--- a/spec/models/drop_activity_spec.rb
+++ b/spec/models/drop_activity_spec.rb
@@ -8,23 +8,45 @@ RSpec.describe DropActivity, '.from' do
     allow(PusherHighPriorityCountChangedJob).to receive(:perform_later)
   end
 
-  subject { described_class.from('drop', 'message', appointment) }
+  context 'when the initial confirmation is dropped' do
+    subject { described_class.from('drop', 'message', 'booking_created', appointment) }
 
-  it 'creates an activity entry' do
-    expect(subject).to have_attributes(
-      appointment_id: appointment.id,
-      owner_id: appointment.guider_id,
-      message: 'Drop - message'
-    )
+    it 'creates an activity entry assigned to the agent' do
+      expect(subject).to have_attributes(
+        appointment: appointment,
+        owner: appointment.agent,
+        message: 'Drop - message'
+      )
+    end
+
+    it 'notifies the agent' do
+      expect(PusherActivityCreatedJob).to have_received(:perform_later).with(
+        appointment.agent_id,
+        subject.id
+      )
+
+      expect(PusherHighPriorityCountChangedJob).to have_received(:perform_later).with(
+        appointment.agent
+      )
+    end
   end
 
-  it 'notifies asynchronously' do
-    expect(PusherActivityCreatedJob).to have_received(:perform_later).with(
-      appointment.guider_id,
-      subject.id
-    )
-    expect(PusherHighPriorityCountChangedJob).to have_received(:perform_later).with(
-      appointment.guider
-    )
+  context 'for any other dropped email' do
+    subject { described_class.from('drop', 'message', 'booking_missed', appointment) }
+
+    it 'assigns the guider as the owner' do
+      expect(subject.owner).to eq(appointment.guider)
+    end
+
+    it 'notifies the guider' do
+      expect(PusherActivityCreatedJob).to have_received(:perform_later).with(
+        appointment.guider_id,
+        subject.id
+      )
+
+      expect(PusherHighPriorityCountChangedJob).to have_received(:perform_later).with(
+        appointment.guider
+      )
+    end
   end
 end

--- a/spec/requests/mailgun_drop_notification_spec.rb
+++ b/spec/requests/mailgun_drop_notification_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'POST /mail_gun/drops' do
     post mail_gun_drops_path, params: {
       'event'          => 'dropped',
       'description'    => 'the reasoning',
+      'environment'    => 'production',
       'appointment_id' => @appointment.to_param,
       'timestamp'      => '1474638633',
       'token'          => 'secret',
@@ -35,7 +36,7 @@ RSpec.describe 'POST /mail_gun/drops' do
   end
 
   def then_an_activity_is_created
-    expect(@appointment.activities).to_not be_empty
+    expect(DropActivity.last.appointment).to eq(@appointment)
   end
 
   def and_the_service_responds_ok

--- a/spec/requests/mailgun_drop_notification_spec.rb
+++ b/spec/requests/mailgun_drop_notification_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe 'POST /mail_gun/drops' do
       'event'          => 'dropped',
       'description'    => 'the reasoning',
       'environment'    => 'production',
+      'message_type'   => 'booking_created',
       'appointment_id' => @appointment.to_param,
       'timestamp'      => '1474638633',
       'token'          => 'secret',


### PR DESCRIPTION
We now notify and assign responsibility for dropped / bounced emails to the
agent making the booking. For any other dropped emails we assign the
responsibility and notify the guider.

Mailgun returns the original headers we supply when sending the emails so
we pick the `message_type` reliably from the inbound webhook.