### PR TITLE
Revert grace period to two business days

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -286,7 +286,7 @@ class Appointment < ApplicationRecord
     return unless new_record? && start_at?
 
     too_soon = start_at < BookableSlot.next_valid_start_date
-    errors.add(:start_at, 'must be more than one business day from now') if too_soon
+    errors.add(:start_at, 'must be more than two business days from now') if too_soon
   end
 
   def valid_within_booking_window

--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -17,7 +17,7 @@ class BookableSlot < ApplicationRecord
   def self.next_valid_start_date(user = nil)
     return Time.zone.now.advance(hours: 1) if user && user.resource_manager?
 
-    BusinessDays.from_now(1).change(hour: 18, min: 30)
+    BusinessDays.from_now(2).change(hour: 18, min: 30)
   end
 
   def self.find_available_slot(start_at, agent)

--- a/spec/models/bookable_slot_spec.rb
+++ b/spec/models/bookable_slot_spec.rb
@@ -26,13 +26,13 @@ RSpec.describe BookableSlot, type: :model do
         after { travel_back }
 
         {
-          'Monday'    => 'Tuesday',
-          'Tuesday'   => 'Wednesday',
-          'Wednesday' => 'Thursday',
-          'Thursday'  => 'Friday',
-          'Friday'    => 'Monday',
-          'Saturday'  => 'Monday',
-          'Sunday'    => 'Monday'
+          'Monday'    => 'Wednesday',
+          'Tuesday'   => 'Thursday',
+          'Wednesday' => 'Friday',
+          'Thursday'  => 'Monday',
+          'Friday'    => 'Tuesday',
+          'Saturday'  => 'Tuesday',
+          'Sunday'    => 'Tuesday'
         }.each do |day, expected_day|
           context "Day is #{day}" do
             it "next valid start date is #{expected_day}" do
@@ -51,7 +51,7 @@ RSpec.describe BookableSlot, type: :model do
 
         it 'takes account of holidays' do
           travel_to '2018-05-05 12:00' do
-            expect(subject.to_date).to eq('2018-05-08'.to_date)
+            expect(subject.to_date).to eq('2018-05-09'.to_date)
           end
         end
       end


### PR DESCRIPTION
This has been causing TPAS many scheduling issues so we're reverting
back to a day while we review a course of action suitable to all
partners.