### PR TITLE
appointments need sms reminders at both 7 days and 2 days

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -224,10 +224,8 @@ class Appointment < ApplicationRecord
   end
 
   def self.needing_sms_reminder
-    window = 2.days.from_now.beginning_of_day..2.days.from_now.end_of_day
-
     pending
-      .where(start_at: window)
+      .where(start_at: [day_range(2), day_range(7)])
       .with_mobile_number
   end
 
@@ -342,6 +340,14 @@ class Appointment < ApplicationRecord
 
   def regular_agent?
     agent && !agent.pension_wise_api?
+  end
+
+  class << self
+    private
+
+    def day_range(days_from)
+      days_from.days.from_now.beginning_of_day.in_time_zone..days_from.days.from_now.end_of_day.in_time_zone
+    end
   end
 end
 

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -628,4 +628,24 @@ RSpec.describe Appointment, type: :model do
       end
     end
   end
+
+  describe '.needing_sms_reminder' do
+    let!(:eleven) { create(:appointment, start_at: 11.days.from_now, end_at: 11.days.from_now) }
+
+    let!(:twelve) { create(:appointment, start_at: 12.days.from_now, end_at: 12.days.from_now) }
+
+    let!(:thirteen) { create(:appointment, start_at: 13.days.from_now, end_at: 13.days.from_now) }
+
+    it 'is all pending appointments starting 2 days from now' do
+      travel_to(twelve.start_at - 47.hours) do
+        expect(Appointment.needing_sms_reminder).to eq [twelve]
+      end
+    end
+
+    it 'is all pending appointments starting 7 days from now' do
+      travel_to(twelve.start_at - (7 * 24 - 1).hours) do
+        expect(Appointment.needing_sms_reminder).to eq [twelve]
+      end
+    end
+  end
 end


### PR DESCRIPTION
Increase the window for sms reminders to be both 7 days before and 2 days before.

https://trello.com/c/uLUWENbE
