### PR TITLE
Store status transitions upon creation or changes

### DIFF
--- a/app/models/status_transition.rb
+++ b/app/models/status_transition.rb
@@ -1,0 +1,3 @@
+class StatusTransition < ApplicationRecord
+  belongs_to :appointment
+end

--- a/db/migrate/20180425083620_create_status_transitions.rb
+++ b/db/migrate/20180425083620_create_status_transitions.rb
@@ -1,0 +1,10 @@
+class CreateStatusTransitions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :status_transitions do |t|
+      t.belongs_to :appointment, index: true
+      t.string :status, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180423115902) do
+ActiveRecord::Schema.define(version: 20180425083620) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -148,6 +148,14 @@ ActiveRecord::Schema.define(version: 20180423115902) do
     t.integer "start_minute"
     t.integer "end_hour"
     t.integer "end_minute"
+  end
+
+  create_table "status_transitions", force: :cascade do |t|
+    t.bigint "appointment_id"
+    t.string "status", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["appointment_id"], name: "index_status_transitions_on_appointment_id"
   end
 
   create_table "users", id: :serial, force: :cascade do |t|

--- a/lib/tasks/statuses.rake
+++ b/lib/tasks/statuses.rake
@@ -1,0 +1,22 @@
+namespace :statuses do
+  desc 'Generate `status_transitions` from audits'
+  task generate: :environment do
+    ActiveRecord::Base.transaction do
+      Audited::Audit.find_each do |audit|
+        if audit.audited_changes.key?('status') && audit.auditable
+          appointment = audit.auditable
+          status      = audit.audited_changes['status']
+
+          # Status is scalar for the initial creation
+          status = status.is_a?(Array) ? status.last : status
+
+          appointment.status_transitions.create!(
+            status: status,
+            created_at: audit.created_at,
+            updated_at: audit.created_at
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -1,6 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe Appointment, type: :model do
+  context 'when the status changes before saving' do
+    it 'stores the associated statuses' do
+      appointment = create(:appointment)
+
+      expect(appointment.status_transitions.map(&:status)).to match_array('pending')
+
+      appointment.update(status: 'cancelled_by_pension_wise')
+
+      expect(appointment.status_transitions.map(&:status)).to match_array(
+        %w(pending cancelled_by_pension_wise)
+      )
+    end
+  end
+
   context 'when copying an appointment that had printed confirmation' do
     it 'ensures the copy will also be batch processed' do
       @old  = create(:appointment, batch_processed_at: Time.zone.now, status: :complete)


### PR DESCRIPTION
Stores the status transition in an association when it is initially created
or upon a status change.