### PR TITLE
Do not send reminders for fresh appointments

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -50,7 +50,7 @@ class Appointment < ApplicationRecord
   end
 
   def self.needing_reminder
-    window = Time.zone.now..48.hours.from_now.in_time_zone
+    window = 3.hours.from_now..48.hours.from_now.in_time_zone
 
     pending
       .where(start_at: window)

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -445,6 +445,16 @@ RSpec.describe Appointment, type: :model do
   end
 
   describe '.needing_reminder' do
+    context 'less than 3 hours before the appointment' do
+      it 'does not return the appointment' do
+        appointment = create(:appointment, start_at: BusinessDays.from_now(10))
+
+        travel_to(appointment.start_at - 2.hours) do
+          expect(Appointment.needing_reminder).not_to include(appointment)
+        end
+      end
+    end
+
     context 'more than 48 hours before the appointment' do
       it 'does not return the appointment' do
         appointment = create(:appointment, start_at: BusinessDays.from_now(10))


### PR DESCRIPTION
Now appointments can be created at very short notice we need to guard
against this particular circumstance. By extending the window a few
hours we allow a grace period before sending a reminder.