### PR TITLE
Thoroughly guard against appointment activities

### DIFF
--- a/app/jobs/customer_update_job.rb
+++ b/app/jobs/customer_update_job.rb
@@ -2,6 +2,8 @@ class CustomerUpdateJob < ActiveJob::Base
   queue_as :default
 
   def perform(appointment, message)
+    return unless appointment.email?
+
     send_email(appointment, message)
 
     activity = CustomerUpdateActivity.from(appointment, message)

--- a/app/lib/notifier.rb
+++ b/app/lib/notifier.rb
@@ -23,8 +23,6 @@ class Notifier
   end
 
   def notify_customer
-    return unless appointment.email?
-
     if appointment_cancelled?
       CustomerUpdateJob.perform_later(appointment, CustomerUpdateActivity::CANCELLED_MESSAGE)
     elsif appointment_missed?

--- a/db/migrate/20170620093338_delete_incorrect_email_activities.rb
+++ b/db/migrate/20170620093338_delete_incorrect_email_activities.rb
@@ -1,0 +1,16 @@
+class DeleteIncorrectEmailActivities < ActiveRecord::Migration[5.1]
+  def up
+    activities = CustomerUpdateActivity
+      .joins(:appointment)
+      .where(message: CustomerUpdateActivity::CONFIRMED_MESSAGE)
+      .where(appointments: { email: '' })
+
+    say "Deleting #{activities.count} incorrectly created activities"
+
+    activities.delete_all
+  end
+
+  def down
+    # noop
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170413091442) do
+ActiveRecord::Schema.define(version: 20170620093338) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/jobs/customer_update_job_spec.rb
+++ b/spec/jobs/customer_update_job_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe CustomerUpdateJob, '#perform' do
+  include ActiveJob::TestHelper
+
+  it 'guards against no customer email' do
+    appointment = double(email?: false)
+
+    described_class.new.perform(appointment, 'message')
+
+    assert_no_enqueued_jobs
+    expect(CustomerUpdateActivity.count).to be_zero
+  end
+end


### PR DESCRIPTION
We need to thoroughly guard against notification activities for appointments
without customer-supplied email addresses. There have been ~500 created for
appointments and this bug was reported by TPAS.

Review commit-by-commit.