### PR TITLE
Add an explicit accessibility requirements field

### DIFF
--- a/app/controllers/api/v1/appointments_controller.rb
+++ b/app/controllers/api/v1/appointments_controller.rb
@@ -30,7 +30,9 @@ module Api
           :date_of_birth,
           :dc_pot_confirmed,
           :where_you_heard,
-          :gdpr_consent
+          :gdpr_consent,
+          :accessibility_requirements,
+          :notes
         ).merge(agent: current_user)
       end
     end

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -147,6 +147,7 @@ class AppointmentsController < ApplicationController
       :mobile,
       :date_of_birth,
       :memorable_word,
+      :accessibility_requirements,
       :notes,
       :status,
       :type_of_appointment,

--- a/app/forms/api/v1/appointment.rb
+++ b/app/forms/api/v1/appointment.rb
@@ -13,6 +13,8 @@ module Api
       attr_accessor :dc_pot_confirmed
       attr_accessor :where_you_heard
       attr_accessor :gdpr_consent
+      attr_accessor :accessibility_requirements
+      attr_accessor :notes
       attr_accessor :agent
 
       attr_reader :model
@@ -20,7 +22,7 @@ module Api
       def initialize(*)
         super
 
-        @model = Models::Appointment.new(to_params)
+        @model = ::Appointment.new(to_params)
       end
 
       def create
@@ -44,7 +46,9 @@ module Api
           dc_pot_confirmed: dc_pot_confirmed,
           where_you_heard: where_you_heard,
           gdpr_consent: gdpr_consent.to_s,
-          agent: agent
+          agent: agent,
+          accessibility_requirements: accessibility_requirements,
+          notes: notes
         }
       end
     end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -64,6 +64,7 @@ class Appointment < ApplicationRecord
   validates :date_of_birth, presence: true
   validates :memorable_word, presence: true
   validates :dc_pot_confirmed, inclusion: [true, false]
+  validates :accessibility_requirements, inclusion: [true, false]
   validates :type_of_appointment, inclusion: %w(standard 50-54)
   validates :where_you_heard, inclusion: WhereYouHeard.options_for_inclusion, on: :create, unless: :rebooked_from_id?
   validates :gdpr_consent, inclusion: ['yes', 'no', '']

--- a/app/views/appointments/_personal_details_form.html.erb
+++ b/app/views/appointments/_personal_details_form.html.erb
@@ -57,6 +57,7 @@
     <%= f.text_field :postcode, class: 't-postcode' %>
 
     <h2 class="h3">Additional information and marketing</h2>
+    <%= f.check_box :accessibility_requirements, class: 't-accessibility-requirements', label: 'Do you need any help or an adjustment to access our service?' %>
     <%= f.text_area :notes, class: 't-notes', rows: 6, placeholder: 'Is the customer hard of hearing? Is English their first language? etc.' %>
     <div class="form-group">
       <%= f.select :where_you_heard,

--- a/app/views/appointments/preview.html.erb
+++ b/app/views/appointments/preview.html.erb
@@ -26,6 +26,7 @@
   <%= f.hidden_field :phone %>
   <%= f.hidden_field :mobile %>
   <%= f.hidden_field :memorable_word %>
+  <%= f.hidden_field :accessibility_requirements %>
   <%= f.hidden_field :notes %>
   <%= f.hidden_field :gdpr_consent %>
   <%= f.hidden_field :status %>
@@ -92,6 +93,10 @@
             <tr>
               <td class="active"><b>Memorable word</b></td>
               <td><%= @appointment.memorable_word %></td>
+            </tr>
+            <tr>
+              <td class="active"><b>I require help or an adjustment to help me access my appointment</b></td>
+              <td><%= @appointment.accessibility_requirements %></td>
             </tr>
             <tr>
               <td class="active"><b>Notes</b></td>

--- a/db/migrate/20190910114253_add_accessibility_requirements_to_appointments.rb
+++ b/db/migrate/20190910114253_add_accessibility_requirements_to_appointments.rb
@@ -1,0 +1,5 @@
+class AddAccessibilityRequirementsToAppointments < ActiveRecord::Migration[5.1]
+  def change
+    add_column :appointments, :accessibility_requirements, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180518131750) do
+ActiveRecord::Schema.define(version: 20190910114253) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,6 +62,8 @@ ActiveRecord::Schema.define(version: 20180518131750) do
     t.datetime "batch_processed_at"
     t.datetime "rescheduled_at"
     t.string "gdpr_consent", default: "", null: false
+    t.string "pension_provider", default: "", null: false
+    t.boolean "accessibility_requirements", default: false, null: false
     t.index ["start_at"], name: "index_appointments_on_start_at"
   end
 

--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
     guider { create(:guider) }
     where_you_heard { WhereYouHeard.options_for_inclusion.sample }
     created_at { 1.day.ago }
+    accessibility_requirements { false }
 
     factory :imported_appointment do
       date_of_birth { Appointment::FAKE_DATE_OF_BIRTH }

--- a/spec/features/agent_manages_appointments_spec.rb
+++ b/spec/features/agent_manages_appointments_spec.rb
@@ -191,6 +191,7 @@ RSpec.feature 'Agent manages appointments' do
     @page.phone.set '0000000'
     @page.mobile.set '1111111'
     @page.memorable_word.set 'lozenge'
+    @page.accessibility_requirements.set true
     @page.notes.set 'something'
     @page.gdpr_consent_yes.set true
     @page.start_at.set day.change(hour: 9, min: 30).to_s
@@ -256,6 +257,7 @@ RSpec.feature 'Agent manages appointments' do
     expect(appointment.end_at).to eq day.change(hour: 10, min: 40).to_s
     expect(appointment.type_of_appointment).to eq('standard')
     expect(appointment.where_you_heard).to eq(17)
+    expect(appointment).to be_accessibility_requirements
   end
 
   def and_the_customer_gets_an_email_confirmation
@@ -312,6 +314,7 @@ RSpec.feature 'Agent manages appointments' do
     @page.start_at.set day.change(hour: 9, min: 30).to_s
     @page.end_at.set day.change(hour: 10, min: 40).to_s
     @page.type_of_appointment_50_54.set true
+    @page.accessibility_requirements.set false
 
     @page.preview_appointment.click
   end
@@ -343,6 +346,7 @@ RSpec.feature 'Agent manages appointments' do
     expect(appointment.status).to eq 'pending'
     expect(appointment.end_at).to eq day.change(hour: 10, min: 40).to_s
     expect(appointment.type_of_appointment).to eq('50-54')
+    expect(appointment).not_to be_accessibility_requirements
   end
 
   def and_there_is_an_appointment

--- a/spec/requests/appointments_api_spec.rb
+++ b/spec/requests/appointments_api_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe 'POST /api/v1/appointments' do
       'date_of_birth'    => '1950-02-02',
       'dc_pot_confirmed' => true,
       'where_you_heard'  => '1',
-      'gdpr_consent'     => 'yes'
+      'gdpr_consent'     => 'yes',
+      'accessibility_requirements' => 'false'
     }
 
     post api_v1_appointments_path, params: @payload, as: :json
@@ -67,7 +68,9 @@ RSpec.describe 'POST /api/v1/appointments' do
       'date_of_birth'    => '1950-02-02',
       'dc_pot_confirmed' => true,
       'where_you_heard'  => '1',
-      'gdpr_consent'     => nil
+      'gdpr_consent'     => nil,
+      'accessibility_requirements' => true,
+      'notes' => 'I am hard of hearing'
     }
 
     post api_v1_appointments_path, params: @payload, as: :json
@@ -97,7 +100,9 @@ RSpec.describe 'POST /api/v1/appointments' do
         memorable_word: 'snootboop',
         dc_pot_confirmed: true,
         where_you_heard: 1,
-        gdpr_consent: ''
+        gdpr_consent: '',
+        accessibility_requirements: true,
+        notes: 'I am hard of hearing'
       )
     end
   end

--- a/spec/support/pages/new_appointment.rb
+++ b/spec/support/pages/new_appointment.rb
@@ -11,6 +11,7 @@ module Pages
     element :date_of_birth_month,                   '.t-date-of-birth-month'
     element :date_of_birth_year,                    '.t-date-of-birth-year'
     element :memorable_word,                        '.t-memorable-word'
+    element :accessibility_requirements,            '.t-accessibility-requirements'
     element :notes,                                 '.t-notes'
     element :gdpr_consent_yes,                      '.t-gdpr-consent-yes'
     element :gdpr_consent_no,                       '.t-gdpr-consent-no'


### PR DESCRIPTION
Allows customers/agents to specify accessibility requirements explicitly
during booking.