### PR TITLE
Allow non-TPAS users to 'process' appointments

### DIFF
--- a/app/controllers/processes_controller.rb
+++ b/app/controllers/processes_controller.rb
@@ -1,0 +1,13 @@
+class ProcessesController < ApplicationController
+  def create
+    @appointment = Appointment
+                   .unscoped
+                   .joins(:guider)
+                   .where(users: { organisation_content_id: current_user.organisation_content_id })
+                   .find(params[:appointment_id])
+
+    @appointment.process!(current_user)
+
+    redirect_back success: 'The appointment was marked as processed.', fallback_location: root_path
+  end
+end

--- a/app/helpers/appointment_helper.rb
+++ b/app/helpers/appointment_helper.rb
@@ -1,4 +1,10 @@
 module AppointmentHelper
+  def processed_tick(appointment)
+    return unless appointment.processed_at?
+
+    content_tag(:span, '', class: 'glyphicon glyphicon-ok t-processed text-muted', title: 'Processed')
+  end
+
   def display_with_newline(value)
     safe_join([value, tag.br]) if value.present?
   end

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -1,4 +1,8 @@
 module UserHelper
+  def can_process?(current_user, appointment)
+    !current_user.tpas? && !appointment.processed_at?
+  end
+
   def organisation_options
     Provider.all.map do |organisation|
       [organisation.name, organisation.id]

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -89,6 +89,18 @@ class Appointment < ApplicationRecord
   before_create :track_initial_status
   before_update :track_status_transitions
 
+  def process!(by)
+    return if processed_at?
+
+    without_auditing do
+      transaction do
+        touch(:processed_at)
+
+        ProcessedActivity.from(user: by, appointment: self)
+      end
+    end
+  end
+
   def mark_rescheduled!
     self.batch_processed_at = nil
     self.rescheduled_at     = Time.zone.now

--- a/app/models/processed_activity.rb
+++ b/app/models/processed_activity.rb
@@ -1,0 +1,9 @@
+class ProcessedActivity < Activity
+  def self.from(user:, appointment:)
+    create!(
+      appointment: appointment,
+      user: user,
+      owner: appointment.guider
+    )
+  end
+end

--- a/app/views/activities/_processed_activity.html.erb
+++ b/app/views/activities/_processed_activity.html.erb
@@ -1,0 +1,6 @@
+<% content_for(:activity_message, flush: true) do %>
+  <span class="glyphicon glyphicon-flag" aria-hidden="true"></span>
+  <strong><%= processed_activity.user_name %></strong>
+  processed this appointment
+<% end %>
+<%= render 'activities/activity', activity: processed_activity, details: details, hide: hide %>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -35,6 +35,12 @@
     <%= rebooked_from_heading(@appointment) %>
   </div>
   <div class="col-md-5 action-buttons">
+    <% if can_process?(current_user, @appointment) %>
+      <%= link_to appointment_process_path(@appointment), method: :post, title: 'Mark as Processed', class: 'btn btn-info t-process' do %>
+        <span class="glyphicon glyphicon-flag" aria-hidden="true"></span>
+        <span>Mark as Processed</span>
+      <% end %>
+    <% end %>
     <% if @appointment.can_create_summary? %>
       <%= link_to SummaryDocumentLink.generate(@appointment), title: 'Create summary', class: 'btn btn-info', target: '_blank' do %>
         <span class="glyphicon glyphicon-print" aria-hidden="true"></span>

--- a/app/views/appointments/search.html.erb
+++ b/app/views/appointments/search.html.erb
@@ -58,7 +58,7 @@
         <td class="appointment-search-results__item"><b class="visible-xs-block">Guider</b><span class="js-allow-highlighting"><%= result.guider_name %></span> <small>(<%= result.guider_organisation %>)</small></td>
         <td class="appointment-search-results__item"><b class="visible-xs-block">Appointment Date/Time</b><%= result.date %></td>
         <td class="appointment-search-results__item"><b class="visible-xs-block">Created</b><%= result.created_at %></td>
-        <td class="appointment-search-results__item"><b class="visible-xs-block">Status</b><%= result.status %></td>
+        <td class="appointment-search-results__item"><b class="visible-xs-block">Status</b><%= result.status %> <%= processed_tick(result) %></td>
         <td class="appointment-search-results__item" nowrap="true">
           <%= link_to edit_appointment_path(result), title: 'Edit appointment', class: 'btn btn-info' do %>
             <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   resource :my_appointments, only: :show
   resource :company_calendar, only: :show
   resources :appointments, only: %i(new index show edit update create) do
+    resource :process, only: :create
     resources :changes, only: :index
 
     post :preview, on: :collection

--- a/db/migrate/20200326124042_add_processed_at_to_appointments.rb
+++ b/db/migrate/20200326124042_add_processed_at_to_appointments.rb
@@ -1,0 +1,5 @@
+class AddProcessedAtToAppointments < ActiveRecord::Migration[5.1]
+  def change
+    add_column :appointments, :processed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190910114253) do
+ActiveRecord::Schema.define(version: 20200326124042) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(version: 20190910114253) do
     t.string "gdpr_consent", default: "", null: false
     t.string "pension_provider", default: "", null: false
     t.boolean "accessibility_requirements", default: false, null: false
+    t.datetime "processed_at"
     t.index ["start_at"], name: "index_appointments_on_start_at"
   end
 

--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -41,5 +41,9 @@ FactoryBot.define do
       county { 'Some County' }
       postcode { 'E3 3NN' }
     end
+
+    trait :processed do
+      processed_at { Time.zone.now }
+    end
   end
 end

--- a/spec/features/resource_manager_processes_an_appointment_spec.rb
+++ b/spec/features/resource_manager_processes_an_appointment_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.feature 'Resource manager processes an appointment' do
+  scenario 'Processing is not visible to TPAS members' do
+    given_the_user_is_a_resource_manager do
+      and_an_appointment_exists_for(:tpas)
+      when_they_edit_the_appointment
+      then_they_do_not_see_the_process_button
+    end
+  end
+
+  scenario 'Another organisation member processes their appointment' do
+    given_the_user_is_a_resource_manager(organisation: :cas) do
+      and_an_appointment_exists_for(:cas)
+      when_they_edit_the_appointment
+      and_they_process_the_appointment
+      then_the_appointment_is_processed
+      and_the_process_button_is_hidden
+      and_an_activity_is_logged
+    end
+  end
+
+  def and_an_appointment_exists_for(organisation)
+    @appointment = create(:appointment, organisation: organisation)
+  end
+
+  def when_they_edit_the_appointment
+    @page = Pages::EditAppointment.new
+    @page.load(id: @appointment.id)
+  end
+
+  def then_they_do_not_see_the_process_button
+    expect(@page).to have_no_process
+  end
+
+  def and_they_process_the_appointment
+    @page.process.click
+  end
+
+  def then_the_appointment_is_processed
+    expect(@page).to have_flash_of_success
+  end
+
+  def and_the_process_button_is_hidden
+    expect(@page).to have_no_process
+  end
+
+  def and_an_activity_is_logged
+    expect(@page.activity_feed).to have_text('processed this appointment')
+  end
+end

--- a/spec/features/resource_manager_processes_an_appointment_spec.rb
+++ b/spec/features/resource_manager_processes_an_appointment_spec.rb
@@ -20,6 +20,33 @@ RSpec.feature 'Resource manager processes an appointment' do
     end
   end
 
+  scenario 'Viewing processed/unprocessed appointments in search results' do
+    given_the_user_is_a_resource_manager(organisation: :cas) do
+      and_an_appointment_exists_for(:cas)
+      and_a_processed_appointment_exists_for(:cas)
+      when_they_view_the_appointments
+      then_one_appointment_is_processed
+      and_the_other_is_not_processed
+    end
+  end
+
+  def and_a_processed_appointment_exists_for(organisation)
+    create(:appointment, :processed, organisation: organisation)
+  end
+
+  def when_they_view_the_appointments
+    @page = Pages::Search.new
+    @page.load
+  end
+
+  def then_one_appointment_is_processed
+    expect(@page).to have_processed(count: 1)
+  end
+
+  def and_the_other_is_not_processed
+    expect(@page).to have_results(count: 2)
+  end
+
   def and_an_appointment_exists_for(organisation)
     @appointment = create(:appointment, organisation: organisation)
   end

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -21,6 +21,7 @@ module Pages
     element :status, '.t-status'
     element :submit, '.t-save'
     element :rebook, '.t-rebook'
+    element :process, '.t-process'
 
     element :permissions_warning, '.t-permissions'
 

--- a/spec/support/pages/search.rb
+++ b/spec/support/pages/search.rb
@@ -11,5 +11,7 @@ module Pages
       element :id, '.t-id'
       element :name, '.t-name'
     end
+
+    elements :processed, '.t-processed'
   end
 end


### PR DESCRIPTION
This marks an appointment as synchronised with casebook and only applies to
non-TPAS providers.