### PR TITLE
Send accessibility alerts to resource managers

### DIFF
--- a/app/forms/api/v1/appointment.rb
+++ b/app/forms/api/v1/appointment.rb
@@ -30,7 +30,7 @@ module Api
         model.save
       end
 
-      delegate :errors, to: :model
+      delegate :errors, :accessibility_requirements?, to: :model
 
       private
 

--- a/app/jobs/accessibility_adjustment_notifications_job.rb
+++ b/app/jobs/accessibility_adjustment_notifications_job.rb
@@ -1,0 +1,9 @@
+class AccessibilityAdjustmentNotificationsJob < ApplicationJob
+  queue_as :default
+
+  def perform(appointment)
+    appointment.resource_managers.each do |rm|
+      AppointmentMailer.accessibility_adjustment(appointment, rm).deliver_later
+    end
+  end
+end

--- a/app/mailers/appointment_mailer.rb
+++ b/app/mailers/appointment_mailer.rb
@@ -1,6 +1,12 @@
 class AppointmentMailer < ApplicationMailer
   default subject: 'Your Pension Wise Appointment'
 
+  def accessibility_adjustment(appointment, resource_manager)
+    mailgun_headers('accessibility_adjustment', appointment.id)
+    @appointment = appointment
+    mail to: resource_manager.email, subject: 'Pension Wise Accessibility Adjustment'
+  end
+
   def confirmation(appointment)
     return unless appointment.email?
 

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -50,6 +50,8 @@ class Appointment < ApplicationRecord
 
   attr_accessor :ad_hoc_start_at
 
+  delegate :resource_managers, to: :guider
+
   scope :cancelled, -> { where(status: CANCELLED_STATUSES) }
   scope :not_cancelled, -> { where.not(status: CANCELLED_STATUSES) }
   scope :with_mobile_number, -> { where("mobile != '' or phone like '07%'") }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,11 +47,19 @@ class User < ApplicationRecord
 
   scope :guiders, -> { where('permissions @> ?', %(["#{GUIDER_PERMISSION}"])) }
   scope :active, -> { where(active: true) }
+  scope :enabled, -> { where(disabled: false) }
 
   ALL_PERMISSIONS.each do |permission|
     define_method "#{permission}?" do
       has_permission?(permission)
     end
+  end
+
+  def resource_managers
+    colleagues
+      .where('permissions @> ?', %(["#{RESOURCE_MANAGER_PERMISSION}"]))
+      .enabled
+      .active
   end
 
   def tp?

--- a/app/views/appointment_mailer/accessibility_adjustment.html.erb
+++ b/app/views/appointment_mailer/accessibility_adjustment.html.erb
@@ -1,0 +1,15 @@
+<h1 style="color: #0B0C0C !important;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-weight: 700;font-size: 20px;line-height: 1.111111111;padding: 15px 0;">
+  The customer has indicated they require help or an accessibility adjustment to access their appointment
+</h1>
+
+<%= p do %>
+  Reference number:
+  <br>
+  <strong class="emphasize">
+    <%= @appointment.id %>
+  </strong>
+<% end %>
+
+<%= p do %>
+  <%= link_to 'View the appointment', edit_appointment_url(@appointment) %>
+<% end %>

--- a/app/views/appointment_mailer/accessibility_adjustment.text.erb
+++ b/app/views/appointment_mailer/accessibility_adjustment.text.erb
@@ -1,0 +1,6 @@
+The customer has indicated they require help or an accessibility adjustment to access their appointment
+
+Reference number:
+<%= @appointment.id %>
+
+<%= edit_appointment_url(@appointment) %>

--- a/app/views/appointment_mailer/reminder.text.erb
+++ b/app/views/appointment_mailer/reminder.text.erb
@@ -7,5 +7,4 @@ This is a reminder that you have a Pension Wise phone appointment booked for:
 <%= render 'shared/email/appointment_details' %>
 
 Full details of our privacy policy, including information on your rights in relation to the data we hold can be found at https://www.pensionwise.gov.uk/en/privacy
-
 <%= render 'shared/email/preparing_for_appointment' %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,6 +31,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3001 }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,6 +103,7 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
   config.active_record.dump_schema_after_migration = false
 
   # Configure email delivery using Mailgun
+  config.action_mailer.default_url_options = { host: ENV['APPLICATION_HOST'] }
   config.action_mailer.smtp_settings = {
     port: ENV['MAILGUN_SMTP_PORT'],
     address: ENV['MAILGUN_SMTP_SERVER'],

--- a/spec/jobs/accessibility_adjustment_notifications_job_spec.rb
+++ b/spec/jobs/accessibility_adjustment_notifications_job_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe AccessibilityAdjustmentNotificationsJob, '#perform' do
+  it 'sends a notification email to associated resource managers' do
+    resource_manager = double(:resource_manager)
+    appointment      = double(:appointment, resource_managers: Array(resource_manager))
+
+    expect(AppointmentMailer).to receive(:accessibility_adjustment)
+      .with(appointment, resource_manager)
+      .and_return(double(deliver_later: true))
+
+    subject.perform(appointment)
+  end
+end

--- a/spec/mailers/appointment_mailer_spec.rb
+++ b/spec/mailers/appointment_mailer_spec.rb
@@ -10,6 +10,30 @@ RSpec.describe AppointmentMailer, type: :mailer do
     )
   end
 
+  describe 'Accessibility Adjustment' do
+    subject(:mail) { described_class.accessibility_adjustment(appointment, resource_manager) }
+
+    let(:mailgun_headers) { JSON.parse(mail['X-Mailgun-Variables'].value) }
+    let(:resource_manager) { build_stubbed(:resource_manager) }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Pension Wise Accessibility Adjustment')
+      expect(mail.to).to eq([resource_manager.email])
+      expect(mail.from).to eq(['booking@pensionwise.gov.uk'])
+    end
+
+    it 'renders the mailgun specific headers' do
+      expect(mailgun_headers).to include(
+        'message_type'   => 'accessibility_adjustment',
+        'appointment_id' => appointment.id
+      )
+    end
+
+    it 'renders the body specifics' do
+      expect(subject.body.encoded).to match(%q(http://localhost:3001/appointments/\d+/edit))
+    end
+  end
+
   describe 'Confirmation' do
     subject(:mail) { described_class.confirmation(appointment) }
     let(:mailgun_headers) { JSON.parse(mail['X-Mailgun-Variables'].value) }

--- a/spec/mailers/previews/appointment_mailer_preview.rb
+++ b/spec/mailers/previews/appointment_mailer_preview.rb
@@ -1,5 +1,11 @@
 # Preview all emails at http://localhost:3000/rails/mailers/appointment_mailer
 class AppointmentMailerPreview < ActionMailer::Preview
+  def accessibility_adjustment
+    appointment = random_appointment
+
+    AppointmentMailer.accessibility_adjustment(appointment, appointment.resource_managers.first)
+  end
+
   def confirmation
     AppointmentMailer.confirmation(random_appointment)
   end

--- a/spec/requests/appointments_api_spec.rb
+++ b/spec/requests/appointments_api_spec.rb
@@ -5,11 +5,13 @@ RSpec.describe 'POST /api/v1/appointments' do
     travel_to '2017-01-10 12:00' do
       given_the_user_is_a_pension_wise_api_user do
         and_a_bookable_slot_exists_for_the_given_appointment_date
+        and_a_resource_manager_exists
         when_the_client_posts_a_valid_appointment_request
         then_the_service_responds_with_a_201
         and_the_location_header_describes_the_booking_reference
         and_the_appointment_is_created
         and_the_customer_receives_a_confirmation_email
+        and_the_resource_manager_receives_an_accessibility_notification
       end
     end
   end
@@ -37,7 +39,7 @@ RSpec.describe 'POST /api/v1/appointments' do
       'dc_pot_confirmed' => true,
       'where_you_heard'  => '1',
       'gdpr_consent'     => 'yes',
-      'accessibility_requirements' => 'false'
+      'accessibility_requirements' => 'true'
     }
 
     post api_v1_appointments_path, params: @payload, as: :json
@@ -55,6 +57,10 @@ RSpec.describe 'POST /api/v1/appointments' do
 
   def and_a_bookable_slot_exists_for_the_given_appointment_date
     @bookable_slot = create(:bookable_slot, start_at: Time.zone.parse('2017-01-13 12:10'))
+  end
+
+  def and_a_resource_manager_exists
+    @resource_manager = create(:resource_manager)
   end
 
   def when_the_client_posts_a_valid_appointment_request
@@ -109,5 +115,9 @@ RSpec.describe 'POST /api/v1/appointments' do
 
   def and_the_customer_receives_a_confirmation_email
     expect(ActionMailer::Base.deliveries.map(&:to)).to include(%w(rick@example.com))
+  end
+
+  def and_the_resource_manager_receives_an_accessibility_notification
+    expect(ActionMailer::Base.deliveries.map(&:to)).to include(Array(@resource_manager.email))
   end
 end


### PR DESCRIPTION
When a customer or agent specifies that they need an accessibility
adjustment to access their appointment we should notify those resource
managers associated with the appointment ahead of time.