### PR TITLE
Display time zone information in customer emails

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -149,6 +149,10 @@ class Appointment < ApplicationRecord
     age_at_appointment >= 55 ? 'standard' : '50-54'
   end
 
+  def timezone
+    start_at.in_time_zone('London').utc_offset.zero? ? 'GMT' : 'BST'
+  end
+
   def agent_is_pension_wise_api?
     agent && agent.pension_wise_api?
   end

--- a/app/views/appointment_mailer/cancelled.html.erb
+++ b/app/views/appointment_mailer/cancelled.html.erb
@@ -22,7 +22,7 @@
   Time:
   <br>
   <strong class="emphasize">
-    <%= @appointment.start_at.to_time.to_s(:govuk_time) %>
+    <%= "#{@appointment.start_at.to_time.to_s(:govuk_time)} (#{@appointment.timezone})" %>
   </strong>
 <% end %>
 

--- a/app/views/appointment_mailer/cancelled.text.erb
+++ b/app/views/appointment_mailer/cancelled.text.erb
@@ -8,7 +8,7 @@ Date:
 <%= @appointment.start_at.to_date.to_s(:govuk_date) %>
 
 Time:
-<%= @appointment.start_at.to_time.to_s(:govuk_time) %>
+<%= "#{@appointment.start_at.to_time.to_s(:govuk_time)} (#{@appointment.timezone})" %>
 
 Reference number:
 <%= @appointment.id %>

--- a/app/views/appointment_mailer/missed.html.erb
+++ b/app/views/appointment_mailer/missed.html.erb
@@ -22,7 +22,7 @@
   Time:
   <br>
   <strong class="emphasize">
-    <%= @appointment.start_at.to_time.to_s(:govuk_time) %>
+    <%= "#{@appointment.start_at.to_time.to_s(:govuk_time)} (#{@appointment.timezone})" %>
   </strong>
 <% end %>
 

--- a/app/views/appointment_mailer/missed.text.erb
+++ b/app/views/appointment_mailer/missed.text.erb
@@ -9,7 +9,7 @@ Date:
 <%= @appointment.start_at.to_date.to_s(:govuk_date) %>
 
 Time:
-<%= @appointment.start_at.to_time.to_s(:govuk_time) %>
+<%= "#{@appointment.start_at.to_time.to_s(:govuk_time)} (#{@appointment.timezone})" %>
 
 Your phone number:
 <%= @appointment.phone %>

--- a/app/views/shared/email/_appointment_details.html.erb
+++ b/app/views/shared/email/_appointment_details.html.erb
@@ -10,7 +10,7 @@
   Time:
   <br>
   <strong class="emphasize">
-    <%= @appointment.start_at.to_time.to_s(:govuk_time) %>
+    <%= "#{@appointment.start_at.to_time.to_s(:govuk_time)} (#{@appointment.timezone})" %>
   </strong>
 <% end %>
 

--- a/app/views/shared/email/_appointment_details.text.erb
+++ b/app/views/shared/email/_appointment_details.text.erb
@@ -2,7 +2,7 @@ Date:
 <%= @appointment.start_at.to_date.to_s(:govuk_date) %>
 
 Time:
-<%= @appointment.start_at.to_time.to_s(:govuk_time) %>
+<%= "#{@appointment.start_at.to_time.to_s(:govuk_time)} (#{@appointment.timezone})" %>
 
 Appointment lasts:
 45 to 60 minutes

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -51,6 +51,18 @@ RSpec.describe Appointment, type: :model do
     end
   end
 
+  describe '#timezone' do
+    it 'returns "GMT" when the appointment is in winter time' do
+      appointment = described_class.new(start_at: Time.zone.parse('1 January 2017 12:00'))
+      expect(appointment.timezone).to eq 'GMT'
+    end
+
+    it 'returns "BST" when the appointment is in summer time' do
+      appointment = described_class.new(start_at: Time.zone.parse('1 June 2017 12:00'))
+      expect(appointment.timezone).to eq 'BST'
+    end
+  end
+
   describe '`#future?` does not respect timezones regression' do
     it 'must apply the local offset when checking' do
       appointment = build_stubbed(:appointment, start_at: Time.zone.parse('2017-03-30 12:20 UTC'))


### PR DESCRIPTION
**Example:**

<img width="575" alt="screen shot 2017-06-16 at 15 03 31" src="https://user-images.githubusercontent.com/9943/27230086-f9a692fa-52a5-11e7-9396-cca0b0029aa5.png">
