### PR TITLE
Calculate type from age at appointment

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -143,8 +143,8 @@ class Appointment < ApplicationRecord
   end
 
   def type_of_appointment
+    return super if super.present? && persisted?
     return ''    if age_at_appointment.zero?
-    return super if super.present?
 
     age_at_appointment >= 55 ? 'standard' : '50-54'
   end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -136,19 +136,17 @@ class Appointment < ApplicationRecord
     start_at.advance(hours: -1) > Time.zone.now
   end
 
-  def age
-    return 0 unless date_of_birth?
+  def age_at_appointment
+    return 0 unless date_of_birth? && start_at?
 
-    age = Time.zone.today.year - date_of_birth.year
-    age -= 1 if Time.zone.today.to_date < date_of_birth + age.years
-    age
+    ((start_at.to_date - date_of_birth) / 365).floor
   end
 
   def type_of_appointment
-    return ''    if age.zero?
+    return ''    if age_at_appointment.zero?
     return super if super.present?
 
-    age >= 55 ? 'standard' : '50-54'
+    age_at_appointment >= 55 ? 'standard' : '50-54'
   end
 
   def agent_is_pension_wise_api?

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -25,18 +25,24 @@ RSpec.describe Appointment, type: :model do
     end
   end
 
-  describe '#age' do
+  describe '#age_at_appointment' do
     context 'without a date of birth' do
       it 'is 0' do
-        expect(build_stubbed(:appointment, date_of_birth: '').age).to eq(0)
+        expect(build_stubbed(:appointment, date_of_birth: '').age_at_appointment).to eq(0)
       end
     end
 
     context 'when a date of birth is present' do
-      it 'returns the correct age' do
-        travel_to '2017-04-05' do
-          expect(build_stubbed(:appointment, date_of_birth: '1980-02-02').age).to eq(37)
-        end
+      it 'returns the age at the time of the appointment' do
+        appointment = build_stubbed(
+          :appointment,
+          date_of_birth: '1980-02-02',
+          start_at: Time.zone.parse('2017-01-20 13:00')
+        )
+        expect(appointment.age_at_appointment).to eq(36)
+
+        appointment.start_at = Time.zone.parse('2017-02-02 13:00')
+        expect(appointment.age_at_appointment).to eq(37)
       end
     end
   end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -4,15 +4,19 @@ RSpec.describe Appointment, type: :model do
   describe '#type_of_appointment' do
     context 'without a date of birth' do
       it 'returns an empty string' do
-        expect(
-          build_stubbed(:appointment, date_of_birth: '').type_of_appointment
-        ).to be_empty
+        appointment = build_stubbed(
+          :appointment,
+          date_of_birth: '',
+          type_of_appointment: ''
+        )
+
+        expect(appointment.type_of_appointment).to be_empty
       end
     end
 
     context 'when specified' do
       it 'returns the underlying attribute' do
-        expect(build_stubbed(:appointment).type_of_appointment).to eq('50-54')
+        expect(create(:appointment).type_of_appointment).to eq('50-54')
       end
     end
 


### PR DESCRIPTION
This ensures the appointment type is correctly inferred from the customers age
at the time of their appointment.