### PR TITLE
Allow resource managers to adhoc reschedule

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-bootstrap-daterangepicker'
+  gem 'rails-assets-eonasdan-bootstrap-datetimepicker'
   gem 'rails-assets-fullcalendar', '3.2.0'
   gem 'rails-assets-fullcalendar-scheduler', '1.5.1'
   gem 'rails-assets-listjs'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,6 +274,9 @@ GEM
     rails-assets-bootstrap-daterangepicker (2.1.25)
       rails-assets-jquery (>= 1.9.1, < 4)
       rails-assets-moment (>= 2.9.0)
+    rails-assets-eonasdan-bootstrap-datetimepicker (4.17.47)
+      rails-assets-jquery (>= 1.8.3)
+      rails-assets-moment (>= 2.10.5)
     rails-assets-ev-emitter (1.1.1)
     rails-assets-fullcalendar (3.2.0)
       rails-assets-jquery (>= 2, < 4)
@@ -470,6 +473,7 @@ DEPENDENCIES
   pusher-fake!
   rails (~> 5.1.1)!
   rails-assets-bootstrap-daterangepicker!
+  rails-assets-eonasdan-bootstrap-datetimepicker!
   rails-assets-fullcalendar (= 3.2.0)!
   rails-assets-fullcalendar-scheduler (= 1.5.1)!
   rails-assets-listjs!

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,6 +16,7 @@
 //= require qTip2
 //= require listjs
 //= require bootstrap-daterangepicker
+//= require eonasdan-bootstrap-datetimepicker
 //= require core.js/core.js
 //= require select2
 //= require sortable-rails

--- a/app/assets/javascripts/modules/date-time-picker.es6
+++ b/app/assets/javascripts/modules/date-time-picker.es6
@@ -1,0 +1,25 @@
+/* global TapBase */
+{
+  'use strict';
+
+  class DateTimePicker extends TapBase {
+    start(el) {
+      this.config = {
+        format: 'DD/MM/YYYY h:mm a',
+        stepping: 5,
+        useCurrent: false,
+        daysOfWeekDisabled: [5, 6],
+        sideBySide: true
+      };
+
+      super.start(el);
+      this.init();
+    }
+
+    init() {
+      this.$el.datetimepicker(this.config);
+    }
+  }
+
+  window.GOVUKAdmin.Modules.DateTimePicker = DateTimePicker;
+}

--- a/app/assets/javascripts/modules/guider-select.es6
+++ b/app/assets/javascripts/modules/guider-select.es6
@@ -1,0 +1,14 @@
+/* global TapBase */
+{
+  'use strict';
+
+  class GuiderSelect extends TapBase {
+    start(el) {
+      super.start(el);
+
+      this.$el.select2({theme: 'bootstrap'});
+    }
+  }
+
+  window.GOVUKAdmin.Modules.GuiderSelect = GuiderSelect;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,3 +2,5 @@
 @import "vendor/*";
 @import "components/*";
 @import "helper/*";
+
+@import "eonasdan-bootstrap-datetimepicker";

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -160,7 +160,7 @@ class AppointmentsController < ApplicationController
   def create_params
     params
       .require(:appointment)
-      .permit(updateable_params.concat(%i(guider_id end_at rebooked_from_id)))
+      .permit(updateable_params.concat(%i(ad_hoc_start_at guider_id end_at rebooked_from_id)))
       .merge(start_at: munge_start_at)
   end
 

--- a/app/forms/api/v1/appointment.rb
+++ b/app/forms/api/v1/appointment.rb
@@ -24,7 +24,7 @@ module Api
       end
 
       def create
-        model.assign_to_guider
+        model.allocate
         model.save
       end
 

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -22,7 +22,7 @@ module UserHelper
   end
 
   def user_options
-    User.guiders.active.map do |guider|
+    User.guiders.active.reorder(:name).map do |guider|
       [
         guider.name,
         guider.id,

--- a/app/views/appointments/_schedule_form.html.erb
+++ b/app/views/appointments/_schedule_form.html.erb
@@ -17,19 +17,7 @@
         <%= form.text_field(
             :ad_hoc_start_at,
             class: 't-ad-hoc-start-at', 
-            data: {
-              module: 'date-range-picker',
-              config: {
-                singleDatePicker: true,
-                timePicker: true,
-                timePickerSeconds: false,
-                timePickerIncrement: 10,
-                autoApply: true,
-                locale: {
-                  format: 'DD/MM/YYYY h:mm A'
-                }
-              }
-            }
+            data: { module: 'date-time-picker' }
           )
         %>
       </div>

--- a/app/views/appointments/_schedule_form.html.erb
+++ b/app/views/appointments/_schedule_form.html.erb
@@ -1,0 +1,54 @@
+<div class="col-md-12" data-module="radio-toggle">
+  <% if current_user.resource_manager? %>
+    <div class="radio">
+      <%= label_tag :scheduled_true do %>
+        <%= radio_button_tag :scheduled, 'true', true, class: 't-availability-calendar-on', data: { target: 'availability-calendar-on' } %>
+        <strong>Choose from the availability calendar</strong>
+      <% end %>
+    </div>
+    <div class="radio">
+      <%= label_tag :scheduled_false do %>
+        <%= radio_button_tag :scheduled, 'false', false, class: 't-availability-calendar-off', data: { target: 'availability-calendar-off' } %>
+        <strong>Choose from ad-hoc availability</strong>
+      <% end %>
+    </div>
+    <div class="col-md-4" id="availability-calendar-off">
+      <div class="form-group">
+        <%= form.text_field(
+            :ad_hoc_start_at,
+            class: 't-ad-hoc-start-at', 
+            data: {
+              module: 'date-range-picker',
+              config: {
+                singleDatePicker: true,
+                timePicker: true,
+                timePickerSeconds: false,
+                timePickerIncrement: 10,
+                autoApply: true,
+                locale: {
+                  format: 'DD/MM/YYYY h:mm A'
+                }
+              }
+            }
+          )
+        %>
+      </div>
+      <div class="form-group">
+        <%= form.select(
+            :guider_id,
+            options_for_select(user_options),
+            { label: 'Guider' },
+            class: 't-guider',
+            data: { module: 'guider-select' }
+          )
+        %>
+      </div>
+    </div>
+    <div id="availability-calendar-on">
+      <%= render 'availability_calendar', form: form %>
+    </div>
+  <% else %>
+    <%= hidden_field_tag :scheduled, true %>
+    <%= render 'availability_calendar', form: form %>
+  <% end %>
+</div>

--- a/app/views/appointments/_schedule_form.html.erb
+++ b/app/views/appointments/_schedule_form.html.erb
@@ -2,13 +2,13 @@
   <% if current_user.resource_manager? %>
     <div class="radio">
       <%= label_tag :scheduled_true do %>
-        <%= radio_button_tag :scheduled, 'true', true, class: 't-availability-calendar-on', data: { target: 'availability-calendar-on' } %>
+        <%= radio_button_tag :scheduled, 'true', calendar_scheduling?, class: 't-availability-calendar-on', data: { target: 'availability-calendar-on' } %>
         <strong>Choose from the availability calendar</strong>
       <% end %>
     </div>
     <div class="radio">
       <%= label_tag :scheduled_false do %>
-        <%= radio_button_tag :scheduled, 'false', false, class: 't-availability-calendar-off', data: { target: 'availability-calendar-off' } %>
+        <%= radio_button_tag :scheduled, 'false', !calendar_scheduling?, class: 't-availability-calendar-off', data: { target: 'availability-calendar-off' } %>
         <strong>Choose from ad-hoc availability</strong>
       <% end %>
     </div>
@@ -36,7 +36,7 @@
       <div class="form-group">
         <%= form.select(
             :guider_id,
-            options_for_select(user_options),
+            options_for_select(user_options, @appointment.guider_id),
             { label: 'Guider' },
             class: 't-guider',
             data: { module: 'guider-select' }

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -12,9 +12,7 @@
       <h2>Date of birth</h2>
       <%= render 'shared/date_of_birth_form_field', form: f %>
     </div>
-    <div class="col-md-12">
-      <%= render 'availability_calendar', form: f %>
-    </div>
+    <%= render 'schedule_form', form: f %>
   </div>
   <%= render partial: 'personal_details_form', locals: { f: f } %>
   <div class="row form-group">

--- a/app/views/appointments/preview.html.erb
+++ b/app/views/appointments/preview.html.erb
@@ -12,10 +12,13 @@
 <hr>
 
 <%= form_for @appointment, layout: :basic do |f| %>
+  <%= hidden_field_tag :scheduled, calendar_scheduling? %>
   <%= f.hidden_field :rebooked_from_id %>
   <%= f.hidden_field :date_of_birth %>
   <%= f.hidden_field :start_at %>
+  <%= f.hidden_field :ad_hoc_start_at %>
   <%= f.hidden_field :end_at %>
+  <%= f.hidden_field :guider_id %>
 
   <%= f.hidden_field :first_name %>
   <%= f.hidden_field :last_name %>

--- a/app/views/appointments/reschedule.html.erb
+++ b/app/views/appointments/reschedule.html.erb
@@ -9,8 +9,59 @@
 <%= render 'shared/required_fields_note' %>
 <%= form_for [@appointment], url: appointment_update_reschedule_path(@appointment), layout: :basic do |f| %>
   <div class="row form-group">
-    <div class="col-md-12">
-      <%= render 'availability_calendar', form: f %>
+    <div class="col-md-12" data-module="radio-toggle">
+      <% if current_user.resource_manager? %>
+        <div class="radio">
+          <%= label_tag :scheduled_true do %>
+            <%= radio_button_tag :scheduled, 'true', true, class: 't-availability-calendar-on', data: { target: 'availability-calendar-on' } %>
+            <strong>Choose from the availability calendar</strong>
+          <% end %>
+        </div>
+        <div class="radio">
+          <%= label_tag :scheduled_false do %>
+            <%= radio_button_tag :scheduled, 'false', false, class: 't-availability-calendar-off', data: { target: 'availability-calendar-off' } %>
+            <strong>Choose from ad-hoc availability</strong>
+          <% end %>
+        </div>
+        <div class="col-md-4" id="availability-calendar-off">
+          <div class="form-group">
+            <%= f.text_field(
+                :ad_hoc_start_at,
+                class: 't-ad-hoc-start-at', 
+                data: {
+                  module: 'date-range-picker',
+                  config: {
+                    singleDatePicker: true,
+                    timePicker: true,
+                    timePickerSeconds: false,
+                    timePickerIncrement: 10,
+                    autoApply: true,
+                    locale: {
+                      format: 'DD/MM/YYYY h:mm A'
+                    }
+                  }
+                }
+              )
+            %>
+          </div>
+          <div class="form-group">
+            <%= f.select(
+                :guider_id,
+                options_for_select(user_options),
+                { label: 'Guider' },
+                class: 't-guider',
+                data: { module: 'guider-select' }
+              )
+            %>
+          </div>
+        </div>
+        <div id="availability-calendar-on">
+          <%= render 'availability_calendar', form: f %>
+        </div>
+      <% else %>
+        <%= hidden_field_tag :scheduled, true %>
+        <%= render 'availability_calendar', form: f %>
+      <% end %>
     </div>
   </div>
   <div class="row form-group">

--- a/app/views/appointments/reschedule.html.erb
+++ b/app/views/appointments/reschedule.html.erb
@@ -9,60 +9,7 @@
 <%= render 'shared/required_fields_note' %>
 <%= form_for [@appointment], url: appointment_update_reschedule_path(@appointment), layout: :basic do |f| %>
   <div class="row form-group">
-    <div class="col-md-12" data-module="radio-toggle">
-      <% if current_user.resource_manager? %>
-        <div class="radio">
-          <%= label_tag :scheduled_true do %>
-            <%= radio_button_tag :scheduled, 'true', true, class: 't-availability-calendar-on', data: { target: 'availability-calendar-on' } %>
-            <strong>Choose from the availability calendar</strong>
-          <% end %>
-        </div>
-        <div class="radio">
-          <%= label_tag :scheduled_false do %>
-            <%= radio_button_tag :scheduled, 'false', false, class: 't-availability-calendar-off', data: { target: 'availability-calendar-off' } %>
-            <strong>Choose from ad-hoc availability</strong>
-          <% end %>
-        </div>
-        <div class="col-md-4" id="availability-calendar-off">
-          <div class="form-group">
-            <%= f.text_field(
-                :ad_hoc_start_at,
-                class: 't-ad-hoc-start-at', 
-                data: {
-                  module: 'date-range-picker',
-                  config: {
-                    singleDatePicker: true,
-                    timePicker: true,
-                    timePickerSeconds: false,
-                    timePickerIncrement: 10,
-                    autoApply: true,
-                    locale: {
-                      format: 'DD/MM/YYYY h:mm A'
-                    }
-                  }
-                }
-              )
-            %>
-          </div>
-          <div class="form-group">
-            <%= f.select(
-                :guider_id,
-                options_for_select(user_options),
-                { label: 'Guider' },
-                class: 't-guider',
-                data: { module: 'guider-select' }
-              )
-            %>
-          </div>
-        </div>
-        <div id="availability-calendar-on">
-          <%= render 'availability_calendar', form: f %>
-        </div>
-      <% else %>
-        <%= hidden_field_tag :scheduled, true %>
-        <%= render 'availability_calendar', form: f %>
-      <% end %>
-    </div>
+    <%= render 'schedule_form', form: f %>
   </div>
   <div class="row form-group">
     <div class="col-md-12">

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -54,7 +54,7 @@ if Rails.env.development?
     appointment = FactoryGirl.build(:appointment, guider: User.first)
     appointment.start_at = slot.start_at
     appointment.end_at = slot.end_at
-    appointment.assign_to_guider
+    appointment.allocate
     appointment.save!
     print '.'
   end

--- a/spec/features/agent_manages_appointments_spec.rb
+++ b/spec/features/agent_manages_appointments_spec.rb
@@ -351,6 +351,7 @@ RSpec.feature 'Agent manages appointments' do
   end
 
   def when_they_reschedule_the_appointment
+    expect(@page).to have_no_availability_calendar_off
     @page.start_at.set day.change(hour: 16, min: 15).to_s
     @page.end_at.set day.change(hour: 17, min: 15).to_s
     @page.reschedule.click

--- a/spec/features/resource_manager_reschedules_an_appointment_spec.rb
+++ b/spec/features/resource_manager_reschedules_an_appointment_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.feature 'Resource manager reschedules an appointment', js: true do
+  scenario 'Rescheduling with ad-hoc allocation' do
+    given_the_user_is_a_resource_manager do
+      travel_to '2017-12-27 13:00 UTC' do
+        and_there_is_an_appointment
+        and_there_are_several_guiders
+        when_they_attempt_to_reschedule_the_appointment
+        and_select_ad_hoc_allocation
+        and_reschedule_the_appointment
+        then_the_appointment_is_rescheduled
+      end
+    end
+  end
+
+  def and_there_is_an_appointment
+    @appointment = create(:appointment)
+  end
+
+  def and_there_are_several_guiders
+    @guider_one, @guider_two = create_list(:guider, 2)
+  end
+
+  def when_they_attempt_to_reschedule_the_appointment
+    @page = Pages::RescheduleAppointment.new
+    @page.load(id: @appointment.id)
+  end
+
+  def and_select_ad_hoc_allocation
+    @page.availability_calendar_off.set(true)
+  end
+
+  def and_reschedule_the_appointment
+    @page.wait_until_ad_hoc_start_at_visible
+    # bump it to the next hour
+    @page.ad_hoc_start_at('2017-12-27 14:00')
+    # change the guider
+    @page.guider.select(@guider_two.name)
+    @page.reschedule.click
+  end
+
+  def then_the_appointment_is_rescheduled
+    @page = Pages::EditAppointment.new
+    expect(@page).to be_displayed(id: @appointment.id)
+    expect(@page).to have_flash_of_success
+
+    expect(@page.guider).to have_text(@guider_two.name)
+    expect(@page.date_time).to have_text('27 Dec 2017, 2:00pm - 3:10pm')
+  end
+end

--- a/spec/features/resource_manager_reschedules_an_appointment_spec.rb
+++ b/spec/features/resource_manager_reschedules_an_appointment_spec.rb
@@ -1,6 +1,19 @@
 require 'rails_helper'
 
 RSpec.feature 'Resource manager reschedules an appointment', js: true do
+  scenario 'Rebooking with ad-hoc allocation' do
+    given_the_user_is_a_resource_manager do
+      travel_to '2017-12-27 13:00 UTC' do
+        and_there_is_a_cancelled_appointment
+        and_there_are_several_guiders
+        when_they_attempt_to_rebook_the_appointment
+        and_select_ad_hoc_allocation
+        and_rebook_the_appointment
+        then_the_appointment_is_rebooked
+      end
+    end
+  end
+
   scenario 'Rescheduling with ad-hoc allocation' do
     given_the_user_is_a_resource_manager do
       travel_to '2017-12-27 13:00 UTC' do
@@ -18,6 +31,10 @@ RSpec.feature 'Resource manager reschedules an appointment', js: true do
     @appointment = create(:appointment)
   end
 
+  def and_there_is_a_cancelled_appointment
+    @appointment = create(:appointment, status: :cancelled_by_customer)
+  end
+
   def and_there_are_several_guiders
     @guider_one, @guider_two = create_list(:guider, 2)
   end
@@ -27,17 +44,27 @@ RSpec.feature 'Resource manager reschedules an appointment', js: true do
     @page.load(id: @appointment.id)
   end
 
+  def when_they_attempt_to_rebook_the_appointment
+    @page = Pages::NewAppointment.new
+    @page.load(query: { copy_from: @appointment.id })
+  end
+
   def and_select_ad_hoc_allocation
     @page.availability_calendar_off.set(true)
   end
 
   def and_reschedule_the_appointment
-    @page.wait_until_ad_hoc_start_at_visible
-    # bump it to the next hour
-    @page.ad_hoc_start_at('2017-12-27 14:00')
-    # change the guider
-    @page.guider.select(@guider_two.name)
+    provide_scheduling_details
     @page.reschedule.click
+  end
+
+  def and_rebook_the_appointment
+    provide_scheduling_details
+    @page.preview_appointment.click
+
+    @page = Pages::PreviewAppointment.new
+    expect(@page).to be_displayed
+    @page.confirm_appointment.click
   end
 
   def then_the_appointment_is_rescheduled
@@ -47,5 +74,24 @@ RSpec.feature 'Resource manager reschedules an appointment', js: true do
 
     expect(@page.guider).to have_text(@guider_two.name)
     expect(@page.date_time).to have_text('27 Dec 2017, 2:00pm - 3:10pm')
+  end
+
+  def then_the_appointment_is_rebooked
+    @page = Pages::Search.new
+    expect(@page).to be_displayed
+
+    expect(Appointment.last).to have_attributes(
+      guider_id: @guider_two.id,
+      start_at: Time.zone.parse('2017-12-27 14:00 UTC'),
+      end_at: Time.zone.parse('2017-12-27 15:10 UTC')
+    )
+  end
+
+  def provide_scheduling_details
+    @page.wait_until_ad_hoc_start_at_visible
+    # bump it to the next hour
+    @page.ad_hoc_start_at('2017-12-27 14:00')
+    # change the guider
+    @page.guider.select(@guider_two.name)
   end
 end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe Appointment, type: :model do
     end
   end
 
-  describe '#assign_to_guider' do
+  describe '#allocate' do
     let(:appointment_start_time) do
       BusinessDays.from_now(5).change(hour: 9, min: 0, second: 0)
     end
@@ -283,7 +283,7 @@ RSpec.describe Appointment, type: :model do
         subject.memorable_word = 'lozenge'
         subject.start_at = appointment_start_time
         subject.end_at = appointment_end_time
-        subject.assign_to_guider
+        subject.allocate
         expect(subject.guider).to eq guider_with_slot
       end
 
@@ -300,7 +300,7 @@ RSpec.describe Appointment, type: :model do
         it 'does not assign to a guider' do
           subject.start_at = appointment_start_time
           subject.end_at = appointment_end_time
-          expect { subject.assign_to_guider }.to_not change { subject.guider }
+          expect { subject.allocate }.to_not change { subject.guider }
         end
       end
 
@@ -317,7 +317,7 @@ RSpec.describe Appointment, type: :model do
         it 'does not assign to a guider' do
           subject.start_at = appointment_start_time
           subject.end_at = appointment_end_time
-          expect { subject.assign_to_guider }.to_not change { subject.guider }
+          expect { subject.allocate }.to_not change { subject.guider }
         end
       end
 
@@ -333,7 +333,7 @@ RSpec.describe Appointment, type: :model do
         it 'does not assign to a guider' do
           subject.start_at = appointment_start_time
           subject.end_at = appointment_end_time
-          expect { subject.assign_to_guider }.to_not change { subject.guider }
+          expect { subject.allocate }.to_not change { subject.guider }
         end
       end
     end

--- a/spec/support/pages/new_appointment.rb
+++ b/spec/support/pages/new_appointment.rb
@@ -1,6 +1,6 @@
 module Pages
   class NewAppointment < Base
-    set_url '/appointments/new'
+    set_url '/appointments/new{?query*}'
 
     element :first_name,                            '.t-first-name'
     element :last_name,                             '.t-last-name'
@@ -22,5 +22,14 @@ module Pages
     element :type_of_appointment_50_54,             '.t-type-of-appointment-50-54'
     element :suggestion,                            '.t-suggestion'
     element :where_you_heard, '.t-where-you-heard'
+
+    element :availability_calendar_off, '.t-availability-calendar-off'
+    element :availability_calendar_on, '.t-availability-calendar-on'
+    element :guider, '.t-guider'
+    element :ad_hoc_start_at, '.t-ad-hoc-start-at'
+
+    def ad_hoc_start_at(value)
+      execute_script("$('.t-ad-hoc-start-at').val('#{value}')")
+    end
   end
 end

--- a/spec/support/pages/reschedule_appointment.rb
+++ b/spec/support/pages/reschedule_appointment.rb
@@ -5,5 +5,14 @@ module Pages
     element :end_at,   '.t-end-at', visible: false
     element :reschedule, '.t-reschedule'
     element :slot_unavailable_message, '.t-slot-unavailable-message'
+
+    element :availability_calendar_off, '.t-availability-calendar-off'
+    element :availability_calendar_on, '.t-availability-calendar-on'
+    element :guider, '.t-guider'
+    element :ad_hoc_start_at, '.t-ad-hoc-start-at'
+
+    def ad_hoc_start_at(value)
+      execute_script("$('.t-ad-hoc-start-at').val('#{value}')")
+    end
   end
 end


### PR DESCRIPTION
Grants resource managers the ability to reschedule appointments on an
adhoc basis, ie not from the calendar schedule. When rescheduling the
resource manager is presented with a further option to select from
adhoc availability. When they select this they are then presented with
a date and guider to choose from.