### PR TITLE
Enforce edit permission

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -2,6 +2,10 @@
 class AppointmentsController < ApplicationController
   store_previous_page_on :search
 
+  rescue_from ActiveRecord::RecordNotFound do
+    render :missing
+  end
+
   def batch_update
     BatchAppointmentUpdate.new(params[:changes]).call
     head :ok
@@ -14,7 +18,7 @@ class AppointmentsController < ApplicationController
   end
 
   def edit
-    @appointment = Appointment.find(params[:id])
+    @appointment = Appointment.for_organisation(current_user).find(params[:id])
   end
 
   def reschedule

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -206,6 +206,13 @@ class Appointment < ApplicationRecord
     gdpr_consent == '' ? 'No response' : gdpr_consent.titleize
   end
 
+  def self.for_organisation(user)
+    return where('1 = 1') if user.tp_agent?
+
+    joins(:guider)
+      .where(users: { organisation_content_id: user.organisation_content_id })
+  end
+
   def self.copy_or_new_by(id)
     return new unless id
 

--- a/app/views/appointments/missing.html.erb
+++ b/app/views/appointments/missing.html.erb
@@ -1,0 +1,8 @@
+<% content_for(:page_title, t('service.title', page_title: 'You cannot view this appointment')) %>
+
+<div class="alert alert-warning t-permissions" role="alert">
+  <p>
+    You do not have the required permissions or organisational membership to
+    view this appointment.
+  </p>
+</div>

--- a/spec/features/appointment_permissions_spec.rb
+++ b/spec/features/appointment_permissions_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.feature 'Editing appointments and permissions' do
+  scenario 'TP agent can edit other’s appointments' do
+    given_the_user_is_an_agent do # TP agent
+      and_another_organisations_appointment_exists
+      when_they_edit_the_appointment
+      they_see_the_appointment
+    end
+  end
+
+  scenario 'Other people can’t edit other’s appointments' do
+    given_the_user_is_a_resource_manager(organisation: :cas) do
+      and_another_organisations_appointment_exists
+      when_they_edit_the_appointment
+      then_they_do_not_see_the_appointment
+    end
+  end
+
+  def and_another_organisations_appointment_exists
+    @appointment = create(:appointment) # TPAS guider
+  end
+
+  def when_they_edit_the_appointment
+    @page = Pages::EditAppointment.new
+    @page.load(id: @appointment.id)
+  end
+
+  def they_see_the_appointment
+    expect(@page).to be_displayed
+    expect(@page).to have_no_permissions_warning
+  end
+
+  def then_they_do_not_see_the_appointment
+    expect(@page).to be_displayed
+    expect(@page).to have_permissions_warning
+  end
+end

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -22,6 +22,8 @@ module Pages
     element :submit, '.t-save'
     element :rebook, '.t-rebook'
 
+    element :permissions_warning, '.t-permissions'
+
     section :activity_feed, '.t-activity-feed' do
       elements :activities, '.t-activity'
 


### PR DESCRIPTION
This wasn't enforced explicitly before so when viewing duplicates,
sometimes a cross-organisation appointment would be linked and therefore
editable.