### PR TITLE
[WIP] Assign regular drops to TP agents

### DIFF
--- a/app/forms/drop_form.rb
+++ b/app/forms/drop_form.rb
@@ -30,7 +30,6 @@ class DropForm
     DropActivity.from(
       event,
       description,
-      message_type,
       appointment
     )
   end

--- a/app/models/drop_activity.rb
+++ b/app/models/drop_activity.rb
@@ -1,16 +1,12 @@
 class DropActivity < Activity
-  def self.from(event, description, message_type, appointment)
+  def self.from(event, description, appointment)
     create!(
       message: "#{event.humanize} - #{description}",
       appointment: appointment,
-      owner: owner(appointment, message_type)
+      owner: appointment.agent
     ).tap do |activity|
       PusherHighPriorityCountChangedJob.perform_later(activity.owner)
     end
-  end
-
-  def self.owner(appointment, message_type)
-    message_type == 'booking_created' ? appointment.agent : appointment.guider
   end
 
   def pusher_notify_user_ids

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -75,7 +75,7 @@ def when_they_are_viewing_the_appointment
 end
 
 def and_a_high_priority_activity_occurs
-  DropActivity.from('an event', 'an event description', 'booking_created', @appointment)
+  DropActivity.from('an event', 'an event description', @appointment)
 end
 
 def and_they_click_on_the_high_priority_activity_badge

--- a/spec/forms/drop_form_spec.rb
+++ b/spec/forms/drop_form_spec.rb
@@ -67,7 +67,6 @@ RSpec.describe DropForm, '#create_activity' do
         expect(DropActivity).to receive(:from).with(
           params['event'],
           params['description'],
-          params['message_type'],
           appointment
         )
 

--- a/spec/models/drop_activity_spec.rb
+++ b/spec/models/drop_activity_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe DropActivity, '.from' do
     allow(PusherHighPriorityCountChangedJob).to receive(:perform_later)
   end
 
-  context 'when the initial confirmation is dropped' do
-    subject { described_class.from('drop', 'message', 'booking_created', appointment) }
+  context 'when an email is dropped' do
+    subject { described_class.from('drop', 'message', appointment) }
 
     it 'creates an activity entry assigned to the agent' do
       expect(subject).to have_attributes(
@@ -27,25 +27,6 @@ RSpec.describe DropActivity, '.from' do
 
       expect(PusherHighPriorityCountChangedJob).to have_received(:perform_later).with(
         appointment.agent
-      )
-    end
-  end
-
-  context 'for any other dropped email' do
-    subject { described_class.from('drop', 'message', 'booking_missed', appointment) }
-
-    it 'assigns the guider as the owner' do
-      expect(subject.owner).to eq(appointment.guider)
-    end
-
-    it 'notifies the guider' do
-      expect(PusherActivityCreatedJob).to have_received(:perform_later).with(
-        appointment.guider_id,
-        subject.id
-      )
-
-      expect(PusherHighPriorityCountChangedJob).to have_received(:perform_later).with(
-        appointment.guider
       )
     end
   end


### PR DESCRIPTION
Previously, we were assigning high-priority activities to the agent for
the appointment created notification and guiders for all other message
types. TPAS have requested that their guiders only receive dropped
summary document notifications so this change ensures we abide by this.