### PR TITLE
Add some determinism to guider selection

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -59,7 +59,7 @@ class AppointmentsController < ApplicationController
 
   def preview
     @appointment = Appointment.new(create_params.merge(agent: current_user))
-    @appointment.allocate(via_slot: calendar_scheduling?)
+    @appointment.allocate(via_slot: calendar_scheduling?, agent: current_user)
 
     if @appointment.valid?
       render :preview

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -122,9 +122,9 @@ class Appointment < ApplicationRecord
     status.start_with?('cancelled')
   end
 
-  def allocate(via_slot: true)
+  def allocate(via_slot: true, agent: nil)
     if via_slot
-      allocate_slot
+      allocate_slot(agent)
     else
       self.end_at = start_at + APPOINTMENT_LENGTH_MINUTES
     end
@@ -264,8 +264,8 @@ class Appointment < ApplicationRecord
     track_initial_status if status_changed?
   end
 
-  def allocate_slot
-    slot = BookableSlot.find_available_slot(start_at)
+  def allocate_slot(agent)
+    slot = BookableSlot.find_available_slot(start_at, agent)
     self.guider = nil
     return unless slot
 

--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -29,12 +29,11 @@ class BookableSlot < ApplicationRecord
     BusinessDays.from_now(1).change(hour: 18, min: 30)
   end
 
-  def self.find_available_slot(start_at)
-    bookable
-      .where(start_at: start_at)
-      .limit(1)
-      .order('RANDOM()')
-      .first
+  def self.find_available_slot(start_at, agent)
+    scope = bookable.where(start_at: start_at)
+    scope = scope.for_organisation(agent) if agent
+
+    scope.limit(1).order('RANDOM()').first
   end
 
   def self.bookable(from = nil, to = nil)


### PR DESCRIPTION
Prior to this change there were instances of guiders being allocated
across the organisation boundaries when they had identically available
slots. This change ensures only TP agents can allocate across the
organisation boundaries. All other permeations of role/organisation are
restricted to their own guiders.