### PR TITLE
Prevent hiding of bookable slots that are adjacent to holidays

### DIFF
--- a/app/assets/javascripts/modules/calendars/company.es6
+++ b/app/assets/javascripts/modules/calendars/company.es6
@@ -243,8 +243,8 @@ class CompanyCalendar extends Calendar {
           )
           &&
           (
-            slots[slot].start.isBetween(holidays[holiday].start, holidays[holiday].end, null, '[]') ||
-            slots[slot].end.isBetween(holidays[holiday].start, holidays[holiday].end, null, '[]')
+            slots[slot].start.isBetween(holidays[holiday].start, holidays[holiday].end, null, '[)') ||
+            slots[slot].end.isBetween(holidays[holiday].start, holidays[holiday].end, null, '(]')
           )
         ) {
           $(`#${slots[slot].elementId}`).addClass('fc-bgevent--bookable-slot-over-holiday');

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,7 +31,7 @@ if Rails.env.development?
       :holiday,
       user: holiday_guiders.next,
       all_day: false,
-      end_at: date.end_of_day,
+      end_at: date.beginning_of_day + 1.day,
       start_at: date.beginning_of_day
     )
     print '.'


### PR DESCRIPTION
So, the solution turned out to be as simple as what I could swear I tried right at the start.

Possibly one red herring was that the test data used ActiveSupport's `end_of_day` time helper which set the end of the seeded holidays to 23:59:59 whereas holidays created within tap are 10:00 - 11:00, etc, which threw my initial assessment of the situation.

I've included a change to the seeds to address this.

Some screencaps of the behaviour below.

![Holiday just before a bookable slot](http://g.recordit.co/qQjp8wu1m9.gif)

![Holiday just after a bookable slot](http://g.recordit.co/FVpGShgaGS.gif)

![Holiday overlapping a bookable slot](http://g.recordit.co/Q3KWgNH7iG.gif)