### PR TITLE
Bump `audited`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,6 @@ source 'https://rubygems.org' do
   gem 'puma', '~> 3.0'
   gem 'pusher'
   gem 'rails', '~> 5.1.1'
-  gem 'rails-observers', github: 'rails/rails-observers'
   gem 'sassc-rails'
   gem 'select2-rails'
   gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/rails/rails-observers.git
-  revision: c569dc1525259f5ab82cddf90958777473499997
-  specs:
-    rails-observers (0.2.0)
-      activemodel (>= 4.2)
-
 GEM
   remote: https://rails-assets.org/
   remote: https://rubygems.org/
@@ -155,7 +148,8 @@ GEM
     hashie (3.5.6)
     http_parser.rb (0.6.0)
     httpclient (2.8.3)
-    i18n (0.8.6)
+    i18n (0.9.1)
+      concurrent-ruby (~> 1.0)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -406,7 +400,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.7)
     tins (1.15.0)
-    tzinfo (1.2.3)
+    tzinfo (1.2.4)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
@@ -478,7 +472,6 @@ DEPENDENCIES
   rails-assets-pusher!
   rails-assets-qTip2!
   rails-assets-zloirock--core-js!
-  rails-observers!
   rails_12factor!
   rspec-rails!
   rspec-retry!
@@ -501,4 +494,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.15.4
+   1.16.0


### PR DESCRIPTION
This allows us to drop the pre-release dependency for `rails-observers`.