### PR TITLE
Reduce grace period to one business day

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -80,7 +80,7 @@ class Appointment < ApplicationRecord
   validates :status, presence: true
   validates :guider, presence: true
 
-  validate :not_within_two_business_days, unless: :agent_is_resource_manager?
+  validate :not_within_grace_period, unless: :agent_is_resource_manager?
   validate :valid_within_booking_window
   validate :not_during_guider_conference
   validate :date_of_birth_valid
@@ -224,11 +224,11 @@ class Appointment < ApplicationRecord
     end
   end
 
-  def not_within_two_business_days
+  def not_within_grace_period
     return unless new_record? && start_at?
 
     too_soon = start_at < BookableSlot.next_valid_start_date
-    errors.add(:start_at, 'must be more than two business days from now') if too_soon
+    errors.add(:start_at, 'must be more than one business day from now') if too_soon
   end
 
   def valid_within_booking_window

--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -26,7 +26,7 @@ class BookableSlot < ApplicationRecord
   def self.next_valid_start_date(user = nil)
     return Time.zone.now.advance(hours: 1) if user && user.resource_manager?
 
-    BusinessDays.from_now(2).change(hour: 18, min: 30)
+    BusinessDays.from_now(1).change(hour: 18, min: 30)
   end
 
   def self.find_available_slot(start_at)

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Appointment, type: :model do
       travel_to '2017-03-26 11:05 UTC' do
         # force new_record? to evaluate truthily
         appointment = Appointment.new(
-          attributes_for(:appointment, start_at: Time.zone.parse('2017-03-28 11:20 UTC'))
+          attributes_for(:appointment, start_at: Time.zone.parse('2017-03-27 11:20 UTC'))
         )
 
         expect(appointment).to be_invalid

--- a/spec/models/bookable_slot_spec.rb
+++ b/spec/models/bookable_slot_spec.rb
@@ -26,13 +26,13 @@ RSpec.describe BookableSlot, type: :model do
         after { travel_back }
 
         {
-          'Monday'    => 'Wednesday',
-          'Tuesday'   => 'Thursday',
-          'Wednesday' => 'Friday',
-          'Thursday'  => 'Monday',
-          'Friday'    => 'Tuesday',
-          'Saturday'  => 'Tuesday',
-          'Sunday'    => 'Tuesday'
+          'Monday'    => 'Tuesday',
+          'Tuesday'   => 'Wednesday',
+          'Wednesday' => 'Thursday',
+          'Thursday'  => 'Friday',
+          'Friday'    => 'Monday',
+          'Saturday'  => 'Monday',
+          'Sunday'    => 'Monday'
         }.each do |day, expected_day|
           context "Day is #{day}" do
             it "next valid start date is #{expected_day}" do
@@ -51,7 +51,7 @@ RSpec.describe BookableSlot, type: :model do
 
         it 'takes account of holidays' do
           travel_to '2018-05-05 12:00' do
-            expect(subject.to_date).to eq('2018-05-09'.to_date)
+            expect(subject.to_date).to eq('2018-05-08'.to_date)
           end
         end
       end


### PR DESCRIPTION
Cuts the initial grace period for bookings down to one business day, as
requested by TPAS.