### PR TITLE
Don't validate presence of WDYH when rebooked

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -62,7 +62,7 @@ class Appointment < ApplicationRecord
   validates :memorable_word, presence: true
   validates :dc_pot_confirmed, inclusion: [true, false]
   validates :type_of_appointment, inclusion: %w(standard 50-54)
-  validates :where_you_heard, inclusion: WhereYouHeard.options_for_inclusion, on: :create
+  validates :where_you_heard, inclusion: WhereYouHeard.options_for_inclusion, on: :create, unless: :rebooked_from_id?
 
   validates :status, presence: true
   validates :guider, presence: true

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -110,6 +110,16 @@ RSpec.describe Appointment, type: :model do
       expect(subject).to be_valid
     end
 
+    context 'when rebooked' do
+      it 'does not validate WDYH' do
+        subject.id = nil
+        subject.rebooked_from_id = 1
+        subject.where_you_heard  = nil
+
+        expect(subject).to be_valid
+      end
+    end
+
     required = [
       :start_at,
       :end_at,


### PR DESCRIPTION
Some bookings prior to the WDYH change will be unspecified so when
these are the basis of a rebooking we ought not to validate for WDYH
presence.