### PR TITLE
Ignore bounced accessibility adjustment emails

### DIFF
--- a/app/forms/drop_form.rb
+++ b/app/forms/drop_form.rb
@@ -19,7 +19,7 @@ class DropForm
   validates :signature, presence: true
   validates :event, presence: true
   validates :appointment_id, presence: true
-  validates :message_type, presence: true
+  validates :message_type, presence: true, exclusion: { in: %w(accessibility_adjustment) }
   validates :environment, inclusion: { in: %w(production) }
 
   def create_activity

--- a/spec/forms/drop_form_spec.rb
+++ b/spec/forms/drop_form_spec.rb
@@ -62,6 +62,12 @@ RSpec.describe DropForm, '#create_activity' do
       expect(subject).not_to be_valid
     end
 
+    it 'does not bounce for `accessibility_adjustment` messages' do
+      params['message_type'] = 'accessibility_adjustment'
+
+      expect(subject).to be_invalid
+    end
+
     context 'when everything is validated' do
       it 'creates the drop activity' do
         expect(DropActivity).to receive(:from).with(


### PR DESCRIPTION
These were firing web hooks but are not handled internally by resource
managers, plus they appear as bounce activities against the associated
booking, thus confusing agents that may be viewing the activity feed. We
can just ignore these particular calls instead.