### PR TITLE
Use 'business days' logic to calculate window

### DIFF
--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -34,7 +34,7 @@ class BookableSlot < ApplicationRecord
 
   def self.grouped(organisation_id = nil) # rubocop:disable Metrics/AbcSize
     from = next_valid_start_date
-    to   = 8.weeks.from_now.end_of_day
+    to   = BusinessDays.from_now(40).end_of_day
 
     scope = bookable(from, to).within_date_range(from, to)
     scope = scope.joins(:guider).where(users: { organisation_content_id: organisation_id }) if organisation_id

--- a/config/initializers/working_hours.rb
+++ b/config/initializers/working_hours.rb
@@ -1,7 +1,12 @@
-WorkingHours::Config.holidays = [
-  Date.parse('07/05/2018'),
-  Date.parse('28/05/2018'),
-  Date.parse('27/08/2018'),
-  Date.parse('25/12/2018'),
-  Date.parse('26/12/2018')
-]
+WorkingHours::Config.holidays = %w(
+  25/12/2018
+  26/12/2018
+  01/01/2019
+  19/04/2019
+  22/04/2019
+  06/05/2019
+  27/05/2019
+  26/08/2019
+  25/12/2019
+  26/12/2019
+).map(&:to_date)

--- a/spec/models/bookable_slot_spec.rb
+++ b/spec/models/bookable_slot_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe BookableSlot, type: :model do
         subject { BookableSlot.next_valid_start_date(user) }
 
         it 'takes account of holidays' do
-          travel_to '2018-05-05 12:00' do
-            expect(subject.to_date).to eq('2018-05-09'.to_date)
+          travel_to '2018-12-24 12:00' do
+            expect(subject.to_date).to eq('2018-12-28'.to_date)
           end
         end
       end


### PR DESCRIPTION
Previously the end of the booking window was calculated at 8 weeks from the
time of request and didn't consider bank holidays. This change ensures we
also skip those days when calculating the end of the window.