### PR TITLE
Do not alert guiders on drop notifications

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -6,7 +6,7 @@ class Activity < ApplicationRecord
   belongs_to :owner, class_name: 'User'
   belongs_to :prior_owner, class_name: 'User'
   belongs_to :resolver, class_name: 'User'
-  validates :owner, presence: true
+  validates :owner, presence: true, if: :owner_required?
 
   scope :resolved, -> { where.not(resolved_at: nil) }
   scope :unresolved, -> { where(resolved_at: nil) }
@@ -54,6 +54,10 @@ class Activity < ApplicationRecord
 
   def pusher_notify_user_ids
     []
+  end
+
+  def owner_required?
+    true
   end
 
   after_commit on: :create do

--- a/app/models/drop_activity.rb
+++ b/app/models/drop_activity.rb
@@ -5,15 +5,19 @@ class DropActivity < Activity
       appointment: appointment,
       owner: owner(appointment, message_type)
     ).tap do |activity|
-      PusherHighPriorityCountChangedJob.perform_later(activity.owner)
+      PusherHighPriorityCountChangedJob.perform_later(activity.owner) if activity.owner
     end
   end
 
   def self.owner(appointment, message_type)
-    message_type == 'booking_created' ? appointment.agent : appointment.guider
+    return appointment.agent if message_type == 'booking_created'
   end
 
   def pusher_notify_user_ids
     owner_id
+  end
+
+  def owner_required?
+    false
   end
 end

--- a/spec/models/drop_activity_spec.rb
+++ b/spec/models/drop_activity_spec.rb
@@ -34,19 +34,12 @@ RSpec.describe DropActivity, '.from' do
   context 'for any other dropped email' do
     subject { described_class.from('drop', 'message', 'booking_missed', appointment) }
 
-    it 'assigns the guider as the owner' do
-      expect(subject.owner).to eq(appointment.guider)
+    it 'does not associate an owner' do
+      expect(subject.owner).to be_nil
     end
 
-    it 'notifies the guider' do
-      expect(PusherActivityCreatedJob).to have_received(:perform_later).with(
-        appointment.guider_id,
-        subject.id
-      )
-
-      expect(PusherHighPriorityCountChangedJob).to have_received(:perform_later).with(
-        appointment.guider
-      )
+    it 'does not issue priority notifications' do
+      expect(PusherHighPriorityCountChangedJob).not_to have_received(:perform_later)
     end
   end
 end


### PR DESCRIPTION
This ensures guiders are not alerted or assigned high-priority
activities when an email is permanently failed by mailgun. They will
continue to receive notifications and assignments for dropped summary
documents.