### PR TITLE
Ensure SMS candidates are correctly determined

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -55,7 +55,7 @@ class Appointment < ApplicationRecord
 
   scope :cancelled, -> { where(status: CANCELLED_STATUSES) }
   scope :not_cancelled, -> { where.not(status: CANCELLED_STATUSES) }
-  scope :with_mobile_number, -> { where("mobile != '' or phone like '07%'") }
+  scope :with_mobile_number, -> { where("mobile like '07%' or phone like '07%'") }
   scope :not_booked_today, -> { where.not(created_at: Time.current.beginning_of_day..Time.current.end_of_day) }
 
   validates :agent, presence: true

--- a/spec/features/sms_appointment_reminder_spec.rb
+++ b/spec/features/sms_appointment_reminder_spec.rb
@@ -15,6 +15,8 @@ RSpec.feature 'SMS appointment reminders' do
     @past = create(:appointment, start_at: 5.days.from_now)
     # in the window but no mobile number
     @no_mobile = create(:appointment, mobile: '', start_at: 2.days.from_now, agent: @agent)
+    # in the window but the 'mobile' number is not valid UK
+    @no_uk_mobile = create(:appointment, mobile: '0121 123 4567', start_at: 2.days.from_now, agent: @agent)
     # in the window with a mobile number
     @mobile = create(:appointment, start_at: 2.days.from_now, agent: @agent)
   end


### PR DESCRIPTION
We should ensure that 'mobile' numbers are 'valid' UK mobile numbers
before including them in the SMS reminder candidate list.

Prior to this change there was no checks performed against the mobile
field and regular numbers as well as international numbers were creeping
through.