### PR TITLE
Don't trigger audits after redacting

### DIFF
--- a/app/controllers/api/v1/searches_controller.rb
+++ b/app/controllers/api/v1/searches_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class SearchesController < ApplicationController
+    class SearchesController < Api::V1::ApplicationController
       def index
         @results = AppointmentApiSearch.new(params[:query]).call
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,4 +34,8 @@ class ApplicationController < ActionController::Base
   def authorise_for_administrators!
     authorise_user!(User::ADMINISTRATOR_PERMISSION)
   end
+
+  def authorise_for_api_users!
+    authorise_user!(User::PENSION_WISE_API_PERMISSION)
+  end
 end

--- a/lib/tasks/confidentiality.rake
+++ b/lib/tasks/confidentiality.rake
@@ -4,21 +4,23 @@ namespace :confidentiality do
     appointment = Appointment.find(ENV.fetch('REFERENCE'))
 
     ActiveRecord::Base.transaction do
-      appointment.update(
-        first_name: 'redacted',
-        last_name: 'redacted',
-        email: 'redacted@example.com',
-        phone: '00000000000',
-        mobile: '00000000000',
-        date_of_birth: '1950-01-01',
-        memorable_word: 'redacted',
-        address_line_one: 'redacted',
-        address_line_two: 'redacted',
-        address_line_three: 'redacted',
-        town: 'redacted',
-        postcode: 'redacted',
-        notes: 'redacted'
-      )
+      Appointment.without_auditing do
+        appointment.update(
+          first_name: 'redacted',
+          last_name: 'redacted',
+          email: 'redacted@example.com',
+          phone: '00000000000',
+          mobile: '00000000000',
+          date_of_birth: '1950-01-01',
+          memorable_word: 'redacted',
+          address_line_one: 'redacted',
+          address_line_two: 'redacted',
+          address_line_three: 'redacted',
+          town: 'redacted',
+          postcode: 'redacted',
+          notes: 'redacted'
+        )
+      end
 
       appointment.audits.delete_all
       appointment.activities.where(

--- a/spec/lib/appointment_api_search_spec.rb
+++ b/spec/lib/appointment_api_search_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe AppointmentApiSearch do
   context 'with a name or email' do
     it 'returns the matching results' do
       @appointment = create(:appointment, last_name: 'Jones')
-      @other       = create(:appointment, email: 'bleh@example.com')
+      @other       = create(:appointment, last_name: 'Smith', email: 'bleh@example.com')
 
       # by name
       expect(described_class.new('jones').call).to eq([@appointment])


### PR DESCRIPTION
Previously this would trigger the creation of an activity that would
then be enqueued to pusher, meanwhile the activities are destroyed as
part of the redaction process and once the job is dequeued, the
underlying activity is gone so would cause an error.