### PR TITLE
Segment grace period for TPAS

### DIFF
--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -10,8 +10,29 @@ class BookableSlot < ApplicationRecord
     end
   end
 
-  def self.within_date_range(from, to)
+  def self.within_date_range(from, to, organisation_limit: false)
+    return limit_by_organisation(from, to) if organisation_limit
+
     where("#{quoted_table_name}.start_at > ? AND #{quoted_table_name}.end_at < ?", from, to)
+  end
+
+  def self.limit_by_organisation(from, to) # rubocop:disable MethodLength
+    tpas_start_at = BusinessDays.from_now(2).change(hour: 18, min: 30)
+
+    joins(:guider)
+      .where(
+        '
+        (users.organisation_content_id = :tpas_id
+          AND bookable_slots.start_at > :tpas_start_at AND bookable_slots.end_at < :end_at)
+        OR
+        (users.organisation_content_id != :tpas_id
+          AND bookable_slots.start_at > :start_at AND bookable_slots.end_at < :end_at)
+        ',
+        tpas_id: User::TPAS_ORGANISATION_ID,
+        tpas_start_at: tpas_start_at,
+        start_at: from,
+        end_at: to
+      )
   end
 
   def self.next_valid_start_date(user = nil)
@@ -36,7 +57,7 @@ class BookableSlot < ApplicationRecord
     from = next_valid_start_date
     to   = BusinessDays.from_now(40).end_of_day
 
-    scope = bookable(from, to).within_date_range(from, to)
+    scope = bookable(from, to).within_date_range(from, to, organisation_limit: true)
     scope = scope.joins(:guider).where(users: { organisation_content_id: organisation_id }) if organisation_id
 
     scope
@@ -98,7 +119,7 @@ class BookableSlot < ApplicationRecord
       .starting_after_next_valid_start_date(user)
       .for_organisation(user)
       .group("#{quoted_table_name}.start_at, #{quoted_table_name}.end_at")
-      .within_date_range(from, to)
+      .within_date_range(from, to, organisation_limit: true)
       .map do |us|
         { guiders: us.attributes['guiders'], start: us.start_at, end: us.end_at, selected: false }
       end

--- a/spec/models/bookable_slot_spec.rb
+++ b/spec/models/bookable_slot_spec.rb
@@ -355,37 +355,6 @@ RSpec.describe BookableSlot, type: :model do
         )
       end
 
-      context 'user is a resource manager' do
-        let(:user) do
-          build_stubbed(:resource_manager)
-        end
-
-        it 'includes bookable slots that start after now' do
-          start_at = BusinessDays.from_now(1).change(hour: 12, min: 30)
-          end_at = BusinessDays.from_now(1).change(hour: 14, min: 30)
-          create(
-            :bookable_slot,
-            guider: create(:guider),
-            start_at: start_at,
-            end_at: end_at
-          )
-
-          expect(result.count).to eq 2
-          expect(result).to include(
-            guiders: 3,
-            start: make_time(10, 30),
-            end: make_time(11, 30),
-            selected: false
-          )
-          expect(result).to include(
-            guiders: 1,
-            start: start_at,
-            end: end_at,
-            selected: false
-          )
-        end
-      end
-
       context 'one guider has a bookable slot obscured by a non cancelled appointment' do
         it 'excludes the slot' do
           create(

--- a/spec/requests/bookable_slots_api_spec.rb
+++ b/spec/requests/bookable_slots_api_spec.rb
@@ -18,7 +18,10 @@ RSpec.describe 'GET /api/v1/bookable_slots' do
     create_list(:bookable_slot, 2, start_at: Time.zone.parse('2017-01-16 12:00'))
 
     # falls before the booking window
-    create(:bookable_slot, start_at: 1.day.from_now)
+    create(:bookable_slot, start_at: 2.days.from_now.advance(hours: 1))
+
+    # in the window since it's TP with a short start
+    create(:bookable_slot, :tp, start_at: 1.day.from_now)
 
     # included since the window is now 8 weeks
     create(:bookable_slot, start_at: 7.weeks.from_now)


### PR DESCRIPTION
TPAS need a 3 day grace period whereas the other providers can remain
the same. This change ensures the correct slots are deemed 'available'
within the correct, segmented grace periods.