### PR TITLE
Extend permissable booking window

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -230,8 +230,8 @@ class Appointment < ApplicationRecord
   def valid_within_booking_window
     return unless start_at
 
-    too_late = start_at > BusinessDays.from_now(40)
-    errors.add(:start_at, 'must be less than 40 business days from now') if too_late
+    too_late = start_at > BusinessDays.from_now(45)
+    errors.add(:start_at, 'must be less than 45 business days from now') if too_late
   end
 
   def date_of_birth_valid

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -215,8 +215,8 @@ RSpec.describe Appointment, type: :model do
       end
     end
 
-    it 'cannot be booked further ahead than forty working days' do
-      subject.start_at = BusinessDays.from_now(41)
+    it 'cannot be booked further ahead than forty five working days' do
+      subject.start_at = BusinessDays.from_now(46)
       subject.validate
       expect(subject.errors[:start_at]).to_not be_empty
     end


### PR DESCRIPTION
This resolves the discrepancy between the slots being displayed in the
internal booking journey and the latest slot actually allowed.