### PR TITLE
Ensure grace period is respected

### DIFF
--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -113,13 +113,15 @@ class BookableSlot < ApplicationRecord
     where("#{quoted_table_name}.start_at > ?", next_valid_start_date(user))
   end
 
-  def self.with_guider_count(user, from, to)
+  def self.with_guider_count(user, from, to) # rubocop:disable AbcSize
+    limit_by_organisation = !user.resource_manager?
+
     select("DISTINCT #{quoted_table_name}.start_at, #{quoted_table_name}.end_at, count(1) AS guiders")
       .bookable
       .starting_after_next_valid_start_date(user)
       .for_organisation(user)
       .group("#{quoted_table_name}.start_at, #{quoted_table_name}.end_at")
-      .within_date_range(from, to, organisation_limit: true)
+      .within_date_range(from, to, organisation_limit: limit_by_organisation)
       .map do |us|
         { guiders: us.attributes['guiders'], start: us.start_at, end: us.end_at, selected: false }
       end

--- a/spec/models/bookable_slot_spec.rb
+++ b/spec/models/bookable_slot_spec.rb
@@ -355,6 +355,37 @@ RSpec.describe BookableSlot, type: :model do
         )
       end
 
+      context 'user is a resource manager' do
+        let(:user) do
+          build_stubbed(:resource_manager)
+        end
+
+        it 'includes bookable slots that start after now' do
+          start_at = BusinessDays.from_now(1).change(hour: 12, min: 30)
+          end_at = BusinessDays.from_now(1).change(hour: 14, min: 30)
+          create(
+            :bookable_slot,
+            guider: create(:guider),
+            start_at: start_at,
+            end_at: end_at
+          )
+
+          expect(result.count).to eq 2
+          expect(result).to include(
+            guiders: 3,
+            start: make_time(10, 30),
+            end: make_time(11, 30),
+            selected: false
+          )
+          expect(result).to include(
+            guiders: 1,
+            start: start_at,
+            end: end_at,
+            selected: false
+          )
+        end
+      end
+
       context 'one guider has a bookable slot obscured by a non cancelled appointment' do
         it 'excludes the slot' do
           create(


### PR DESCRIPTION
Resource managers should see slots within the grace period but the
recent changes for segmentation caused a regression. This change ensures
resource managers can once again book short notice appointments.