### PR TITLE
Summarise availability per provider

### DIFF
--- a/app/lib/scheduled_reporting_summary.rb
+++ b/app/lib/scheduled_reporting_summary.rb
@@ -1,20 +1,30 @@
 class ScheduledReportingSummary
+  ORGANISATIONS = {
+    User::TPAS_ORGANISATION_ID => 'TPAS',
+    User::TP_ORGANISATION_ID   => 'TP',
+    User::CAS_ORGANISATION_ID  => 'CAS'
+  }.freeze
+
   def call
-    ReportingSummary.create!(
-      organisation: 'TPAS',
-      four_week_availability: four_week_available?,
-      first_available_slot_on: first_available_slot_on
-    )
+    ORGANISATIONS.each do |id, name|
+      ReportingSummary.create!(
+        organisation: name,
+        four_week_availability: four_week_available?(id),
+        first_available_slot_on: first_available_slot_on(id)
+      )
+    end
   end
 
-  def four_week_available?
-    return false unless windowed_bookable_slots.first
+  def four_week_available?(organisation_id)
+    slot = first_available_slot_on(organisation_id)
 
-    windowed_bookable_slots.first <= four_week_period
+    return false unless slot
+
+    slot <= four_week_period
   end
 
-  def first_available_slot_on
-    windowed_bookable_slots.first
+  def first_available_slot_on(organisation_id)
+    windowed_bookable_slots(organisation_id).first
   end
 
   private
@@ -23,7 +33,7 @@ class ScheduledReportingSummary
     BusinessDays.from_now(20)
   end
 
-  def windowed_bookable_slots
-    BookableSlot.grouped.map(&:first)
+  def windowed_bookable_slots(organisation_id)
+    BookableSlot.grouped(organisation_id).map(&:first)
   end
 end

--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -43,12 +43,14 @@ class BookableSlot < ApplicationRecord
       .without_holidays
   end
 
-  def self.grouped # rubocop:disable Metrics/AbcSize
+  def self.grouped(organisation_id = nil) # rubocop:disable Metrics/AbcSize
     from = next_valid_start_date
     to   = 8.weeks.from_now.end_of_day
 
-    bookable(from, to)
-      .within_date_range(from, to)
+    scope = bookable(from, to).within_date_range(from, to)
+    scope = scope.joins(:guider).where(users: { organisation_content_id: organisation_id }) if organisation_id
+
+    scope
       .select("#{quoted_table_name}.start_at::date as start_date")
       .select("#{quoted_table_name}.start_at")
       .order('start_date asc, start_at asc')

--- a/spec/factories/bookable_slots.rb
+++ b/spec/factories/bookable_slots.rb
@@ -3,5 +3,13 @@ FactoryBot.define do
     start_at Time.zone.now
     end_at { start_at + 1.hour }
     guider { create(:guider) }
+
+    trait :tp do
+      guider { create(:guider, :tp) }
+    end
+
+    trait :cas do
+      guider { create(:guider, :cas) }
+    end
   end
 end

--- a/spec/features/scheduled_reporting_summary_spec.rb
+++ b/spec/features/scheduled_reporting_summary_spec.rb
@@ -15,16 +15,30 @@ RSpec.feature 'Scheduled reporting summary' do
   end
 
   def given_availability_in_the_booking_window
-    @slot = create(:bookable_slot, start_at: Time.zone.parse('2018-04-26 09:00'))
+    create(:bookable_slot, start_at: Time.zone.parse('2018-04-26 09:00'))
+    create(:bookable_slot, :tp, start_at: Time.zone.parse('2018-04-27 10:00'))
+    create(:bookable_slot, :cas, start_at: Time.zone.parse('2018-04-28 11:00'))
   end
 
   def then_the_availability_is_summarised_correctly
-    expect(ReportingSummary.count).to eq(1)
+    expect(ReportingSummary.count).to eq(3)
 
     expect(ReportingSummary.first).to have_attributes(
       organisation: 'TPAS',
       four_week_availability: true,
       first_available_slot_on: '2018-04-26'.to_date
+    )
+
+    expect(ReportingSummary.second).to have_attributes(
+      organisation: 'TP',
+      four_week_availability: true,
+      first_available_slot_on: '2018-04-27'.to_date
+    )
+
+    expect(ReportingSummary.third).to have_attributes(
+      organisation: 'CAS',
+      four_week_availability: true,
+      first_available_slot_on: '2018-04-28'.to_date
     )
   end
 
@@ -33,12 +47,14 @@ RSpec.feature 'Scheduled reporting summary' do
   end
 
   def then_the_availability_is_summarised
-    expect(ReportingSummary.count).to eq(1)
+    expect(ReportingSummary.count).to eq(3)
 
-    expect(ReportingSummary.first).to have_attributes(
-      organisation: 'TPAS',
-      four_week_availability: false,
-      first_available_slot_on: nil
-    )
+    ReportingSummary.all.each do |entry|
+      expect(entry).to have_attributes(
+        organisation: a_string_matching(/TPAS|CAS|TP/),
+        four_week_availability: false,
+        first_available_slot_on: nil
+      )
+    end
   end
 end


### PR DESCRIPTION
The currently released summary is generated based on TPAS availability only
for the timebeing. This change ensures availability is correctly
summarised, per organisation.