### PR TITLE
Allowing appointment slots to be tabbed to on availablity calendar

### DIFF
--- a/app/assets/javascripts/modules/calendars/appointment-availability.es6
+++ b/app/assets/javascripts/modules/calendars/appointment-availability.es6
@@ -43,7 +43,9 @@
       this.selectedEventColour = 'green';
     }
 
-    eventClick(event) {
+    eventClick(event, jsEvent) {
+      jsEvent.preventDefault();
+
       const events = this.$el.fullCalendar('clientEvents');
 
       let start = '',
@@ -70,9 +72,14 @@
     eventRender(event, element) {
       super.eventRender(event, element);
 
+      // force the events to have hrefs to allow them to be focusable via tabbing
+      element.attr('href', '#');
+
       element.html(`
+        <span class="sr-only">${event.start.format('dddd, MMMM Do YYYY')}</span>
         <div style="font-size:18px;">${event.start.format('HH:mm')}</div>
         <span class="glyphicon glyphicon-user" aria-hidden="true"></span> ${event.guiders}
+        <span class="sr-only">guider${event.guiders === 1 ? '' : 's'} available</span>
       `).css({
         'max-width': '46%',
         'padding': '.2em',
@@ -80,6 +87,10 @@
         'cursor': 'pointer',
         'background': this.getEventColour(event)
       });
+
+      if (event.selected === true) {
+        element.append('<span class="sr-only">Selected</span>');
+      }
     }
 
     getEventColour(event) {

--- a/app/assets/stylesheets/components/_appointment-availability-calendar.scss
+++ b/app/assets/stylesheets/components/_appointment-availability-calendar.scss
@@ -1,0 +1,14 @@
+.appointment-availability-calendar {
+  .fc-event {
+    color: $color-white;
+
+    &:visited {
+      color: $color-white;
+    }
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
+  }
+}


### PR DESCRIPTION
A lack of 'href' attributes on the event links in the calendar
meant that they could not be tabbed to.

This forces an href and also adds additional information for
screen reader users to understand what is currently selected
and what the number in an event actually means (guider count)

<img width="345" alt="screen shot 2017-05-05 at 14 46 07" src="https://cloud.githubusercontent.com/assets/6049076/25748038/96e9136a-31a1-11e7-8d3f-deb21daa176d.png">

![screen-shot-2017-05-05-at-14 46 44](https://cloud.githubusercontent.com/assets/6049076/25748088/cfca5de2-31a1-11e7-9b26-c2bbe7e675b1.png)
