### PR TITLE
Include a column for summary document existence

### DIFF
--- a/app/forms/appointment_report.rb
+++ b/app/forms/appointment_report.rb
@@ -43,6 +43,12 @@ class AppointmentReport
               SQL
              )
       .select('(SELECT MAX(created_at) FROM status_transitions WHERE appointment_id = appointments.id) as status_changed') # rubocop:disable LineLength
+      .select(<<-SQL
+                CASE WHEN EXISTS(SELECT 1 FROM Activities WHERE type = 'SummaryDocumentActivity' AND appointment_id = appointments.id) THEN 'Yes'
+                     ELSE 'No'
+                END as summary_document_created
+              SQL
+             )
       .select('appointments.first_name')
       .select('appointments.last_name')
       .select('appointments.notes')

--- a/spec/features/resource_manager_downloads_appointment_reports_spec.rb
+++ b/spec/features/resource_manager_downloads_appointment_reports_spec.rb
@@ -140,6 +140,7 @@ RSpec.feature 'Resource manager downloads appointment reports' do
       :duration,
       :status,
       :status_changed,
+      :summary_document_created,
       :first_name,
       :last_name,
       :notes,
@@ -160,6 +161,7 @@ RSpec.feature 'Resource manager downloads appointment reports' do
       '60 minutes',
       appointment.status,
       appointment.status_transitions.last.created_at,
+      'No', # summary document created
       appointment.first_name,
       appointment.last_name,
       appointment.notes,


### PR DESCRIPTION
Adds a column to the appointment report `summary_document_created` with
the value of 'Yes' or 'No' denoting the existence or absence of a
summary document.