### PR TITLE
Remove now redundant guider conference days

### DIFF
--- a/app/controllers/bookable_slots_controller.rb
+++ b/app/controllers/bookable_slots_controller.rb
@@ -20,10 +20,7 @@ class BookableSlotsController < ApplicationController
   private
 
   def bookable_slots
-    slots = BookableSlot
-            .without_guider_conference_days
-            .within_date_range(start_at, end_at)
-
+    slots = BookableSlot.within_date_range(start_at, end_at)
     slots = slots.without_holidays.for_guider(current_user) if scoped_to_me?
     slots
   end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -78,7 +78,6 @@ class Appointment < ApplicationRecord
 
   validate :not_within_two_business_days, unless: :agent_is_resource_manager?
   validate :valid_within_booking_window
-  validate :not_during_guider_conference
   validate :date_of_birth_valid
   validate :email_valid, if: :agent_is_pension_wise_api?, on: :create
 
@@ -197,14 +196,6 @@ class Appointment < ApplicationRecord
 
   def after_audit
     Activity.from(audits.last, self)
-  end
-
-  def not_during_guider_conference
-    return unless start_at
-
-    if BookableSlot::GUIDER_CONFERENCE_DAYS.cover?(start_at.to_date) # rubocop:disable Style/GuardClause
-      errors.add(:start_at, 'must not be during the guider conference')
-    end
   end
 
   def not_within_two_business_days

--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -1,7 +1,5 @@
 # rubocop:disable Metrics/ClassLength
 class BookableSlot < ApplicationRecord
-  GUIDER_CONFERENCE_DAYS = Date.parse('2017-10-03')..Date.parse('2017-10-04')
-
   belongs_to :guider, class_name: 'User'
 
   scope :for_guider, ->(guider) { where(guider: guider) }
@@ -14,13 +12,6 @@ class BookableSlot < ApplicationRecord
 
   def self.within_date_range(from, to)
     where("#{quoted_table_name}.start_at > ? AND #{quoted_table_name}.end_at < ?", from, to)
-  end
-
-  def self.without_guider_conference_days
-    where.not(
-      "#{quoted_table_name}.start_at::date in (?)",
-      GUIDER_CONFERENCE_DAYS
-    )
   end
 
   def self.next_valid_start_date(user = nil)
@@ -38,9 +29,7 @@ class BookableSlot < ApplicationRecord
   end
 
   def self.bookable(from = nil, to = nil)
-    without_appointments(from, to)
-      .without_guider_conference_days
-      .without_holidays
+    without_appointments(from, to).without_holidays
   end
 
   def self.grouped # rubocop:disable Metrics/AbcSize

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -236,17 +236,6 @@ RSpec.describe Appointment, type: :model do
         expect(subject).to_not be_valid
       end
     end
-
-    context 'when attempting to book on a guider conference day' do
-      it 'is not valid' do
-        subject.start_at = '2017-10-03 13:00'
-        subject.end_at   = '2017-10-03 14:00'
-
-        travel_to '2017-09-25 13:00' do
-          expect(subject).not_to be_valid
-        end
-      end
-    end
   end
 
   describe '#assign_to_guider' do


### PR DESCRIPTION
This has passed so is no longer required.