### PR TITLE
Don't process print confirmations on day created

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -220,6 +220,7 @@ class Appointment < ApplicationRecord
 
   def self.needing_print_confirmation
     pending
+      .not_booked_today
       .where(batch_processed_at: nil, email: '')
       .where.not(address_line_one: '')
   end


### PR DESCRIPTION
Ensure we don't needlessly process a print confirmation on the same day
as the appointment.