### PR TITLE
Ensure appointments with email are not printed

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -193,7 +193,7 @@ class Appointment < ApplicationRecord
 
   def self.needing_print_confirmation
     pending
-      .where(batch_processed_at: nil)
+      .where(batch_processed_at: nil, email: '')
       .where.not(address_line_one: '')
   end
 

--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -26,6 +26,7 @@ FactoryBot.define do
     end
 
     trait :with_address do
+      email ''
       address_line_one '10 Some Road'
       address_line_two 'Some Street'
       address_line_three 'Somewhere'


### PR DESCRIPTION
When an email AND postal address is supplied, we should not be exporting
these appointments for print confirmation.