### PR TITLE
Set agent when rescheduling

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -182,7 +182,10 @@ class AppointmentsController < ApplicationController
     params
       .require(:appointment)
       .permit(:end_at, :guider_id)
-      .merge(start_at: munge_start_at)
+      .merge(
+        start_at: munge_start_at,
+        agent: current_user
+      )
   end
 
   def creating?


### PR DESCRIPTION
When rescheduling the appointment we mark the agent as the current
user, this is to ensure the permissions checks are carried out again.
This allows resource managers to assign appointments during the guider
conference days.