### PR TITLE
Send SMS reminders 48hr before appointments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ source 'https://rubygems.org' do
   gem 'kaminari'
   gem 'momentjs-rails', '2.15.1'
   gem 'newrelic_rpm'
+  gem 'notifications-ruby-client'
   gem 'oj'
   gem 'pg', '~> 0.18'
   gem 'plek'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,8 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
+    notifications-ruby-client (2.2.0)
+      jwt (~> 1.5)
     oauth2 (1.4.0)
       faraday (>= 0.8, < 0.13)
       jwt (~> 1.0)
@@ -458,6 +460,7 @@ DEPENDENCIES
   lograge!
   momentjs-rails (= 2.15.1)!
   newrelic_rpm!
+  notifications-ruby-client!
   oj!
   parallel_tests!
   pg (~> 0.18)!
@@ -501,4 +504,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/app/jobs/sms_appointment_reminder_job.rb
+++ b/app/jobs/sms_appointment_reminder_job.rb
@@ -1,0 +1,42 @@
+require 'notifications/client'
+
+class SmsAppointmentReminderJob < ApplicationJob
+  TEMPLATE_ID = '14d350d2-f962-4daa-b3b8-e6c3696864c0'.freeze
+
+  queue_as :default
+
+  def perform(appointment)
+    return unless api_key
+
+    send_sms_reminder(appointment)
+    create_activity(appointment)
+  end
+
+  private
+
+  def send_sms_reminder(appointment)
+    sms_client.send_sms(
+      phone_number: appointment.canonical_sms_number,
+      template_id: TEMPLATE_ID,
+      reference: appointment.to_param,
+      personalisation: {
+        date: appointment.start_at.to_s(:govuk_date_short)
+      }
+    )
+  end
+
+  def create_activity(appointment)
+    SmsReminderActivity.create!(
+      appointment: appointment,
+      owner: appointment.guider
+    )
+  end
+
+  def sms_client
+    @sms_client ||= Notifications::Client.new(api_key)
+  end
+
+  def api_key
+    ENV['NOTIFY_API_KEY']
+  end
+end

--- a/app/lib/sms_appointment_reminders.rb
+++ b/app/lib/sms_appointment_reminders.rb
@@ -1,0 +1,15 @@
+class SmsAppointmentReminders
+  def initialize(job_class = SmsAppointmentReminderJob)
+    @job_class = job_class
+  end
+
+  def call
+    Appointment.needing_sms_reminder.find_each do |appointment|
+      job_class.perform_later(appointment)
+    end
+  end
+
+  private
+
+  attr_reader :job_class
+end

--- a/app/models/sms_reminder_activity.rb
+++ b/app/models/sms_reminder_activity.rb
@@ -1,0 +1,5 @@
+class SmsReminderActivity < Activity
+  def pusher_notify_user_ids
+    appointment.guider_id
+  end
+end

--- a/app/views/activities/_sms_reminder_activity.html.erb
+++ b/app/views/activities/_sms_reminder_activity.html.erb
@@ -1,0 +1,7 @@
+<% content_for(:activity_message, flush: true) do %>
+  <span class="glyphicon glyphicon-phone" aria-hidden="true"></span>
+  <strong>The system</strong>
+  sent an appointment reminder SMS to
+  <strong><%= sms_reminder_activity.appointment.canonical_sms_number %></strong>
+<% end %>
+<%= render 'activities/activity', activity: sms_reminder_activity, details: details, hide: hide %>

--- a/app/views/appointments/_personal_details_form.html.erb
+++ b/app/views/appointments/_personal_details_form.html.erb
@@ -10,7 +10,9 @@
                                                         api_key: 'pubkey-b37c931b1fcef90bf2d83b7cdfd6df39',
                                                         api_host: Rails.env.test? ? 'http://localhost:9293' : nil } %>
     <%= f.telephone_field :phone, class: 't-phone', label: required_label(:phone) %>
-    <%= f.telephone_field :mobile, class: 't-mobile' %>
+    <%= f.telephone_field :mobile, class: 't-mobile',
+      help: 'Pension Wise will use this to send an SMS appointment reminder by 8am - 48 hours before the appointment.'
+    %>
     <%= render 'shared/date_of_birth_form_field', form: f if defined?(edit) && edit %>
   </div>
   <div class="col-md-6">

--- a/spec/features/sms_appointment_reminder_spec.rb
+++ b/spec/features/sms_appointment_reminder_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.feature 'SMS appointment reminders' do
+  scenario 'Executing the SMS appointment reminders job' do
+    travel_to '2017-11-28 08:00 UTC' do
+      given_appointments_due_sms_reminders_exist
+      when_the_task_is_executed
+      then_the_required_jobs_are_scheduled
+    end
+  end
+
+  def given_appointments_due_sms_reminders_exist
+    @agent = create(:resource_manager)
+    # past the reminder window
+    @past = create(:appointment, start_at: 5.days.from_now)
+    # in the window but no mobile number
+    @no_mobile = create(:appointment, mobile: '', start_at: 2.days.from_now, agent: @agent)
+    # in the window with a mobile number
+    @mobile = create(:appointment, start_at: 2.days.from_now, agent: @agent)
+  end
+
+  def when_the_task_is_executed
+    @job_class = double(SmsAppointmentReminderJob, perform_later: true)
+
+    SmsAppointmentReminders.new(@job_class).call
+  end
+
+  def then_the_required_jobs_are_scheduled
+    expect(@job_class).to have_received(:perform_later).at_most(:once)
+    expect(@job_class).to have_received(:perform_later).with(@mobile)
+  end
+end

--- a/spec/jobs/sms_appointment_reminder_job_spec.rb
+++ b/spec/jobs/sms_appointment_reminder_job_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe SmsAppointmentReminderJob, '#perform' do
+  let(:appointment) { create(:appointment) }
+  let(:client) { double(Notifications::Client, send_sms: true) }
+
+  it 'sends an SMS' do
+    expect(client).to receive(:send_sms).with(
+      phone_number: '07715 930 444',
+      template_id: SmsAppointmentReminderJob::TEMPLATE_ID,
+      reference: appointment.to_param,
+      personalisation: {
+        date: a_string_matching(/12:00pm/)
+      }
+    )
+
+    described_class.new.perform(appointment)
+
+    expect(appointment.activities.first).to be_an(SmsReminderActivity)
+  end
+
+  before do
+    ENV['NOTIFY_API_KEY'] = 'blahblah'
+
+    allow(Notifications::Client).to receive(:new).and_return(client)
+  end
+
+  after do
+    ENV.delete('NOTIFY_API_KEY')
+  end
+end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -1,6 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe Appointment, type: :model do
+  describe '#canonical_sms_number' do
+    context 'when a `mobile` is present' do
+      it 'returns the `mobile`' do
+        @appointment = Appointment.new(
+          phone: '07715 930 444',
+          mobile: '07715 999 123'
+        )
+
+        expect(@appointment.canonical_sms_number).to eq(@appointment.mobile)
+      end
+    end
+
+    context 'when a `phone` is present' do
+      it 'returns the `phone`' do
+        @appointment = Appointment.new(
+          phone: '07715 930 444',
+          mobile: ''
+        )
+
+        expect(@appointment.canonical_sms_number).to eq(@appointment.phone)
+      end
+    end
+  end
+
   describe '#type_of_appointment' do
     context 'without a date of birth' do
       it 'returns an empty string' do


### PR DESCRIPTION
Sends SMS reminders via Notify, 48 hours before an appointment is due.
This needs to be scheduled.