### PR TITLE
Reverse the ordering of guider schedules

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -2,7 +2,7 @@ class Schedule < ApplicationRecord
   belongs_to :user
   has_many :slots, inverse_of: :schedule, dependent: :destroy
   accepts_nested_attributes_for :slots, allow_destroy: true
-  scope :by_start_at, -> { order(:start_at) }
+  scope :by_start_at, -> { order(start_at: :desc) }
 
   validates :start_at, presence: true
   validates :start_at, uniqueness: { scope: :user_id }

--- a/spec/features/resource_manager_manages_schedules_spec.rb
+++ b/spec/features/resource_manager_manages_schedules_spec.rb
@@ -214,13 +214,13 @@ RSpec.feature 'Resource manager manages schedules' do
   def then_they_cant_edit_the_schedule
     @page = Pages::EditUser.new
     @page.load(id: @guider.id)
-    expect(@page.schedules.first).to have_no_edit
+    expect(@page.schedules.last).to have_no_edit
   end
 
   def and_they_cant_delete_the_schedule
     @page = Pages::EditUser.new
     @page.load(id: @guider.id)
-    expect(@page.schedules.first.delete).to be_disabled
+    expect(@page.schedules.last.delete).to be_disabled
   end
 
   def and_the_guider_bookable_slots_are_regenerated


### PR DESCRIPTION
This was requested by resource managers to aid the location of the most recent
schedule for a particular guider.