### PR TITLE
Remove final nudge fields

### DIFF
--- a/app/controllers/api/v1/appointments_controller.rb
+++ b/app/controllers/api/v1/appointments_controller.rb
@@ -16,7 +16,7 @@ module Api
 
       def send_notifications(appointment)
         AccessibilityAdjustmentNotificationsJob.perform_later(appointment) if appointment.accessibility_requirements?
-        WebsiteAppointmentSlackPingerJob.perform_later(appointment)
+        WebsiteAppointmentSlackPingerJob.perform_later
         CustomerUpdateJob.perform_later(appointment, CustomerUpdateActivity::CONFIRMED_MESSAGE)
       end
 
@@ -33,8 +33,7 @@ module Api
           :where_you_heard,
           :gdpr_consent,
           :accessibility_requirements,
-          :notes,
-          :pension_provider
+          :notes
         ).merge(agent: current_user)
       end
     end

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -164,8 +164,7 @@ class AppointmentsController < ApplicationController
       :town,
       :county,
       :postcode,
-      :gdpr_consent,
-      :pension_provider
+      :gdpr_consent
     ]
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/forms/api/v1/appointment.rb
+++ b/app/forms/api/v1/appointment.rb
@@ -15,7 +15,6 @@ module Api
       attr_accessor :gdpr_consent
       attr_accessor :accessibility_requirements
       attr_accessor :notes
-      attr_accessor :pension_provider
       attr_accessor :agent
 
       attr_reader :model
@@ -35,7 +34,7 @@ module Api
 
       private
 
-      def to_params # rubocop:disable Metrics/MethodLength, AbcSize
+      def to_params # rubocop:disable Metrics/MethodLength
         {
           start_at: start_at,
           first_name: first_name,
@@ -49,7 +48,7 @@ module Api
           gdpr_consent: gdpr_consent.to_s,
           accessibility_requirements: accessibility_requirements,
           notes: notes,
-          pension_provider: pension_provider.presence || 'n/a',
+          pension_provider: 'n/a',
           agent: agent
         }
       end

--- a/app/jobs/website_appointment_slack_pinger_job.rb
+++ b/app/jobs/website_appointment_slack_pinger_job.rb
@@ -1,11 +1,11 @@
 class WebsiteAppointmentSlackPingerJob < ActiveJob::Base
   queue_as :default
 
-  def perform(appointment)
+  def perform
     return unless hook_uri
 
     hook = WebHook.new(hook_uri)
-    hook.call(payload(appointment))
+    hook.call(payload)
   end
 
   private
@@ -14,13 +14,11 @@ class WebsiteAppointmentSlackPingerJob < ActiveJob::Base
     ENV['APPOINTMENTS_SLACK_PINGER_URI']
   end
 
-  def payload(appointment)
-    pension_provider = PensionProvider[appointment.pension_provider]
-
+  def payload
     {
       username: 'dave',
       channel: '#online-bookings',
-      text: ":tada: customer telephone booking #{pension_provider} :tada:",
+      text: ':tada: customer telephone booking :tada:',
       icon_emoji: ':mullet:'
     }
   end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -72,8 +72,6 @@ class Appointment < ApplicationRecord
   validates :type_of_appointment, inclusion: %w(standard 50-54)
   validates :where_you_heard, inclusion: WhereYouHeard.options_for_inclusion, on: :create, unless: :rebooked_from_id?
   validates :gdpr_consent, inclusion: ['yes', 'no', '']
-  validates :pension_provider, presence: true, if: :tp_agent?, on: :create
-
   validates :status, presence: true
   validates :guider, presence: true
 

--- a/app/views/appointments/_personal_details_form.html.erb
+++ b/app/views/appointments/_personal_details_form.html.erb
@@ -64,20 +64,6 @@
       %>
     </div>
 
-    <% if current_user.tp_agent? %>
-      <div class="form-group">
-        <%= f.label :pension_provider do %>
-          Pension provider <span class="alert-danger">(required for final nudge trial only)</span>
-        <% end %>
-        <%= f.select :pension_provider,
-          options_for_select(PensionProvider.all.invert.to_a, @appointment.pension_provider),
-          { use_label: false, include_blank: true},
-          class: 't-pension-provider form-control'
-        %>
-        <span class="help-block">Otherwise select <i>Not Applicable</i></span>
-      </div>
-    <% end %>
-
     <%=
       f.select(
         :status,

--- a/app/views/appointments/preview.html.erb
+++ b/app/views/appointments/preview.html.erb
@@ -38,7 +38,6 @@
   <%= f.hidden_field :town %>
   <%= f.hidden_field :county %>
   <%= f.hidden_field :postcode %>
-  <%= f.hidden_field :pension_provider %>
 
   <div class="t-preview appointment-preview">
     <div class="row">
@@ -102,10 +101,6 @@
             <tr>
               <td class="active"><b>Notes</b></td>
               <td><%= @appointment.notes %></td>
-            </tr>
-            <tr>
-              <td class="active"><b>Pension provider</b></td>
-              <td><%= PensionProvider[@appointment.pension_provider] %></td>
             </tr>
             <tr>
               <td class="active"><b>Customer research consent</b></td>

--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -37,9 +37,5 @@ FactoryBot.define do
       county { 'Some County' }
       postcode { 'E3 3NN' }
     end
-
-    trait :aviva do
-      pension_provider { 'aviva' }
-    end
   end
 end

--- a/spec/features/agent_manages_appointments_spec.rb
+++ b/spec/features/agent_manages_appointments_spec.rb
@@ -201,7 +201,6 @@ RSpec.feature 'Agent manages appointments' do
     @page.address_line_one.set(options[:address_line_one]) if options[:address_line_one]
     @page.town.set(options[:town]) if options[:town]
     @page.postcode.set(options[:postcode]) if options[:postcode]
-    @page.pension_provider.select('Not Applicable')
 
     @page.preview_appointment.click
   end

--- a/spec/features/agent_rebooks_appointments_spec.rb
+++ b/spec/features/agent_rebooks_appointments_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.feature 'Agent rebooks appointments' do
   scenario 'Agent rebooks an appointment' do
     given_the_user_is_an_agent do
-      and_pension_providers_are_configured
       and_there_is_an_appointment
       and_they_rebook_an_appointment
       then_the_details_are_copied_over
@@ -14,18 +13,10 @@ RSpec.feature 'Agent rebooks appointments' do
 
   scenario 'Agent attempts to rebook a pending appointment' do
     given_the_user_is_an_agent do
-      and_pension_providers_are_configured
       and_there_is_a_pending_appointment
       when_they_attempt_to_rebook_an_appointment
       then_they_are_told_to_change_the_original_appointment_status
     end
-  end
-
-  def and_pension_providers_are_configured
-    allow(PensionProvider).to receive(:all).and_return(
-      'aviva' => 'Aviva',
-      'hargreaves-landsdown' => 'Hargreaves Landsdown'
-    )
   end
 
   def and_there_is_a_pending_appointment
@@ -46,7 +37,7 @@ RSpec.feature 'Agent rebooks appointments' do
   end
 
   def and_there_is_an_appointment
-    @appointment = create(:appointment, :aviva, status: :cancelled_by_customer)
+    @appointment = create(:appointment, status: :cancelled_by_customer)
   end
 
   def and_they_rebook_an_appointment
@@ -68,7 +59,6 @@ RSpec.feature 'Agent rebooks appointments' do
     expect(@page.memorable_word.value).to eq @appointment.memorable_word
     expect(@page.notes.value).to eq @appointment.notes
     expect(@page.gdpr_consent_yes).to be_checked
-    expect(@page.pension_provider.value).to eq(@appointment.pension_provider)
   end
 
   def and_the_start_and_end_date_are_not_copied_over

--- a/spec/features/resource_manager_modifies_appointments_spec.rb
+++ b/spec/features/resource_manager_modifies_appointments_spec.rb
@@ -277,21 +277,4 @@ RSpec.feature 'Resource manager modifies appointments' do
 
     expect(Holiday.count).to eq 1
   end
-
-  def and_pension_providers_are_configured
-    allow(PensionProvider).to receive(:all).and_return(
-      'aviva' => 'Aviva',
-      'hargreaves-landsdown' => 'Hargreaves Landsdown'
-    )
-  end
-
-  def when_they_attempt_to_create_an_appointment
-    @page = Pages::NewAppointment.new
-    @page.load
-  end
-
-  def then_they_do_not_see_pension_providers
-    expect(@page).to be_displayed
-    expect(@page).to have_no_pension_provider
-  end
 end

--- a/spec/requests/appointments_api_spec.rb
+++ b/spec/requests/appointments_api_spec.rb
@@ -75,7 +75,6 @@ RSpec.describe 'POST /api/v1/appointments' do
       'dc_pot_confirmed' => true,
       'where_you_heard'  => '1',
       'gdpr_consent'     => nil,
-      'pension_provider' => nil,
       'accessibility_requirements' => true,
       'notes' => 'I am hard of hearing'
     }

--- a/spec/support/pages/new_appointment.rb
+++ b/spec/support/pages/new_appointment.rb
@@ -34,8 +34,6 @@ module Pages
     element :guider, '.t-guider'
     element :ad_hoc_start_at, '.t-ad-hoc-start-at'
 
-    element :pension_provider, '.t-pension-provider'
-
     def ad_hoc_start_at(value)
       execute_script("$('.t-ad-hoc-start-at').val('#{value}')")
     end


### PR DESCRIPTION
Removes the final nudge provider from agent bookings and defaults to a
sensible value for customer bookings.