### PR TITLE
Allow `where_you_heard` to be specified

### DIFF
--- a/app/controllers/api/v1/appointments_controller.rb
+++ b/app/controllers/api/v1/appointments_controller.rb
@@ -29,7 +29,8 @@ module Api
           :memorable_word,
           :date_of_birth,
           :dc_pot_confirmed,
-          :opt_out_of_market_research
+          :opt_out_of_market_research,
+          :where_you_heard
         ).merge(agent: current_user)
       end
     end

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -131,7 +131,8 @@ class AppointmentsController < ApplicationController
       :notes,
       :opt_out_of_market_research,
       :status,
-      :type_of_appointment
+      :type_of_appointment,
+      :where_you_heard
     ]
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/forms/api/v1/appointment.rb
+++ b/app/forms/api/v1/appointment.rb
@@ -12,6 +12,7 @@ module Api
       attr_accessor :date_of_birth
       attr_accessor :dc_pot_confirmed
       attr_accessor :opt_out_of_market_research
+      attr_accessor :where_you_heard
       attr_accessor :agent
 
       attr_reader :model
@@ -42,6 +43,7 @@ module Api
           memorable_word: memorable_word,
           dc_pot_confirmed: dc_pot_confirmed,
           opt_out_of_market_research: opt_out_of_market_research,
+          where_you_heard: where_you_heard,
           agent: agent
         }
       end

--- a/app/lib/where_you_heard.rb
+++ b/app/lib/where_you_heard.rb
@@ -1,0 +1,26 @@
+class WhereYouHeard
+  OPTIONS = {
+    '0'  => 'Unspecified',
+    '1'  => 'An employer',
+    '2'  => 'A Pension Provider',
+    '3'  => 'Internet search',
+    '4'  => 'Online advertising',
+    '5'  => 'Social media',
+    '6'  => 'The Government’s GOV.UK website',
+    '7'  => 'TV advert',
+    '8'  => 'Radio advert',
+    '9'  => 'Newspaper/Magazine advert',
+    '10' => 'Local advertising - billboards, buses, bus stops',
+    '11' => 'Mentioned in a TV/radio programme or newspaper/magazine/online article',
+    '12' => 'A Financial Adviser',
+    '13' => 'Money Advice Service (MAS)',
+    '14' => 'The Pensions Advisory Service (TPAS)',
+    '15' => 'Citizens Advice',
+    '16' => 'Relative/Friend/Colleague',
+    '17' => 'Other'
+  }.freeze
+
+  def self.options_for_inclusion
+    OPTIONS.keys.drop(1).map(&:to_i)
+  end
+end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -13,6 +13,7 @@ class Appointment < ApplicationRecord
     dc_pot_confirmed
     updated_at
     type_of_appointment
+    where_you_heard
   ).freeze
 
   belongs_to :agent, class_name: 'User'

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -62,6 +62,7 @@ class Appointment < ApplicationRecord
   validates :memorable_word, presence: true
   validates :dc_pot_confirmed, inclusion: [true, false]
   validates :type_of_appointment, inclusion: %w(standard 50-54)
+  validates :where_you_heard, inclusion: WhereYouHeard.options_for_inclusion, on: :create
 
   validates :status, presence: true
   validates :guider, presence: true

--- a/app/views/appointments/_personal_details_form.html.erb
+++ b/app/views/appointments/_personal_details_form.html.erb
@@ -39,5 +39,12 @@
         class: 't-type-of-appointment-50-54 js-type-of-appointment-50-54'
       %>
     </div>
+
+    <div class="form-group">
+      <%= f.select :where_you_heard,
+            options_for_select(WhereYouHeard::OPTIONS.invert.to_a, @appointment.where_you_heard),
+            {}, { class: 't-where-you-heard form-control' }
+      %>
+    </div>
   </div>
 </div>

--- a/app/views/appointments/preview.html.erb
+++ b/app/views/appointments/preview.html.erb
@@ -27,6 +27,7 @@
   <%= f.hidden_field :opt_out_of_market_research %>
   <%= f.hidden_field :status %>
   <%= f.hidden_field :type_of_appointment %>
+  <%= f.hidden_field :where_you_heard %>
 
   <div class="t-preview appointment-preview">
     <div class="row">

--- a/db/migrate/20171021082029_add_where_you_heard_to_appointments.rb
+++ b/db/migrate/20171021082029_add_where_you_heard_to_appointments.rb
@@ -1,0 +1,5 @@
+class AddWhereYouHeardToAppointments < ActiveRecord::Migration[5.1]
+  def change
+    add_column :appointments, :where_you_heard, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170620093338) do
+ActiveRecord::Schema.define(version: 20171021082029) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 20170620093338) do
     t.integer "rebooked_from_id"
     t.boolean "dc_pot_confirmed", default: true, null: false
     t.string "type_of_appointment", default: "", null: false
+    t.integer "where_you_heard", default: 0, null: false
     t.index ["start_at"], name: "index_appointments_on_start_at"
   end
 

--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -15,6 +15,7 @@ FactoryGirl.define do
     date_of_birth '1945-01-01'
     type_of_appointment '50-54'
     guider { create(:guider) }
+    where_you_heard { WhereYouHeard.options_for_inclusion.sample }
 
     factory :imported_appointment do
       date_of_birth Appointment::FAKE_DATE_OF_BIRTH

--- a/spec/features/agent_manages_appointments_spec.rb
+++ b/spec/features/agent_manages_appointments_spec.rb
@@ -196,6 +196,7 @@ RSpec.feature 'Agent manages appointments' do
     @page.start_at.set day.change(hour: 9, min: 30).to_s
     @page.end_at.set day.change(hour: 10, min: 40).to_s
     @page.type_of_appointment_standard.set true
+    @page.where_you_heard.select 'Other'
 
     @page.preview_appointment.click
   end
@@ -246,6 +247,7 @@ RSpec.feature 'Agent manages appointments' do
     expect(appointment.status).to eq 'pending'
     expect(appointment.end_at).to eq day.change(hour: 10, min: 40).to_s
     expect(appointment.type_of_appointment).to eq('standard')
+    expect(appointment.where_you_heard).to eq(17)
   end
 
   def and_the_customer_gets_an_email_confirmation

--- a/spec/requests/appointments_api_spec.rb
+++ b/spec/requests/appointments_api_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe 'POST /api/v1/appointments' do
       'memorable_word'   => 'snootboop',
       'date_of_birth'    => '1950-02-02',
       'dc_pot_confirmed' => true,
+      'where_you_heard'  => '1',
       'opt_out_of_market_research' => true
     }
 
@@ -94,7 +95,8 @@ RSpec.describe 'POST /api/v1/appointments' do
         phone: '02082524729',
         memorable_word: 'snootboop',
         dc_pot_confirmed: true,
-        opt_out_of_market_research: true
+        opt_out_of_market_research: true,
+        where_you_heard: 1
       )
     end
   end

--- a/spec/requests/appointments_api_spec.rb
+++ b/spec/requests/appointments_api_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe 'POST /api/v1/appointments' do
       'memorable_word'   => 'snootboop',
       'date_of_birth'    => '1950-02-02',
       'dc_pot_confirmed' => true,
+      'where_you_heard'  => '1',
       'opt_out_of_market_research' => true
     }
 

--- a/spec/support/pages/new_appointment.rb
+++ b/spec/support/pages/new_appointment.rb
@@ -21,5 +21,6 @@ module Pages
     element :type_of_appointment_standard,          '.t-type-of-appointment-standard'
     element :type_of_appointment_50_54,             '.t-type-of-appointment-50-54'
     element :suggestion,                            '.t-suggestion'
+    element :where_you_heard, '.t-where-you-heard'
   end
 end


### PR DESCRIPTION
Allows clients to create appointments and assign the customer's
choice for where they first heard of Pension Wise.