### PR TITLE
Validate only an email/address is present

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -279,11 +279,12 @@ class Appointment < ApplicationRecord
   end
 
   def address_or_email_valid
-    unless address? || email? # rubocop:disable GuardClause
-      errors.add(
-        :base,
-        'Please supply either an email or confirmation address'
-      )
+    unless address? || email?
+      errors.add(:base, 'Please supply either an email or confirmation address')
+    end
+
+    if email? && address? # rubocop:disable GuardClause
+      errors.add(:base, 'Please supply only an email or confirmation address, not both')
     end
   end
 

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -238,14 +238,20 @@ RSpec.describe Appointment, type: :model do
 
           expect(subject).to be_valid
         end
+
+        it 'does not permit the presence of an email' do
+          subject.email = 'ben@example.com'
+
+          expect(subject).to be_invalid
+        end
       end
     end
 
     context 'when not persisted' do
       before { allow(subject).to receive(:new_record?).and_return(true) }
 
-      it 'cannot be booked within two working days' do
-        subject.start_at = BusinessDays.from_now(1)
+      it 'cannot be booked at short notice' do
+        subject.start_at = 1.hour.from_now
         subject.validate
         expect(subject.errors[:start_at]).to_not be_empty
       end


### PR DESCRIPTION
Don't permit both an email address and a postal address for
confirmation as they should be mutually exclusive.