### PR TITLE
Provide a simple search API for appointments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ source 'https://rubygems.org' do
   gem 'postgres-copy'
   gem 'puma', '~> 3.12'
   gem 'pusher'
+  gem 'rack-cors'
   gem 'rails', '~> 5.1.1'
   gem 'sassc-rails'
   gem 'select2-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,6 +258,8 @@ GEM
       thin (~> 1.5)
     pusher-signature (0.1.8)
     rack (2.0.8)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-protection (2.0.5)
       rack
     rack-test (1.1.0)
@@ -477,6 +479,7 @@ DEPENDENCIES
   puma (~> 3.12)!
   pusher!
   pusher-fake!
+  rack-cors!
   rails (~> 5.1.1)!
   rails-assets-bootstrap-daterangepicker (= 2.1.27)!
   rails-assets-eonasdan-bootstrap-datetimepicker!

--- a/app/controllers/api/v1/searches_controller.rb
+++ b/app/controllers/api/v1/searches_controller.rb
@@ -1,0 +1,11 @@
+module Api
+  module V1
+    class SearchesController < ApplicationController
+      def index
+        @results = AppointmentApiSearch.new(params[:query]).call
+
+        render json: @results, each_serializer: AppointmentSearchSerializer
+      end
+    end
+  end
+end

--- a/app/lib/appointment_api_search.rb
+++ b/app/lib/appointment_api_search.rb
@@ -1,0 +1,23 @@
+class AppointmentApiSearch
+  def initialize(query)
+    @query = query
+  end
+
+  def call
+    return [] if query.blank?
+    return search_by_reference if /\A\d+\Z/.match?(query.to_s)
+
+    Appointment
+      .where('last_name ILIKE :query OR email ILIKE :query', query: "%#{query}%")
+      .order(created_at: :desc)
+      .limit(20)
+  end
+
+  private
+
+  attr_reader :query
+
+  def search_by_reference
+    Appointment.where(id: query)
+  end
+end

--- a/app/serializers/appointment_search_serializer.rb
+++ b/app/serializers/appointment_search_serializer.rb
@@ -7,4 +7,8 @@ class AppointmentSearchSerializer < ActiveModel::Serializer
   attribute :url do
     edit_appointment_url(object)
   end
+
+  attribute :application do
+    GovukAdminTemplate::Config.app_title
+  end
 end

--- a/app/serializers/appointment_search_serializer.rb
+++ b/app/serializers/appointment_search_serializer.rb
@@ -1,0 +1,10 @@
+class AppointmentSearchSerializer < ActiveModel::Serializer
+  include Rails.application.routes.url_helpers
+
+  attribute :id, key: :reference
+  attribute :name
+
+  attribute :url do
+    edit_appointment_url(object)
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,12 @@ module TelephoneAppointmentPlanner
     # -- all .rb files in that directory are automatically loaded.
 
     config.action_mailer.default_url_options = { host: ENV['APPLICATION_HOST'] }
+
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins '*'
+        resource '/api/v1/searches', headers: :any, methods: %i(get options)
+      end
+    end
   end
 end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,5 @@ require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!
+
+Rails.application.default_url_options = Rails.application.config.action_mailer.default_url_options

--- a/config/initializers/gds_sso.rb
+++ b/config/initializers/gds_sso.rb
@@ -5,5 +5,7 @@ GDS::SSO.config do |config|
   config.oauth_root_url = ENV.fetch('OAUTH_ROOT_URL', 'http://localhost:3001')
   config.oauth_secret = ENV['OAUTH_SECRET']
 
+  config.additional_mock_permissions_required = [User::PENSION_WISE_API_PERMISSION]
+
   config.cache = Rails.cache
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
 
   namespace :api, constraints: { format: :json } do
     namespace :v1 do
+      resources :searches, only: :index
       resources :bookable_slots, only: :index
 
       resources :appointments, only: :create do

--- a/spec/lib/appointment_api_search_spec.rb
+++ b/spec/lib/appointment_api_search_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe AppointmentApiSearch do
+  context 'with a blank query' do
+    it 'returns an empty array' do
+      expect(described_class.new('').call).to eq([])
+    end
+  end
+
+  context 'with a reference number' do
+    it 'returns the matching result' do
+      @appointment = create(:appointment)
+
+      expect(described_class.new(@appointment.id).call).to eq([@appointment])
+    end
+  end
+
+  context 'with a name or email' do
+    it 'returns the matching results' do
+      @appointment = create(:appointment, last_name: 'Jones')
+      @other       = create(:appointment, email: 'bleh@example.com')
+
+      # by name
+      expect(described_class.new('jones').call).to eq([@appointment])
+      # by email
+      expect(described_class.new('bleh@exam').call).to eq([@other])
+    end
+  end
+end

--- a/spec/requests/searches_api_spec.rb
+++ b/spec/requests/searches_api_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe 'GET /api/v1/searches' do
     expect(results.first).to eq(
       'reference' => @appointment.id,
       'name' => @appointment.name,
-      'url' => "http://localhost:3001/appointments/#{@appointment.id}/edit"
+      'url' => "http://localhost:3001/appointments/#{@appointment.id}/edit",
+      'application' => 'Telephone Planner'
     )
   end
 

--- a/spec/requests/searches_api_spec.rb
+++ b/spec/requests/searches_api_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /api/v1/searches' do
+  scenario 'searching for appointments' do
+    given_the_user_is_a_pension_wise_api_user do
+      and_an_appointment_matching_the_search_criteria_exists
+      when_a_valid_search_is_made
+      then_the_service_responds_ok
+      and_the_results_are_serialized_as_json
+    end
+  end
+
+  scenario 'unauthorized access' do
+    given_the_user_has_no_permissions do
+      when_an_unauthorized_request_is_made
+      then_the_service_responds_with_a_403_status
+    end
+  end
+
+  def when_a_valid_search_is_made
+    get api_v1_searches_path, params: { query: 'ben@example.com' }, as: :json
+  end
+
+  def and_an_appointment_matching_the_search_criteria_exists
+    @appointment = create(:appointment, email: 'ben@example.com')
+  end
+
+  def then_the_service_responds_ok
+    expect(response).to be_ok
+  end
+
+  def and_the_results_are_serialized_as_json
+    results = JSON.parse(response.body)
+
+    expect(results.first).to eq(
+      'reference' => @appointment.id,
+      'name' => @appointment.name,
+      'url' => "http://localhost:3001/appointments/#{@appointment.id}/edit"
+    )
+  end
+
+  def when_an_unauthorized_request_is_made
+    get api_v1_searches_path
+  end
+
+  def then_the_service_responds_with_a_403_status
+    expect(response).to be_forbidden
+  end
+end


### PR DESCRIPTION
When provided with a query (reference or partial match on name/email) we
return the appointments matching the given critera. The attributes:
reference, name and URL are serialized and returned as JSON.