### PR TITLE
Summarise availability data for reporting

### DIFF
--- a/app/lib/scheduled_reporting_summary.rb
+++ b/app/lib/scheduled_reporting_summary.rb
@@ -1,0 +1,29 @@
+class ScheduledReportingSummary
+  def call
+    ReportingSummary.create!(
+      organisation: 'TPAS',
+      four_week_availability: four_week_available?,
+      first_available_slot_on: first_available_slot_on
+    )
+  end
+
+  def four_week_available?
+    return false unless windowed_bookable_slots.first
+
+    windowed_bookable_slots.first <= four_week_period
+  end
+
+  def first_available_slot_on
+    windowed_bookable_slots.first
+  end
+
+  private
+
+  def four_week_period
+    BusinessDays.from_now(20)
+  end
+
+  def windowed_bookable_slots
+    BookableSlot.grouped.map(&:first)
+  end
+end

--- a/app/models/reporting_summary.rb
+++ b/app/models/reporting_summary.rb
@@ -1,0 +1,2 @@
+class ReportingSummary < ApplicationRecord
+end

--- a/db/migrate/20180423115902_create_reporting_summaries.rb
+++ b/db/migrate/20180423115902_create_reporting_summaries.rb
@@ -1,0 +1,11 @@
+class CreateReportingSummaries < ActiveRecord::Migration[5.1]
+  def change
+    create_table :reporting_summaries do |t|
+      t.string :organisation, null: false
+      t.boolean :four_week_availability, null: false
+      t.date :first_available_slot_on
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180322154626) do
+ActiveRecord::Schema.define(version: 20180423115902) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -122,6 +122,14 @@ ActiveRecord::Schema.define(version: 20180322154626) do
     t.boolean "all_day", default: false, null: false
     t.index ["start_at", "end_at"], name: "index_holidays_on_start_at_and_end_at"
     t.index ["user_id"], name: "index_holidays_on_user_id"
+  end
+
+  create_table "reporting_summaries", force: :cascade do |t|
+    t.string "organisation", null: false
+    t.boolean "four_week_availability", null: false
+    t.date "first_available_slot_on"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "schedules", id: :serial, force: :cascade do |t|

--- a/spec/features/scheduled_reporting_summary_spec.rb
+++ b/spec/features/scheduled_reporting_summary_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.feature 'Scheduled reporting summary' do
+  scenario 'When there is no availability' do
+    when_the_scheduled_report_runs
+    then_the_availability_is_summarised
+  end
+
+  scenario 'When there is availability' do
+    travel_to '2018-04-23 10:00' do
+      given_availability_in_the_booking_window
+      when_the_scheduled_report_runs
+      then_the_availability_is_summarised_correctly
+    end
+  end
+
+  def given_availability_in_the_booking_window
+    @slot = create(:bookable_slot, start_at: Time.zone.parse('2018-04-26 09:00'))
+  end
+
+  def then_the_availability_is_summarised_correctly
+    expect(ReportingSummary.count).to eq(1)
+
+    expect(ReportingSummary.first).to have_attributes(
+      organisation: 'TPAS',
+      four_week_availability: true,
+      first_available_slot_on: '2018-04-26'.to_date
+    )
+  end
+
+  def when_the_scheduled_report_runs
+    ScheduledReportingSummary.new.call
+  end
+
+  def then_the_availability_is_summarised
+    expect(ReportingSummary.count).to eq(1)
+
+    expect(ReportingSummary.first).to have_attributes(
+      organisation: 'TPAS',
+      four_week_availability: false,
+      first_available_slot_on: nil
+    )
+  end
+end


### PR DESCRIPTION
This will be scheduled to run every morning before the day's
appointments are due to start. It summarises availability over the
following four week period, inside of the regular booking window.

At the moment this is only concerned with TPAS guider appointments but
once we support multiple providers it will address other provider's
appointments also.