### PR TITLE
Ensure the activity feed is updated in realtime

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -184,10 +184,12 @@ class Appointment < ApplicationRecord
   end
 
   def cancel!
-    transaction do
-      update!(status: :cancelled_by_customer_sms)
+    without_auditing do
+      transaction do
+        update!(status: :cancelled_by_customer_sms)
 
-      SmsCancellationActivity.from(self)
+        SmsCancellationActivity.from(self)
+      end
     end
   end
 

--- a/app/models/sms_cancellation_activity.rb
+++ b/app/models/sms_cancellation_activity.rb
@@ -5,4 +5,8 @@ class SmsCancellationActivity < Activity
       owner: appointment.guider
     )
   end
+
+  def pusher_notify_user_ids
+    appointment.guider_id
+  end
 end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -1,6 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe Appointment, type: :model do
+  describe '#cancel!' do
+    it 'does not audit any changes' do
+      appointment = create(:appointment)
+      appointment.audits.destroy_all
+
+      appointment.cancel!
+
+      expect(appointment.reload.audits).to be_empty
+    end
+  end
+
   describe '.for_sms_cancellation' do
     context 'when two appointment exist with the same number' do
       it 'returns the appointment created last' do

--- a/spec/models/sms_cancellation_activity_spec.rb
+++ b/spec/models/sms_cancellation_activity_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe SmsCancellationActivity do
+  let(:appointment) { create(:appointment) }
+
+  subject { described_class.from(appointment) }
+
+  it 'notifies the owning guider' do
+    expect(subject.pusher_notify_user_ids).to eq(appointment.guider_id)
+  end
+end


### PR DESCRIPTION
Unless the `pusher_notify_user_ids` are present, the feed is not updated
since they're tied to the update job.