### PR TITLE
Permit 10 character phone numbers

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -401,13 +401,13 @@ class Appointment < ApplicationRecord
   def validate_phone_digits
     return if phone.blank?
 
-    errors.add(:phone, 'must have at least 11 digits') if phone.gsub(/[^\d]/, '').length < 11
+    errors.add(:phone, 'must have at least 10 digits') if phone.gsub(/[^\d]/, '').length < 10
   end
 
   def validate_mobile_digits
     return if mobile.blank?
 
-    errors.add(:mobile, 'must have at least 11 digits') if mobile.gsub(/[^\d]/, '').length < 11
+    errors.add(:mobile, 'must have at least 10 digits') if mobile.gsub(/[^\d]/, '').length < 10
   end
 
   class << self

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -277,7 +277,7 @@ RSpec.describe Appointment, type: :model do
     context 'when created by a non-API agent' do
       before { subject.id = nil } # not persisted yet
 
-      it 'requires a phone number of at least 11 digits' do
+      it 'requires a phone number of at least 10 digits' do
         subject.agent = build(:agent, :tp)
         subject.phone = '0 1 2 1 2 5 2 4 7 2 8'
 
@@ -290,7 +290,7 @@ RSpec.describe Appointment, type: :model do
         expect(subject).to be_valid
       end
 
-      it 'requires a mobile number of at least 11 digits when specified' do
+      it 'requires a mobile number of at least 10 digits when specified' do
         subject.agent  = build(:agent, :tp)
         subject.mobile = ''
 


### PR DESCRIPTION
We had reports from guiders that some 10 digit numbers are callable in
UK so we need to relax the 11 digit validation.