### PR TITLE
Swallow and publish notify client errors

### DIFF
--- a/app/jobs/sms_appointment_reminder_job.rb
+++ b/app/jobs/sms_appointment_reminder_job.rb
@@ -5,6 +5,10 @@ class SmsAppointmentReminderJob < ApplicationJob
 
   queue_as :default
 
+  rescue_from(Notifications::Client::RequestError) do |exception|
+    Bugsnag.notify(exception)
+  end
+
   def perform(appointment)
     return unless api_key
 


### PR DESCRIPTION
The only failures we see are related to invalid numbers being provided
by our service. There is no need for these to be retried yet should be
captured for operational metrics.