### PR TITLE
Allow TPAS managers to reschedule during conf

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -285,6 +285,7 @@ class Appointment < ApplicationRecord
 
   def not_during_guider_conference
     return unless start_at
+    return if agent_is_tpas_resource_manager?
 
     if BookableSlot::GUIDER_CONFERENCE_DAYS.cover?(start_at.to_date) # rubocop:disable Style/GuardClause
       errors.add(:start_at, 'must not be during the guider conference')
@@ -336,6 +337,10 @@ class Appointment < ApplicationRecord
 
   def agent_is_resource_manager?
     agent.present? && agent.resource_manager?
+  end
+
+  def agent_is_tpas_resource_manager?
+    agent_is_resource_manager? && agent.tpas?
   end
 
   def pension_wise_api?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,6 +41,10 @@ class User < ApplicationRecord
     organisation_content_id == TP_ORGANISATION_ID
   end
 
+  def tpas?
+    organisation_content_id == TPAS_ORGANISATION_ID
+  end
+
   def tp_agent?
     tp? && agent?
   end

--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :appointment do
-    agent { create(:agent) }
+    agent { create(:resource_manager) }
     start_at { BusinessDays.from_now(3).at_midday }
     end_at { start_at + 1.hour }
     first_name { Faker::Name.first_name }

--- a/spec/features/guider_views_appointments_spec.rb
+++ b/spec/features/guider_views_appointments_spec.rb
@@ -83,7 +83,7 @@ RSpec.feature 'Guider views appointments' do
 
   def given_the_requisite_data
     @guider = create(:guider)
-    @appointment = create(:appointment, guider: @guider)
+    @appointment = create(:appointment, guider: @guider, start_at: BusinessDays.from_now(10).change(hour: 9))
     @other_guider = create(:guider)
     @resource_manager = create(:resource_manager)
   end
@@ -117,20 +117,21 @@ RSpec.feature 'Guider views appointments' do
   end
 
   def and_there_are_appointments_for_multiple_guiders
+    start_at = BusinessDays.from_now(10).change(hour: 14)
     # this would appear 'today'
-    @appointment = create(:appointment, guider: current_user)
-    @other_appointment = create(:appointment, guider: create(:guider))
+    @appointment = create(:appointment, guider: current_user, start_at: start_at)
+    @other_appointment = create(:appointment, guider: create(:guider), start_at: start_at)
     # this would appear 'tomorrow'
     @appointment_tomorrow = create(
       :appointment,
       guider: current_user,
-      start_at: BusinessDays.from_now(4).at_midday
+      start_at: BusinessDays.from_now(11).at_midday
     )
   end
 
   def and_the_user_has_a_schedule
-    today    = BusinessDays.from_now(3).beginning_of_day
-    tomorrow = BusinessDays.from_now(4).beginning_of_day
+    today    = BusinessDays.from_now(10).beginning_of_day
+    tomorrow = BusinessDays.from_now(11).beginning_of_day
     # this would appear 'today'
     @bookable_slots = [
       current_user.bookable_slots.create(
@@ -146,7 +147,7 @@ RSpec.feature 'Guider views appointments' do
   end
 
   def and_the_user_has_a_holiday
-    today = BusinessDays.from_now(3).beginning_of_day
+    today = BusinessDays.from_now(10).beginning_of_day
     @holiday = create(
       :holiday,
       user: current_user,

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -66,7 +66,8 @@ RSpec.describe 'Activity notification alerts', js: true do
 end
 
 def and_they_have_an_appointment
-  @appointment = create(:appointment, guider: guider, agent: agent)
+  start_at     = BusinessDays.from_now(10).change(hour: 9)
+  @appointment = create(:appointment, start_at: start_at, guider: guider, agent: agent)
 end
 
 def when_they_are_on_their_dashboard

--- a/spec/features/resource_manager_modifies_appointments_spec.rb
+++ b/spec/features/resource_manager_modifies_appointments_spec.rb
@@ -130,7 +130,7 @@ RSpec.feature 'Resource manager modifies appointments' do
 
   def and_there_is_a_bookable_slot_for_a_guider
     guider = create(:guider)
-    today = BusinessDays.from_now(3)
+    today = BusinessDays.from_now(10)
 
     @bookable_slot = guider.bookable_slots.create(
       start_at: today.change(hour: 11, min: 0),

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Appointment, type: :model do
       travel_to '2017-03-26 11:05 UTC' do
         # force new_record? to evaluate truthily
         appointment = Appointment.new(
-          attributes_for(:appointment, start_at: Time.zone.parse('2017-03-27 11:20 UTC'))
+          attributes_for(:appointment, agent: build_stubbed(:agent), start_at: Time.zone.parse('2017-03-27 11:20 UTC'))
         )
 
         expect(appointment).to be_invalid
@@ -288,6 +288,7 @@ RSpec.describe Appointment, type: :model do
       before { allow(subject).to receive(:new_record?).and_return(true) }
 
       it 'cannot be booked at short notice' do
+        subject.agent = build_stubbed(:agent)
         subject.start_at = 1.hour.from_now
         subject.validate
         expect(subject.errors[:start_at]).to_not be_empty
@@ -326,12 +327,17 @@ RSpec.describe Appointment, type: :model do
     end
 
     context 'when attempting to book on a guider conference day' do
-      it 'is not valid' do
+      it 'is not valid unless the agent is a TPAS resource manager' do
+        subject.agent    = build_stubbed(:agent)
         subject.start_at = '2018-07-17 13:00'
         subject.end_at   = '2017-07-17 14:00'
 
         travel_to '2018-07-12 13:00' do
           expect(subject).not_to be_valid
+
+          subject.agent = build_stubbed(:resource_manager)
+
+          expect(subject).to be_valid
         end
       end
     end


### PR DESCRIPTION
Allows TPAS resource managers to reschedule appointments during guider
conference days that would otherwise be blocked out.

I had to also fix a bunch of stupid time-sensitive specs.