### PR TITLE
Cancel the oldest appointment first

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -252,7 +252,7 @@ class Appointment < ApplicationRecord
 
   def self.for_sms_cancellation(number)
     pending
-      .order(created_at: :desc)
+      .order(:created_at)
       .find_by("REPLACE(mobile, ' ', '') = :number OR REPLACE(phone, ' ', '') = :number", number: number)
   end
 

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe Appointment, type: :model do
 
   describe '.for_sms_cancellation' do
     context 'when two appointment exist with the same number' do
-      it 'returns the appointment created last' do
+      it 'returns the appointment created first' do
         @first = create(:appointment, mobile: '07715930455', created_at: '2018-04-28 13:00')
         @last  = create(:appointment, mobile: '07715930455', created_at: '2018-04-28 14:00')
 
-        expect(described_class.for_sms_cancellation('07715930455')).to eq(@last)
+        expect(described_class.for_sms_cancellation('07715930455')).to eq(@first)
       end
     end
   end


### PR DESCRIPTION
Changes the SMS cancellation logic to ensure the appointment placed
first is cancelled when multiple pending appointments exist with a given
mobile phone number.