### PR TITLE
Copy `default` configuration to production

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -79,4 +79,5 @@ test:
 #     url: <%= ENV['DATABASE_URL'] %>
 #
 production:
+  <<: *default
   url: <%= ENV['DATABASE_URL'] %>


### PR DESCRIPTION
This ensures the correct pool size is configured in the production
environment.