### PR TITLE
Use SSL for `github` references

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,9 @@
 # rubocop:disable Metrics/BlockLength
 ruby IO.read('.ruby-version').strip
 
+# force Bundler to use SSL
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
 source 'https://rails-assets.org' do
   gem 'rails-assets-bootstrap-daterangepicker'
   gem 'rails-assets-fullcalendar', '3.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/macournoyer/thin.git
+  remote: https://github.com/macournoyer/thin.git
   revision: 5cea3f285cdbcb819c7826bbcd7b6f3bdc2ed192
   ref: 5cea3f2
   specs:
@@ -9,7 +9,7 @@ GIT
       rack (>= 1, < 3)
 
 GIT
-  remote: git://github.com/rails/rails-observers.git
+  remote: https://github.com/rails/rails-observers.git
   revision: 206cb17bc14f4f5ac6f83da4204013a69549b9dc
   specs:
     rails-observers (0.1.4)


### PR DESCRIPTION
Hopefully for obvious reasons.