### PR TITLE
Switch to `phantomjs` gem for binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ services:
 cache:
   bundler: true
   directories:
+  - $HOME/.phantomjs
   - tmp/cache/assets/test
   - tmp/cache/assets/sprockets
 before_script:

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ source 'https://rubygems.org' do
     gem 'faker'
     gem 'launchy'
     gem 'parallel_tests'
-    gem 'phantomjs-binaries'
+    gem 'phantomjs'
     gem 'pry-byebug'
     gem 'pusher-fake'
     gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,8 +237,7 @@ GEM
     parser (2.4.0.0)
       ast (~> 2.2)
     pg (0.20.0)
-    phantomjs-binaries (2.1.1.1)
-      sys-uname (= 0.9.0)
+    phantomjs (2.1.1.0)
     plek (2.0.0)
     poltergeist (1.11.0)
       capybara (~> 2.1)
@@ -402,8 +401,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sys-uname (0.9.0)
-      ffi (>= 1.0.0)
     term-ansicolor (1.4.1)
       tins (~> 1.0)
     thor (0.19.4)
@@ -463,7 +460,7 @@ DEPENDENCIES
   newrelic_rpm!
   parallel_tests!
   pg (~> 0.18)!
-  phantomjs-binaries!
+  phantomjs!
   plek!
   poltergeist (= 1.11.0)!
   postgres-copy!

--- a/spec/support/poltergeist.rb
+++ b/spec/support/poltergeist.rb
@@ -1,7 +1,14 @@
 require 'capybara/poltergeist'
 
+# Force installation when necessary
+Phantomjs.path
+
 Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, url_blacklist: %w(/timeline/v2))
+  Capybara::Poltergeist::Driver.new(
+    app,
+    url_blacklist: %w(/timeline/v2),
+    phantomjs: Phantomjs.path
+  )
 end
 
 Capybara.javascript_driver = :poltergeist


### PR DESCRIPTION
For some reason (probably `exec`ing a new process every time, but I
didn't check) the binaries and process overhead from
`phantomjs-binaries` adds around an extra 30 seconds to an `rspec` run
on my machine. We switched away from `phantomjs` in the past since it
used an unreliable bitbucket CDN that was often rate-limited in Travis,
it seems this has been addressed now so switching back to this gem
yields a ~30 second reduction in spec runs.