### PR TITLE
Tag the `email` field with the errors

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -280,11 +280,11 @@ class Appointment < ApplicationRecord
 
   def address_or_email_valid
     unless address? || email?
-      errors.add(:base, 'Please supply either an email or confirmation address')
+      errors.add(:email, 'Please supply either an email or confirmation address')
     end
 
     if email? && address? # rubocop:disable GuardClause
-      errors.add(:base, 'Please supply only an email or confirmation address, not both')
+      errors.add(:email, 'Please supply only an email or confirmation address, not both')
     end
   end
 

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -243,6 +243,7 @@ RSpec.describe Appointment, type: :model do
           subject.email = 'ben@example.com'
 
           expect(subject).to be_invalid
+          expect(subject.errors[:email]).not_to be_empty
         end
       end
     end


### PR DESCRIPTION
These errors were previously attributed to `base` and weren't being
displayed sensibly. Tagging them to the `email` field ensures they
appear in the correct context when creating an appointment.