### PR TITLE
Ensure `agent` is considered during allocation

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -70,7 +70,7 @@ class AppointmentsController < ApplicationController
 
   def create
     @appointment = Appointment.new(create_params.merge(agent: current_user))
-    @appointment.allocate(via_slot: calendar_scheduling?)
+    @appointment.allocate(via_slot: calendar_scheduling?, agent: current_user)
 
     if creating? && @appointment.save
       CustomerUpdateJob.perform_later(@appointment, CustomerUpdateActivity::CONFIRMED_MESSAGE)


### PR DESCRIPTION
The `agent` was considered during the preview phase of allocation yet
was discarded at the actual creation phase. This could lead to
cross-organisation allocations. This change ensures we pass the `agent`
along in both instances.