### PR TITLE
Associate high priority activities with owner

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -23,9 +23,7 @@ class Activity < ApplicationRecord
   end
 
   def self.high_priority_for(user)
-    high_priority
-      .joins(:appointment)
-      .where('appointments.agent_id = :user OR appointments.guider_id = :user', user: user)
+    high_priority.where(owner: user)
   end
 
   def user_name

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -34,9 +34,14 @@ RSpec.describe 'Activity notification alerts', js: true do
     and_they_have_an_appointment
     and_a_high_priority_activity_occurs
 
-    given_a_browser_session_for(guider, agent) do
+    given_a_browser_session_for(agent) do
       and_they_click_on_the_high_priority_activity_badge
       and_they_can_see_their_high_priority_alerts
+    end
+
+    given_a_browser_session_for(guider) do
+      and_they_click_on_the_high_priority_activity_badge
+      then_they_can_see_no_high_priority_alerts_message
     end
   end
 


### PR DESCRIPTION
These were incorrectly determined by the associated appointment's
guider or agent. The `owner` is the person directly responsible for the
resolution of the activity so it should only show up in their
feed/alerts.