### PR TITLE
Improve layout of navigation bar

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,13 +11,11 @@
 <% content_for :navbar_right do %>
   <% if current_user.administrator? %>
     <%= form_for current_user, html: { class: 'js-organisation-form' } do |f| %>
-      <div class="form-group">
       <%= f.select :organisation_content_id,
         options_for_select(organisation_options, current_user.organisation_content_id),
         { include_blank: true },
         { class: 't-organisation js-organisation' }
       %>
-      </div>
     <% end %>
   <% end %>
 <% end %>

--- a/config/initializers/govuk_admin_template.rb
+++ b/config/initializers/govuk_admin_template.rb
@@ -2,7 +2,7 @@ GovukAdminTemplate.environment_style = Rails.env.staging? ? 'preview' : ENV['RAI
 GovukAdminTemplate.environment_label = Rails.env.titleize
 
 GovukAdminTemplate.configure do |c|
-  c.app_title = 'Telephone Appointment Planner'
+  c.app_title = 'Telephone Planner'
   c.show_flash = true
   c.show_signout = true
 end


### PR DESCRIPTION
This would wrap for users with the administrator role, since the
provider dropdown was styled incorrectly and has recently increased in
width. The app title has changed to drop the 'Appointment', this matches
the other planners that also changed recently and has the useful effect
of freeing up some valuable horizontal real estate.