### PR TITLE
Include telephone appointment identifier

### DIFF
--- a/app/lib/summary_document_link.rb
+++ b/app/lib/summary_document_link.rb
@@ -23,7 +23,8 @@ class SummaryDocumentLink
         town: appointment.town,
         county: appointment.county,
         postcode: appointment.postcode,
-        country: 'United Kingdom'
+        country: 'United Kingdom',
+        telephone_appointment: true
       }.to_query(:appointment_summary)
     end
   end

--- a/spec/lib/summary_document_link_spec.rb
+++ b/spec/lib/summary_document_link_spec.rb
@@ -1,10 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe SummaryDocumentLink do
-  it 'includes encoded address elements' do
-    @query = described_class.query(build(:appointment, :with_address))
+  subject { described_class.query(build(:appointment, :with_address)) }
 
-    expect(@query).to include(
+  it 'includes the telephone appointment flag' do
+    expect(subject).to include('%5Btelephone_appointment%5D=true')
+  end
+
+  it 'includes encoded address elements' do
+    expect(subject).to include(
       '10+Some+Road',
       'Some+Street',
       'Somewhere',


### PR DESCRIPTION
Now we support summaries from users with both face-to-face and telephone
permissions we need to pass this flag to distinguish.