### PR TITLE
Improve final nudge labelling

### DIFF
--- a/app/views/appointments/_personal_details_form.html.erb
+++ b/app/views/appointments/_personal_details_form.html.erb
@@ -68,13 +68,15 @@
 
     <% if current_user.tp_agent? %>
       <div class="form-group">
-        <%= f.label :pension_provider, 'Referring pension provider' %>
+        <%= f.label :pension_provider do %>
+          Pension provider <span class="alert-danger">(required for final nudge trial only)</span>
+        <% end %>
         <%= f.select :pension_provider,
           options_for_select(PensionProvider.all.invert.to_a, @appointment.pension_provider),
           { use_label: false, include_blank: true},
           class: 't-pension-provider form-control'
         %>
-        <div class="help-block">Required for final-nudge pilot appointments. Otherwise select <i>Not Applicable</i></div>
+        <span class="help-block">Otherwise select <i>Not Applicable</i></span>
       </div>
     <% end %>
 


### PR DESCRIPTION
Agents are still incorrectly attributing appointments to final nudge
calls. Making the labelling more prominent should help.