### PR TITLE
Move slot picker below customer details

### DIFF
--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -12,9 +12,16 @@
       <h2>Date of birth</h2>
       <%= render 'shared/date_of_birth_form_field', form: f %>
     </div>
+  </div>
+
+  <hr>
+  <%= render partial: 'personal_details_form', locals: { f: f } %>
+  <hr>
+
+  <div class="row form-group">
     <%= render 'schedule_form', form: f %>
   </div>
-  <%= render partial: 'personal_details_form', locals: { f: f } %>
+
   <div class="row form-group">
     <div class="col-md-12">
       <%= f.submit "Continue", class: 't-preview-appointment' %>


### PR DESCRIPTION
Moves the date picker under the customer details form. This is to
mitigate slots being taken during the time it takes for the agent to
complete the customer details.