### PR TITLE
Ensure validation errors on `start_at` display

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -192,6 +192,10 @@ class Appointment < ApplicationRecord
     agent && agent.pension_wise_api?
   end
 
+  def unable_to_assign?
+    errors.key?(:guider) || errors.key?(:start_at)
+  end
+
   private
 
   def allocate_slot

--- a/app/views/appointments/_availability_calendar.html.erb
+++ b/app/views/appointments/_availability_calendar.html.erb
@@ -1,5 +1,5 @@
 <h2>Choose available slot <%= required_label %></h2>
-<% if @appointment.errors[:guider].any? %>
+<% if @appointment.unable_to_assign? %>
   <%= render 'unable_to_assign' %>
 <% end %>
 

--- a/app/views/appointments/_unable_to_assign.html.erb
+++ b/app/views/appointments/_unable_to_assign.html.erb
@@ -1,3 +1,3 @@
 <p class="text-danger js-slot-unavailable-message t-slot-unavailable-message">
-  Unable to assign appointment to a slot, please choose a slot.
+  Unable to assign appointment to the chosen slot, please choose another slot.
 </p>


### PR DESCRIPTION
These were not being shown when present and this causes confusion to
the agents when attempting to place appointments.