### PR TITLE
Display missing owner as 'The system'

### DIFF
--- a/app/presenters/audit_presenter.rb
+++ b/app/presenters/audit_presenter.rb
@@ -1,4 +1,8 @@
 class AuditPresenter < SimpleDelegator
+  def owner
+    user ? user.name : 'The system'
+  end
+
   def changed_fields
     audited_changes.keys.map(&:humanize).to_sentence.downcase
   end

--- a/app/views/changes/index.html.erb
+++ b/app/views/changes/index.html.erb
@@ -11,7 +11,7 @@
   <col width="20%" />
   <col width="40%" />
   <col width="40%" />
-  <caption><%= audit.user.name %> changed the <%= audit.changed_fields %> on <%= audit.timestamp %></caption>
+  <caption><%= audit.owner %> changed the <%= audit.changed_fields %> on <%= audit.timestamp %></caption>
   <thead>
     <tr>
       <th>Field</th>

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -651,21 +651,22 @@ RSpec.describe Appointment, type: :model do
   end
 
   describe '.needing_sms_reminder' do
-    let!(:eleven) { create(:appointment, start_at: 11.days.from_now, end_at: 11.days.from_now) }
+    it 'includes the correct appointments at given periods' do
+      # excluded before
+      create(:appointment, start_at: 20.days.from_now)
+      # this is included
+      found = create(:appointment, start_at: 21.days.from_now)
+      # excluded after
+      create(:appointment, start_at: 22.days.from_now)
 
-    let!(:twelve) { create(:appointment, start_at: 12.days.from_now, end_at: 12.days.from_now) }
-
-    let!(:thirteen) { create(:appointment, start_at: 13.days.from_now, end_at: 13.days.from_now) }
-
-    it 'is all pending appointments starting 2 days from now' do
-      travel_to(twelve.start_at - 47.hours) do
-        expect(Appointment.needing_sms_reminder).to eq [twelve]
+      # at roughly two days prior
+      travel_to(found.start_at - 47.hours) do
+        expect(Appointment.needing_sms_reminder).to contain_exactly(found)
       end
-    end
 
-    it 'is all pending appointments starting 7 days from now' do
-      travel_to(twelve.start_at - (7 * 24 - 1).hours) do
-        expect(Appointment.needing_sms_reminder).to eq [twelve]
+      # at roughly seven days prior
+      travel_to(found.start_at - (7 * 24 - 1).hours) do
+        expect(Appointment.needing_sms_reminder).to contain_exactly(found)
       end
     end
   end


### PR DESCRIPTION
There are some edge-cases where the auditing 'owner' will be missing. In
these instances we can assume the change was made by 'The system' and
display this accordingly.