### PR TITLE
Ensure appointment organisations cannot change

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -76,6 +76,7 @@ class Appointment < ApplicationRecord
   validate :date_of_birth_valid
   validate :email_valid, if: :pension_wise_api?, on: :create
   validate :address_or_email_valid, if: :regular_agent?, on: :create
+  validate :validate_guider_organisation, on: :update
 
   before_validation :format_name, on: :create
   before_create :track_initial_status
@@ -323,6 +324,13 @@ class Appointment < ApplicationRecord
 
   def date_of_birth_pre_cut_off?
     date_of_birth? && date_of_birth < FAKE_DATE_OF_BIRTH
+  end
+
+  def validate_guider_organisation
+    return unless guider_id_changed? && guider
+    return if User.guider_organisation_match?(guider, guider_id_was)
+
+    errors.add(:guider, 'The guider is from another provider')
   end
 
   def agent_is_resource_manager?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,4 +61,10 @@ class User < ApplicationRecord
       ''
     end
   end
+
+  def self.guider_organisation_match?(guider, original_guider_id)
+    original = find(original_guider_id)
+
+    guider.organisation_content_id == original.organisation_content_id
+  end
 end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -171,6 +171,17 @@ RSpec.describe Appointment, type: :model do
       build_stubbed(:appointment)
     end
 
+    describe 'rescheduling across organisations' do
+      it 'is not possible' do
+        @cas_guider  = create(:guider, :cas)
+        @appointment = create(:appointment)
+
+        @appointment.guider = @cas_guider
+
+        expect(@appointment).to be_invalid
+      end
+    end
+
     it 'defaults #status to `pending`' do
       expect(described_class.new).to be_pending
     end


### PR DESCRIPTION
Appointments should never switch organisations. This validation ensures
when the guider changes, they can only ever originate from the same
provider/organisation.