### PR TITLE
Alert supervisors mailbox for TPAS guiders

### DIFF
--- a/app/jobs/accessibility_adjustment_notifications_job.rb
+++ b/app/jobs/accessibility_adjustment_notifications_job.rb
@@ -2,8 +2,18 @@ class AccessibilityAdjustmentNotificationsJob < ApplicationJob
   queue_as :default
 
   def perform(appointment)
-    appointment.resource_managers.each do |rm|
-      AppointmentMailer.accessibility_adjustment(appointment, rm).deliver_later
+    recipients_for(appointment).each do |email|
+      AppointmentMailer.accessibility_adjustment(appointment, email).deliver_later
+    end
+  end
+
+  private
+
+  def recipients_for(appointment)
+    if appointment.tpas_guider?
+      Array('supervisors@maps.org.uk')
+    else
+      appointment.resource_managers.pluck(:email)
     end
   end
 end

--- a/app/mailers/appointment_mailer.rb
+++ b/app/mailers/appointment_mailer.rb
@@ -1,10 +1,10 @@
 class AppointmentMailer < ApplicationMailer
   default subject: 'Your Pension Wise Appointment'
 
-  def accessibility_adjustment(appointment, resource_manager)
+  def accessibility_adjustment(appointment, recipient)
     mailgun_headers('accessibility_adjustment', appointment.id)
     @appointment = appointment
-    mail to: resource_manager.email, subject: 'Pension Wise Accessibility Adjustment'
+    mail to: recipient, subject: 'Pension Wise Accessibility Adjustment'
   end
 
   def confirmation(appointment)

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -181,6 +181,10 @@ class Appointment < ApplicationRecord
     start_at.in_time_zone('London').utc_offset.zero? ? 'GMT' : 'BST'
   end
 
+  def tpas_guider?
+    guider&.tpas?
+  end
+
   def agent_is_pension_wise_api?
     agent && agent.pension_wise_api?
   end

--- a/spec/features/agent_manages_appointments_spec.rb
+++ b/spec/features/agent_manages_appointments_spec.rb
@@ -263,8 +263,8 @@ RSpec.feature 'Agent manages appointments' do
 
   def and_the_customer_gets_an_email_confirmation
     deliveries = ActionMailer::Base.deliveries
-    expect(deliveries.count).to eq 1
-    expect(deliveries.first.subject).to eq 'Your Pension Wise Appointment'
+    expect(deliveries.count).to eq 2
+    expect(deliveries.map(&:subject)).to include('Your Pension Wise Appointment')
   end
 
   def and_the_customer_gets_an_updated_email_confirmation
@@ -275,7 +275,7 @@ RSpec.feature 'Agent manages appointments' do
   end
 
   def then_the_customer_does_not_get_an_email_confirmation
-    expect(ActionMailer::Base.deliveries).to be_empty
+    expect(ActionMailer::Base.deliveries.flat_map(&:to)).to eq(['supervisors@maps.org.uk'])
   end
 
   def then_the_customer_does_not_get_an_updated_email_confirmation

--- a/spec/jobs/accessibility_adjustment_notifications_job_spec.rb
+++ b/spec/jobs/accessibility_adjustment_notifications_job_spec.rb
@@ -1,14 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe AccessibilityAdjustmentNotificationsJob, '#perform' do
-  it 'sends a notification email to associated resource managers' do
-    resource_manager = double(:resource_manager)
-    appointment      = double(:appointment, resource_managers: Array(resource_manager))
+  context 'when the guider is TPAS' do
+    it 'sends to the supervisors mailbox' do
+      resource_manager = 'test@example.org.uk'
+      appointment = double(:appointment, tpas_guider?: false)
+      allow(appointment).to receive_message_chain(:resource_managers, :pluck).and_return([resource_manager])
 
-    expect(AppointmentMailer).to receive(:accessibility_adjustment)
-      .with(appointment, resource_manager)
-      .and_return(double(deliver_later: true))
+      expect(AppointmentMailer).to receive(:accessibility_adjustment)
+        .with(appointment, resource_manager)
+        .and_return(double(deliver_later: true))
 
-    subject.perform(appointment)
+      subject.perform(appointment)
+    end
+  end
+
+  context 'when the guider is not TPAS' do
+    it 'sends a notification email to associated resource managers' do
+      resource_manager = 'supervisors@maps.org.uk'
+      appointment      = double(:appointment, tpas_guider?: true)
+
+      expect(AppointmentMailer).to receive(:accessibility_adjustment)
+        .with(appointment, resource_manager)
+        .and_return(double(deliver_later: true))
+
+      subject.perform(appointment)
+    end
   end
 end

--- a/spec/mailers/appointment_mailer_spec.rb
+++ b/spec/mailers/appointment_mailer_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe AppointmentMailer, type: :mailer do
     subject(:mail) { described_class.accessibility_adjustment(appointment, resource_manager) }
 
     let(:mailgun_headers) { JSON.parse(mail['X-Mailgun-Variables'].value) }
-    let(:resource_manager) { build_stubbed(:resource_manager) }
+    let(:resource_manager) { 'supervisors@maps.org.uk' }
 
     it 'renders the headers' do
       expect(mail.subject).to eq('Pension Wise Accessibility Adjustment')
-      expect(mail.to).to eq([resource_manager.email])
+      expect(mail.to).to eq(['supervisors@maps.org.uk'])
       expect(mail.from).to eq(['booking@pensionwise.gov.uk'])
     end
 

--- a/spec/requests/appointments_api_spec.rb
+++ b/spec/requests/appointments_api_spec.rb
@@ -120,6 +120,6 @@ RSpec.describe 'POST /api/v1/appointments' do
   end
 
   def and_the_resource_manager_receives_an_accessibility_notification
-    expect(ActionMailer::Base.deliveries.map(&:to)).to include(Array(@resource_manager.email))
+    expect(ActionMailer::Base.deliveries.map(&:to)).to include(Array('supervisors@maps.org.uk'))
   end
 end


### PR DESCRIPTION
When the guider is from TPAS and we send an accessibility adjustment
alert we must send them to the supervisors mailbox, otherwise they're
sent to the resource managers as usual.