### PR TITLE
Configure 2018 bank holidays

### DIFF
--- a/config/initializers/working_hours.rb
+++ b/config/initializers/working_hours.rb
@@ -1,9 +1,7 @@
 WorkingHours::Config.holidays = [
-  Date.parse('14/04/2017'),
-  Date.parse('17/04/2017'),
-  Date.parse('01/05/2017'),
-  Date.parse('29/05/2017'),
-  Date.parse('28/08/2017'),
-  Date.parse('25/12/2017'),
-  Date.parse('26/12/2017')
+  Date.parse('07/05/2018'),
+  Date.parse('28/05/2018'),
+  Date.parse('27/08/2018'),
+  Date.parse('25/12/2018'),
+  Date.parse('26/12/2018')
 ]

--- a/spec/models/bookable_slot_spec.rb
+++ b/spec/models/bookable_slot_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe BookableSlot, type: :model do
         subject { BookableSlot.next_valid_start_date(user) }
 
         it 'takes account of holidays' do
-          travel_to '2017-04-13 12:00' do
-            expect(subject.to_date).to eq('2017-04-19'.to_date)
+          travel_to '2018-05-05 12:00' do
+            expect(subject.to_date).to eq('2018-05-09'.to_date)
           end
         end
       end


### PR DESCRIPTION
This ensures the next working day logic is calculated correctly when
booking appointments or displaying availability.