### PR TITLE
Be more permissive with SMS cancellation trigger

### DIFF
--- a/app/forms/sms_cancellation.rb
+++ b/app/forms/sms_cancellation.rb
@@ -5,7 +5,7 @@ class SmsCancellation
   attr_accessor :message
 
   validates :source_number, presence: true
-  validates :message, presence: true, format: { with: /\Acancel/i }
+  validates :message, presence: true, format: { with: /\A'?cancel'?/i }
 
   def call
     if valid? && appointment

--- a/spec/forms/sms_cancellation_spec.rb
+++ b/spec/forms/sms_cancellation_spec.rb
@@ -18,8 +18,10 @@ RSpec.describe SmsCancellation do
 
     it 'requires the correct `message` for cancellation' do
       subject.message = 'Please cancel my appointment.'
-
       expect(subject).to be_invalid
+
+      subject.message = "'Cancel'"
+      expect(subject).to be_valid
     end
   end
 


### PR DESCRIPTION
The reminder SMS tells the customer to reply 'Cancel' to cancel their
appointment so some customers respond literally. This change makes the
trigger text more permissive in regards to accepting optional quote
marks.