### PR TITLE
Persist last date via calendar cookie

### DIFF
--- a/app/assets/javascripts/modules/calendars/allocations.es6
+++ b/app/assets/javascripts/modules/calendars/allocations.es6
@@ -94,14 +94,6 @@
         .fadeOut('slow');
     }
 
-    getCookieConfig() {
-
-    }
-
-    setCookieConfig() {
-
-    }
-
     setCalendarToCorrectHeight() {
       this.alterHeight();
       $(window).on('resize', this.debounce(this.alterHeight.bind(this), 20));


### PR DESCRIPTION
This was not enabled for this particular calendar but TPAS have
requested we change this behaviour.