### PR TITLE
Include date in SMS cancellation

### DIFF
--- a/app/jobs/sms_cancellation_success_job.rb
+++ b/app/jobs/sms_cancellation_success_job.rb
@@ -7,7 +7,10 @@ class SmsCancellationSuccessJob < SmsJobBase
     sms_client.send_sms(
       phone_number: appointment.canonical_sms_number,
       template_id: TEMPLATE_ID,
-      reference: appointment.to_param
+      reference: appointment.to_param,
+      personalisation: {
+        date: "#{appointment.start_at.to_s(:govuk_date_short)} (#{appointment.timezone})"
+      }
     )
   end
 end

--- a/spec/jobs/sms_cancellation_success_job_spec.rb
+++ b/spec/jobs/sms_cancellation_success_job_spec.rb
@@ -1,14 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe SmsCancellationSuccessJob, '#perform' do
-  let(:appointment) { create(:appointment) }
+  let(:appointment) { create(:appointment, start_at: Time.zone.parse('2019-01-01 13:00 UTC')) }
   let(:client) { double(Notifications::Client, send_sms: true) }
 
   it 'sends an SMS' do
     expect(client).to receive(:send_sms).with(
       phone_number: '07715 930 444',
       template_id: SmsCancellationSuccessJob::TEMPLATE_ID,
-      reference: appointment.to_param
+      reference: appointment.to_param,
+      personalisation: {
+        date: '1:00pm, 1 Jan 2019 (GMT)'
+      }
     )
 
     described_class.new.perform(appointment)


### PR DESCRIPTION
Includes the date attribute so it can be embedded into the SMS
cancellation success template.