### PR TITLE
Resource manager email notifications

### DIFF
--- a/app/controllers/api/v1/appointments_controller.rb
+++ b/app/controllers/api/v1/appointments_controller.rb
@@ -18,6 +18,7 @@ module Api
         AccessibilityAdjustmentNotificationsJob.perform_later(appointment) if appointment.accessibility_requirements?
         WebsiteAppointmentSlackPingerJob.perform_later
         CustomerUpdateJob.perform_later(appointment, CustomerUpdateActivity::CONFIRMED_MESSAGE)
+        AppointmentCreatedNotificationsJob.perform_later(appointment)
       end
 
       def appointment_params # rubocop:disable Metrics/MethodLength

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -98,6 +98,7 @@ class AppointmentsController < ApplicationController
   def send_notifications(appointment)
     AccessibilityAdjustmentNotificationsJob.perform_later(appointment) if appointment.accessibility_requirements?
     CustomerUpdateJob.perform_later(appointment, CustomerUpdateActivity::CONFIRMED_MESSAGE)
+    AppointmentCreatedNotificationsJob.perform_later(appointment)
   end
 
   def postcode_api_key

--- a/app/forms/drop_form.rb
+++ b/app/forms/drop_form.rb
@@ -5,6 +5,11 @@ TokenVerificationFailure = Class.new(StandardError)
 class DropForm
   include ActiveModel::Model
 
+  IGNORED_MESSAGE_TYPES = %w(
+    accessibility_adjustment
+    resource_manager_appointment_created
+  ).freeze
+
   attr_accessor :event
   attr_accessor :description
   attr_accessor :appointment_id
@@ -19,7 +24,7 @@ class DropForm
   validates :signature, presence: true
   validates :event, presence: true
   validates :appointment_id, presence: true
-  validates :message_type, presence: true, exclusion: { in: %w(accessibility_adjustment) }
+  validates :message_type, presence: true, exclusion: { in: IGNORED_MESSAGE_TYPES }
   validates :environment, inclusion: { in: %w(production) }
 
   def create_activity

--- a/app/forms/drop_form.rb
+++ b/app/forms/drop_form.rb
@@ -8,6 +8,7 @@ class DropForm
   IGNORED_MESSAGE_TYPES = %w(
     accessibility_adjustment
     resource_manager_appointment_created
+    resource_manager_appointment_cancelled
   ).freeze
 
   attr_accessor :event

--- a/app/forms/drop_form.rb
+++ b/app/forms/drop_form.rb
@@ -9,6 +9,7 @@ class DropForm
     accessibility_adjustment
     resource_manager_appointment_created
     resource_manager_appointment_cancelled
+    resource_manager_appointment_rescheduled
   ).freeze
 
   attr_accessor :event

--- a/app/forms/sms_cancellation.rb
+++ b/app/forms/sms_cancellation.rb
@@ -25,6 +25,7 @@ class SmsCancellation
     )
 
     SmsCancellationSuccessJob.perform_later(appointment)
+    AppointmentCancelledNotificationsJob.perform_later(appointment)
   end
 
   def appointment

--- a/app/jobs/appointment_cancelled_notifications_job.rb
+++ b/app/jobs/appointment_cancelled_notifications_job.rb
@@ -1,0 +1,20 @@
+class AppointmentCancelledNotificationsJob < ApplicationJob
+  queue_as :default
+
+  def perform(appointment)
+    return if appointment.tpas_guider?
+
+    recipients_for(appointment).each do |recipient|
+      AppointmentMailer.resource_manager_appointment_cancelled(
+        appointment,
+        recipient
+      ).deliver_later
+    end
+  end
+
+  private
+
+  def recipients_for(appointment)
+    appointment.resource_managers.pluck(:email)
+  end
+end

--- a/app/jobs/appointment_created_notifications_job.rb
+++ b/app/jobs/appointment_created_notifications_job.rb
@@ -1,0 +1,20 @@
+class AppointmentCreatedNotificationsJob < ApplicationJob
+  queue_as :default
+
+  def perform(appointment)
+    return if appointment.tpas_guider?
+
+    recipients_for(appointment).each do |recipient|
+      AppointmentMailer.resource_manager_appointment_created(
+        appointment,
+        recipient
+      ).deliver_later
+    end
+  end
+
+  private
+
+  def recipients_for(appointment)
+    appointment.resource_managers.pluck(:email)
+  end
+end

--- a/app/jobs/appointment_created_notifications_job.rb
+++ b/app/jobs/appointment_created_notifications_job.rb
@@ -2,7 +2,7 @@ class AppointmentCreatedNotificationsJob < ApplicationJob
   queue_as :default
 
   def perform(appointment)
-    return if appointment.tpas_guider?
+    return if ignore?(appointment)
 
     recipients_for(appointment).each do |recipient|
       AppointmentMailer.resource_manager_appointment_created(
@@ -13,6 +13,10 @@ class AppointmentCreatedNotificationsJob < ApplicationJob
   end
 
   private
+
+  def ignore?(appointment)
+    appointment.tpas_guider? || appointment.cas_guider?
+  end
 
   def recipients_for(appointment)
     appointment.resource_managers.pluck(:email)

--- a/app/jobs/appointment_rescheduled_notifications_job.rb
+++ b/app/jobs/appointment_rescheduled_notifications_job.rb
@@ -1,0 +1,20 @@
+class AppointmentRescheduledNotificationsJob < ApplicationJob
+  queue_as :default
+
+  def perform(appointment)
+    return if appointment.tpas_guider?
+
+    recipients_for(appointment).each do |recipient|
+      AppointmentMailer.resource_manager_appointment_rescheduled(
+        appointment,
+        recipient
+      ).deliver_later
+    end
+  end
+
+  private
+
+  def recipients_for(appointment)
+    appointment.resource_managers.pluck(:email)
+  end
+end

--- a/app/lib/notifier.rb
+++ b/app/lib/notifier.rb
@@ -8,9 +8,17 @@ class Notifier
 
     notify_customer
     notify_guiders
+    notify_resource_managers
   end
 
   private
+
+  def notify_resource_managers
+    return if appointment.tpas_guider?
+    return unless appointment_cancelled?
+
+    AppointmentCancelledNotificationsJob.perform_later(appointment)
+  end
 
   def notify_guiders
     guiders_to_notify.each do |guider_id|

--- a/app/lib/notifier.rb
+++ b/app/lib/notifier.rb
@@ -14,10 +14,11 @@ class Notifier
   private
 
   def notify_resource_managers
-    return if appointment.tpas_guider?
-    return unless appointment_cancelled?
-
-    AppointmentCancelledNotificationsJob.perform_later(appointment)
+    if appointment_cancelled?
+      AppointmentCancelledNotificationsJob.perform_later(appointment)
+    elsif appointment_rescheduled?
+      AppointmentRescheduledNotificationsJob.perform_later(appointment)
+    end
   end
 
   def notify_guiders
@@ -53,6 +54,10 @@ class Notifier
   def appointment_missed?
     appointment.previous_changes.slice('status').present? &&
       appointment.no_show?
+  end
+
+  def appointment_rescheduled?
+    appointment.previous_changes.slice('guider_id', 'start_at').present?
   end
 
   attr_reader :appointment

--- a/app/mailers/appointment_mailer.rb
+++ b/app/mailers/appointment_mailer.rb
@@ -1,6 +1,12 @@
 class AppointmentMailer < ApplicationMailer
   default subject: 'Your Pension Wise Appointment'
 
+  def resource_manager_appointment_rescheduled(appointment, recipient)
+    mailgun_headers('resource_manager_appointment_rescheduled', appointment.id)
+    @appointment = appointment
+    mail to: recipient, subject: 'Pension Wise Appointment Rescheduled'
+  end
+
   def resource_manager_appointment_cancelled(appointment, recipient)
     mailgun_headers('resource_manager_appointment_cancelled', appointment.id)
     @appointment = appointment

--- a/app/mailers/appointment_mailer.rb
+++ b/app/mailers/appointment_mailer.rb
@@ -1,6 +1,12 @@
 class AppointmentMailer < ApplicationMailer
   default subject: 'Your Pension Wise Appointment'
 
+  def resource_manager_appointment_cancelled(appointment, recipient)
+    mailgun_headers('resource_manager_appointment_cancelled', appointment.id)
+    @appointment = appointment
+    mail to: recipient, subject: 'Pension Wise Appointment Cancelled'
+  end
+
   def resource_manager_appointment_created(appointment, recipient)
     mailgun_headers('resource_manager_appointment_created', appointment.id)
     @appointment = appointment

--- a/app/mailers/appointment_mailer.rb
+++ b/app/mailers/appointment_mailer.rb
@@ -1,6 +1,12 @@
 class AppointmentMailer < ApplicationMailer
   default subject: 'Your Pension Wise Appointment'
 
+  def resource_manager_appointment_created(appointment, recipient)
+    mailgun_headers('resource_manager_appointment_created', appointment.id)
+    @appointment = appointment
+    mail to: recipient, subject: 'Pension Wise Appointment Created'
+  end
+
   def accessibility_adjustment(appointment, recipient)
     mailgun_headers('accessibility_adjustment', appointment.id)
     @appointment = appointment

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -186,6 +186,10 @@ class Appointment < ApplicationRecord
     guider&.tpas?
   end
 
+  def cas_guider?
+    guider&.cas?
+  end
+
   def agent_is_pension_wise_api?
     agent && agent.pension_wise_api?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,6 +47,10 @@ class User < ApplicationRecord
     organisation_content_id == Provider::TPAS.id
   end
 
+  def cas?
+    organisation_content_id == Provider::CAS.id
+  end
+
   def tp_agent?
     tp? && agent?
   end

--- a/app/views/appointment_mailer/resource_manager_appointment_cancelled.html.erb
+++ b/app/views/appointment_mailer/resource_manager_appointment_cancelled.html.erb
@@ -1,0 +1,23 @@
+<h1 style="color: #0B0C0C !important;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-weight: 700;font-size: 20px;line-height: 1.111111111;padding: 15px 0;">
+  An appointment was cancelled
+</h1>
+
+<%= p do %>
+  Reference number:
+  <br>
+  <strong class="emphasize">
+    <%= @appointment.id %>
+  </strong>
+<% end %>
+
+<%= p do %>
+  Guider:
+  <br>
+  <strong class="emphasize">
+    <%= @appointment.guider.name %>
+  </strong>
+<% end %>
+
+<%= p do %>
+  <%= link_to 'View the appointment', edit_appointment_url(@appointment) %>
+<% end %>

--- a/app/views/appointment_mailer/resource_manager_appointment_cancelled.text.erb
+++ b/app/views/appointment_mailer/resource_manager_appointment_cancelled.text.erb
@@ -1,0 +1,9 @@
+An appointment was cancelled
+
+Reference number:
+<%= @appointment.id %>
+
+Guider:
+<%= @appointment.guider.name %>
+
+<%= edit_appointment_url(@appointment) %>

--- a/app/views/appointment_mailer/resource_manager_appointment_created.html.erb
+++ b/app/views/appointment_mailer/resource_manager_appointment_created.html.erb
@@ -1,0 +1,23 @@
+<h1 style="color: #0B0C0C !important;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-weight: 700;font-size: 20px;line-height: 1.111111111;padding: 15px 0;">
+  An appointment was created
+</h1>
+
+<%= p do %>
+  Reference number:
+  <br>
+  <strong class="emphasize">
+    <%= @appointment.id %>
+  </strong>
+<% end %>
+
+<%= p do %>
+  Guider:
+  <br>
+  <strong class="emphasize">
+    <%= @appointment.guider.name %>
+  </strong>
+<% end %>
+
+<%= p do %>
+  <%= link_to 'View the appointment', edit_appointment_url(@appointment) %>
+<% end %>

--- a/app/views/appointment_mailer/resource_manager_appointment_created.text.erb
+++ b/app/views/appointment_mailer/resource_manager_appointment_created.text.erb
@@ -1,0 +1,9 @@
+An appointment was created
+
+Reference number:
+<%= @appointment.id %>
+
+Guider:
+<%= @appointment.guider.name %>
+
+<%= edit_appointment_url(@appointment) %>

--- a/app/views/appointment_mailer/resource_manager_appointment_rescheduled.html.erb
+++ b/app/views/appointment_mailer/resource_manager_appointment_rescheduled.html.erb
@@ -1,0 +1,23 @@
+<h1 style="color: #0B0C0C !important;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-weight: 700;font-size: 20px;line-height: 1.111111111;padding: 15px 0;">
+  An appointment was rescheduled
+</h1>
+
+<%= p do %>
+  Reference number:
+  <br>
+  <strong class="emphasize">
+    <%= @appointment.id %>
+  </strong>
+<% end %>
+
+<%= p do %>
+  Guider:
+  <br>
+  <strong class="emphasize">
+    <%= @appointment.guider.name %>
+  </strong>
+<% end %>
+
+<%= p do %>
+  <%= link_to 'View the appointment', edit_appointment_url(@appointment) %>
+<% end %>

--- a/app/views/appointment_mailer/resource_manager_appointment_rescheduled.text.erb
+++ b/app/views/appointment_mailer/resource_manager_appointment_rescheduled.text.erb
@@ -1,0 +1,9 @@
+An appointment was rescheduled
+
+Reference number:
+<%= @appointment.id %>
+
+Guider:
+<%= @appointment.guider.name %>
+
+<%= edit_appointment_url(@appointment) %>

--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -1,6 +1,10 @@
 FactoryBot.define do
   factory :appointment do
-    agent { create(:resource_manager) }
+    transient do
+      organisation { :tpas }
+    end
+
+    agent { create(:resource_manager, organisation) }
     start_at { BusinessDays.from_now(3).at_midday }
     end_at { start_at + 1.hour }
     first_name { Faker::Name.first_name }
@@ -14,7 +18,7 @@ FactoryBot.define do
     memorable_word { 'lozenge' }
     date_of_birth { '1945-01-01' }
     type_of_appointment { '50-54' }
-    guider { create(:guider) }
+    guider { create(:guider, organisation) }
     where_you_heard { WhereYouHeard.options_for_inclusion.sample }
     created_at { 1.day.ago }
     accessibility_requirements { false }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -27,6 +27,7 @@ FactoryBot.define do
     end
 
     factory :resource_manager, traits: [:tpas] do
+      email { 'rm@example.com' }
       permissions { Array(User::RESOURCE_MANAGER_PERMISSION) }
     end
 

--- a/spec/features/resource_manager_manages_holidays_spec.rb
+++ b/spec/features/resource_manager_manages_holidays_spec.rb
@@ -90,7 +90,7 @@ RSpec.feature 'Resource manager manages holidays' do
     end
   end
 
-  scenario 'Deletes a holiday', js: true do
+  scenario 'Deletes a holiday', js: true, retry: 3 do
     given_the_user_is_a_resource_manager do
       travel_to today do
         and_there_are_guiders_with_multiple_day_holidays

--- a/spec/forms/drop_form_spec.rb
+++ b/spec/forms/drop_form_spec.rb
@@ -62,10 +62,12 @@ RSpec.describe DropForm, '#create_activity' do
       expect(subject).not_to be_valid
     end
 
-    it 'does not bounce for `accessibility_adjustment` messages' do
-      params['message_type'] = 'accessibility_adjustment'
+    DropForm::IGNORED_MESSAGE_TYPES.each do |type|
+      it "does not bounce for `#{type}` messages" do
+        params['message_type'] = type
 
-      expect(subject).to be_invalid
+        expect(subject).to be_invalid
+      end
     end
 
     context 'when everything is validated' do

--- a/spec/jobs/appointment_cancelled_notifications_job_spec.rb
+++ b/spec/jobs/appointment_cancelled_notifications_job_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe AppointmentCancelledNotificationsJob do
+  context 'when the appointment has a TPAS guider' do
+    it 'ensures the resource managers are not alerted by email' do
+      appointment = create(:appointment)
+
+      expect(AppointmentMailer).not_to receive(:resource_manager_appointment_cancelled)
+
+      subject.perform(appointment)
+    end
+  end
+
+  context 'when the appointment is not for TPAS' do
+    it 'alerts the resource managers by email' do
+      appointment = create(:appointment, organisation: :wallsend)
+
+      expect(AppointmentMailer).to receive(:resource_manager_appointment_cancelled)
+        .with(appointment, 'rm@example.com')
+        .and_return(double(deliver_later: true))
+
+      subject.perform(appointment)
+    end
+  end
+end

--- a/spec/jobs/appointment_created_notifications_job_spec.rb
+++ b/spec/jobs/appointment_created_notifications_job_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe AppointmentCreatedNotificationsJob do
+  context 'when the guider is from TPAS' do
+    it 'does nothing' do
+      appointment = create(:appointment)
+
+      expect(AppointmentMailer).not_to receive(:resource_manager_appointment_created)
+
+      subject.perform(appointment)
+    end
+  end
+
+  context 'when the guider is from another organisation' do
+    it 'enqueues email notifications for the organisation resource managers' do
+      appointment = create(:appointment, organisation: :cas)
+
+      expect(AppointmentMailer).to receive(:resource_manager_appointment_created)
+        .with(appointment, 'rm@example.com')
+        .and_return(double(deliver_later: true))
+
+      subject.perform(appointment)
+    end
+  end
+end

--- a/spec/jobs/appointment_created_notifications_job_spec.rb
+++ b/spec/jobs/appointment_created_notifications_job_spec.rb
@@ -11,9 +11,19 @@ RSpec.describe AppointmentCreatedNotificationsJob do
     end
   end
 
+  context 'when the guider is from CAS' do
+    it 'does nothing' do
+      appointment = create(:appointment, organisation: :cas)
+
+      expect(AppointmentMailer).not_to receive(:resource_manager_appointment_created)
+
+      subject.perform(appointment)
+    end
+  end
+
   context 'when the guider is from another organisation' do
     it 'enqueues email notifications for the organisation resource managers' do
-      appointment = create(:appointment, organisation: :cas)
+      appointment = create(:appointment, organisation: :wallsend)
 
       expect(AppointmentMailer).to receive(:resource_manager_appointment_created)
         .with(appointment, 'rm@example.com')

--- a/spec/jobs/appointment_rescheduled_notifications_job_spec.rb
+++ b/spec/jobs/appointment_rescheduled_notifications_job_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe AppointmentRescheduledNotificationsJob do
+  context 'when the guider is from TPAS' do
+    it 'does not send notifications' do
+      appointment = create(:appointment)
+
+      expect(AppointmentMailer).not_to receive(:resource_manager_appointment_rescheduled)
+
+      subject.perform(appointment)
+    end
+  end
+
+  context 'when the guider is from another organisation' do
+    it 'sends notifications to the resource managers' do
+      appointment = create(:appointment, organisation: :wallsend)
+
+      expect(AppointmentMailer).to receive(:resource_manager_appointment_rescheduled)
+        .with(appointment, 'rm@example.com')
+        .and_return(double(deliver_later: true))
+
+      subject.perform(appointment)
+    end
+  end
+end

--- a/spec/lib/notifier_spec.rb
+++ b/spec/lib/notifier_spec.rb
@@ -70,6 +70,16 @@ RSpec.describe Notifier, '#call' do
         message: CustomerUpdateActivity::CANCELLED_MESSAGE
       )
     end
+
+    context 'when the appointment is not TPAS' do
+      it 'alerts the resource managers' do
+        appointment.update_attribute(:guider_id, create(:guider, :wallsend))
+
+        expect(AppointmentCancelledNotificationsJob).to receive(:perform_later).with(appointment)
+
+        subject.call
+      end
+    end
   end
 
   context 'and I mark the appointment missed' do

--- a/spec/mailers/appointment_mailer_spec.rb
+++ b/spec/mailers/appointment_mailer_spec.rb
@@ -10,6 +10,31 @@ RSpec.describe AppointmentMailer, type: :mailer do
     )
   end
 
+  describe 'Resource Manager Appointment Cancelled' do
+    subject(:mail) { described_class.resource_manager_appointment_cancelled(appointment, resource_manager) }
+
+    let(:mailgun_headers) { JSON.parse(mail['X-Mailgun-Variables'].value) }
+    let(:resource_manager) { 'supervisors@maps.org.uk' }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Pension Wise Appointment Cancelled')
+      expect(mail.to).to eq(['supervisors@maps.org.uk'])
+      expect(mail.from).to eq(['booking@pensionwise.gov.uk'])
+    end
+
+    it 'renders the mailgun specific headers' do
+      expect(mailgun_headers).to include(
+        'message_type'   => 'resource_manager_appointment_cancelled',
+        'appointment_id' => appointment.id
+      )
+    end
+
+    it 'renders the body specifics' do
+      expect(subject.body.encoded).to match(%q(http://localhost:3001/appointments/\d+/edit))
+      expect(subject.body.encoded).to include(appointment.guider.name)
+    end
+  end
+
   describe 'Resource Manager Appointment Created' do
     subject(:mail) { described_class.resource_manager_appointment_created(appointment, resource_manager) }
 

--- a/spec/mailers/appointment_mailer_spec.rb
+++ b/spec/mailers/appointment_mailer_spec.rb
@@ -10,6 +10,31 @@ RSpec.describe AppointmentMailer, type: :mailer do
     )
   end
 
+  describe 'Resource Manager Appointment Created' do
+    subject(:mail) { described_class.resource_manager_appointment_created(appointment, resource_manager) }
+
+    let(:mailgun_headers) { JSON.parse(mail['X-Mailgun-Variables'].value) }
+    let(:resource_manager) { 'supervisors@maps.org.uk' }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Pension Wise Appointment Created')
+      expect(mail.to).to eq(['supervisors@maps.org.uk'])
+      expect(mail.from).to eq(['booking@pensionwise.gov.uk'])
+    end
+
+    it 'renders the mailgun specific headers' do
+      expect(mailgun_headers).to include(
+        'message_type'   => 'resource_manager_appointment_created',
+        'appointment_id' => appointment.id
+      )
+    end
+
+    it 'renders the body specifics' do
+      expect(subject.body.encoded).to match(%q(http://localhost:3001/appointments/\d+/edit))
+      expect(subject.body.encoded).to include(appointment.guider.name)
+    end
+  end
+
   describe 'Accessibility Adjustment' do
     subject(:mail) { described_class.accessibility_adjustment(appointment, resource_manager) }
 

--- a/spec/mailers/appointment_mailer_spec.rb
+++ b/spec/mailers/appointment_mailer_spec.rb
@@ -10,6 +10,31 @@ RSpec.describe AppointmentMailer, type: :mailer do
     )
   end
 
+  describe 'Resource Manager Appointment Rescheduled' do
+    subject(:mail) { described_class.resource_manager_appointment_rescheduled(appointment, resource_manager) }
+
+    let(:mailgun_headers) { JSON.parse(mail['X-Mailgun-Variables'].value) }
+    let(:resource_manager) { 'supervisors@maps.org.uk' }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Pension Wise Appointment Rescheduled')
+      expect(mail.to).to eq(['supervisors@maps.org.uk'])
+      expect(mail.from).to eq(['booking@pensionwise.gov.uk'])
+    end
+
+    it 'renders the mailgun specific headers' do
+      expect(mailgun_headers).to include(
+        'message_type'   => 'resource_manager_appointment_rescheduled',
+        'appointment_id' => appointment.id
+      )
+    end
+
+    it 'renders the body specifics' do
+      expect(subject.body.encoded).to match(%q(http://localhost:3001/appointments/\d+/edit))
+      expect(subject.body.encoded).to include(appointment.guider.name)
+    end
+  end
+
   describe 'Resource Manager Appointment Cancelled' do
     subject(:mail) { described_class.resource_manager_appointment_cancelled(appointment, resource_manager) }
 

--- a/spec/mailers/previews/appointment_mailer_preview.rb
+++ b/spec/mailers/previews/appointment_mailer_preview.rb
@@ -1,5 +1,32 @@
 # Preview all emails at http://localhost:3000/rails/mailers/appointment_mailer
 class AppointmentMailerPreview < ActionMailer::Preview
+  def resource_manager_appointment_created
+    appointment = random_appointment
+
+    AppointmentMailer.resource_manager_appointment_created(
+      appointment,
+      appointment.resource_managers.first.email
+    )
+  end
+
+  def resource_manager_appointment_rescheduled
+    appointment = random_appointment
+
+    AppointmentMailer.resource_manager_appointment_rescheduled(
+      appointment,
+      appointment.resource_managers.first.email
+    )
+  end
+
+  def resource_manager_appointment_cancelled
+    appointment = random_appointment
+
+    AppointmentMailer.resource_manager_appointment_cancelled(
+      appointment,
+      appointment.resource_managers.first.email
+    )
+  end
+
   def accessibility_adjustment
     appointment = random_appointment
 

--- a/spec/requests/sms_cancellation_callback_spec.rb
+++ b/spec/requests/sms_cancellation_callback_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'POST /sms_cancellations', type: :request do
     and_a_cancellation_activity_is_created
     and_the_customer_is_sent_a_confirmation_sms
     and_the_guider_is_notified
+    and_the_resource_managers_are_notified
   end
 
   def given_a_pending_appointment_exists
@@ -53,6 +54,10 @@ RSpec.describe 'POST /sms_cancellations', type: :request do
 
   def and_the_guider_is_notified
     assert_enqueued_jobs(1, only: PusherAppointmentChangedJob)
+  end
+
+  def and_the_resource_managers_are_notified
+    assert_enqueued_jobs(1, only: AppointmentCancelledNotificationsJob)
   end
 
   def when_the_client_makes_an_unauthorised_request


### PR DESCRIPTION
Notify resource managers by email when an appointment has changed. Does not
apply to appointments pertaining to the TPAS organisation as they receive
realtime notifications.