### PR TITLE
Add a task to delete schedules, slots and holiday

### DIFF
--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -1,4 +1,16 @@
 namespace :jobs do
+  namespace :wipe do
+    desc 'wipes schedules, slots and holidays across all providers'
+    task data: :environment do
+      abort 'This task runs in DEVELOPMENT or STAGING only!' unless Rails.env.development? || Rails.env.staging?
+
+      Schedule.destroy_all
+      Holiday.where(bank_holiday: false).destroy_all
+
+      puts 'Deleted all schedules, slots and non bank holidays'
+    end
+  end
+
   namespace :bookable_slots do
     desc 'generate bookable slots for the next six weeks'
     task generate: :environment do


### PR DESCRIPTION
This helps in the staging environment to keep a clean slate and aid the
onboarding effort for guiders that are channel-switching.