### PR TITLE
Include SMS cancellations with regular ones

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -4,6 +4,12 @@ class Appointment < ApplicationRecord
 
   acts_as_copy_target
 
+  CANCELLED_STATUSES = %i(
+    cancelled_by_customer
+    cancelled_by_pension_wise
+    cancelled_by_customer_sms
+  ).freeze
+
   APPOINTMENT_LENGTH_MINUTES = 70.minutes.freeze
 
   FAKE_DATE_OF_BIRTH = Date.parse('1900-01-01').freeze
@@ -44,8 +50,8 @@ class Appointment < ApplicationRecord
 
   attr_accessor :ad_hoc_start_at
 
-  scope :cancelled, -> { where(status: %i(cancelled_by_customer cancelled_by_pension_wise)) }
-  scope :not_cancelled, -> { where.not(status: %i(cancelled_by_customer cancelled_by_pension_wise)) }
+  scope :cancelled, -> { where(status: CANCELLED_STATUSES) }
+  scope :not_cancelled, -> { where.not(status: CANCELLED_STATUSES) }
   scope :with_mobile_number, -> { where("mobile != '' or phone like '07%'") }
 
   validates :agent, presence: true

--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -63,7 +63,8 @@ class BookableSlot < ApplicationRecord
               #{reduce_by_range(:appointments, from, to)}
               AND NOT appointments.status IN (
                 #{Appointment.statuses['cancelled_by_customer']},
-                #{Appointment.statuses['cancelled_by_pension_wise']}
+                #{Appointment.statuses['cancelled_by_pension_wise']},
+                #{Appointment.statuses['cancelled_by_customer_sms']}
               )
               AND (
                 appointments.start_at, appointments.end_at


### PR DESCRIPTION
Since the introduction of SMS cancellations we should include the newly
introduced `cancelled_by_customer_sms` status when querying by the
previous cancellation statuses to ensure reports are accurate.