### PR TITLE
Only enforce notes after cut off date

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -13,6 +13,7 @@ class Appointment < ApplicationRecord
   APPOINTMENT_LENGTH_MINUTES = 70.minutes.freeze
 
   FAKE_DATE_OF_BIRTH = Date.parse('1900-01-01').freeze
+  ACCESSIBILITY_NOTES_CUTOFF = Date.parse('2019-09-25').freeze
 
   NON_NOTIFY_COLUMNS = %w(
     agent_id
@@ -67,7 +68,7 @@ class Appointment < ApplicationRecord
   validates :memorable_word, presence: true
   validates :dc_pot_confirmed, inclusion: [true, false]
   validates :accessibility_requirements, inclusion: [true, false]
-  validates :notes, presence: true, if: :accessibility_requirements?
+  validates :notes, presence: true, if: :validate_accessibility_needs?
   validates :type_of_appointment, inclusion: %w(standard 50-54)
   validates :where_you_heard, inclusion: WhereYouHeard.options_for_inclusion, on: :create, unless: :rebooked_from_id?
   validates :gdpr_consent, inclusion: ['yes', 'no', '']
@@ -387,6 +388,12 @@ class Appointment < ApplicationRecord
 
   def regular_agent?
     agent && !agent.pension_wise_api?
+  end
+
+  def validate_accessibility_needs?
+    date = created_at || Time.zone.today
+
+    accessibility_requirements? && date > ACCESSIBILITY_NOTES_CUTOFF
   end
 
   class << self

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -193,6 +193,11 @@ RSpec.describe Appointment, type: :model do
 
         subject.notes = 'They require some assistance'
         expect(subject).to be_valid
+
+        # no notes required before cutoff date of 2019-09-25
+        subject.created_at = '2019-01-01'.to_date
+        subject.notes = ''
+        expect(subject).to be_valid
       end
     end
 


### PR DESCRIPTION
Changes logic to only enforce the presence of notes after the initial
change was introduced. This is to permit changes to appointments
pre-dating that time.