### PR TITLE
Do not send reminders on same day as booked

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -53,6 +53,7 @@ class Appointment < ApplicationRecord
   scope :cancelled, -> { where(status: CANCELLED_STATUSES) }
   scope :not_cancelled, -> { where.not(status: CANCELLED_STATUSES) }
   scope :with_mobile_number, -> { where("mobile != '' or phone like '07%'") }
+  scope :not_booked_today, -> { where.not(created_at: Time.current.beginning_of_day..Time.current.end_of_day) }
 
   validates :agent, presence: true
   validates :start_at, presence: true
@@ -225,6 +226,7 @@ class Appointment < ApplicationRecord
 
   def self.needing_sms_reminder
     pending
+      .not_booked_today
       .where(start_at: [day_range(2), day_range(7)])
       .with_mobile_number
   end
@@ -233,6 +235,7 @@ class Appointment < ApplicationRecord
     window = 3.hours.from_now..48.hours.from_now.in_time_zone
 
     pending
+      .not_booked_today
       .where(start_at: window)
       .where.not(email: '', id: reminded_ids)
   end

--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -16,6 +16,7 @@ FactoryBot.define do
     type_of_appointment '50-54'
     guider { create(:guider) }
     where_you_heard { WhereYouHeard.options_for_inclusion.sample }
+    created_at { 1.day.ago }
 
     factory :imported_appointment do
       date_of_birth Appointment::FAKE_DATE_OF_BIRTH

--- a/spec/jobs/sms_appointment_reminder_job_spec.rb
+++ b/spec/jobs/sms_appointment_reminder_job_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe SmsAppointmentReminderJob, '#perform' do
-  let(:appointment) { create(:appointment) }
+  let(:appointment) { create(:appointment, created_at: 1.day.ago) }
   let(:client) { double(Notifications::Client, send_sms: true) }
 
   it 'sends an SMS' do

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -544,6 +544,17 @@ RSpec.describe Appointment, type: :model do
   end
 
   describe '.needing_reminder' do
+    context 'on the same day as booking' do
+      it 'does not return the appointment' do
+        @date = BusinessDays.from_now(2)
+        appointment = create(:appointment, created_at: @date, start_at: @date)
+
+        travel_to(appointment.start_at - 5.hours) do
+          expect(Appointment.needing_reminder).not_to include(appointment)
+        end
+      end
+    end
+
     context 'less than 3 hours before the appointment' do
       it 'does not return the appointment' do
         appointment = create(:appointment, start_at: BusinessDays.from_now(10))


### PR DESCRIPTION
We are sending reminders immediately after confirmations are sent in
the case of appointments booked that immediately fall within the 2 or 7
day reminder period for SMS and email reminders. This change ensures we
do not send these reminders unnecessarily.