### PR TITLE
Explicitly wait for the field to be cleared

### DIFF
--- a/spec/features/user_views_booking_activities_spec.rb
+++ b/spec/features/user_views_booking_activities_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'User views appointment activities' do
   end
 
   def and_the_message_field_is_cleared
-    expect(@page.activity_feed.message.value).to eq('')
+    expect(@page.activity_feed.message).to have_text('')
   end
 
   def and_the_appointment_was_updated_multiple_times


### PR DESCRIPTION
This was causing intermittent timing issues during spec runs in the CI
environment.