### PR TITLE
Include timezone with SMS reminder

### DIFF
--- a/app/jobs/sms_appointment_reminder_job.rb
+++ b/app/jobs/sms_appointment_reminder_job.rb
@@ -18,7 +18,7 @@ class SmsAppointmentReminderJob < SmsJobBase
       template_id: TEMPLATE_ID,
       reference: appointment.to_param,
       personalisation: {
-        date: appointment.start_at.to_s(:govuk_date_short)
+        date: "#{appointment.start_at.to_s(:govuk_date_short)} (#{appointment.timezone})"
       }
     )
   end

--- a/spec/jobs/sms_appointment_reminder_job_spec.rb
+++ b/spec/jobs/sms_appointment_reminder_job_spec.rb
@@ -5,18 +5,20 @@ RSpec.describe SmsAppointmentReminderJob, '#perform' do
   let(:client) { double(Notifications::Client, send_sms: true) }
 
   it 'sends an SMS' do
-    expect(client).to receive(:send_sms).with(
-      phone_number: '07715 930 444',
-      template_id: SmsAppointmentReminderJob::TEMPLATE_ID,
-      reference: appointment.to_param,
-      personalisation: {
-        date: a_string_matching(/12:00pm/)
-      }
-    )
+    travel_to(Time.zone.parse('2018-07-03 12:00')) do
+      expect(client).to receive(:send_sms).with(
+        phone_number: '07715 930 444',
+        template_id: SmsAppointmentReminderJob::TEMPLATE_ID,
+        reference: appointment.to_param,
+        personalisation: {
+          date: a_string_matching(/12:00pm, .* \(BST\)/)
+        }
+      )
 
-    described_class.new.perform(appointment)
+      described_class.new.perform(appointment)
 
-    expect(appointment.activities.first).to be_an(SmsReminderActivity)
+      expect(appointment.activities.find_by(type: 'SmsReminderActivity')).to be
+    end
   end
 
   before do


### PR DESCRIPTION
We do this elsewhere and it's important to include for telephone
customers as they can be situated anywhere in the world.