### PR TITLE
Improve the redactor

### DIFF
--- a/app/lib/redactor.rb
+++ b/app/lib/redactor.rb
@@ -1,0 +1,62 @@
+class Redactor
+  def initialize(reference)
+    @reference = reference
+  end
+
+  def call
+    return unless appointment = Appointment.find(reference) # rubocop:disable AssignmentInCondition
+
+    ActiveRecord::Base.transaction do
+      Appointment.without_auditing do
+        redact_appointment(appointment)
+        redact_audits(appointment)
+        redact_activities(appointment)
+      end
+    end
+  end
+
+  def self.redact_for_gdpr
+    Appointment.for_redaction.pluck(:id).each do |reference|
+      new(reference).call
+    end
+  end
+
+  private
+
+  def redact_appointment(appointment) # rubocop:disable MethodLength
+    appointment.update(
+      first_name: 'redacted',
+      last_name: 'redacted',
+      email: 'redacted@example.com',
+      phone: '00000000000',
+      mobile: '00000000000',
+      date_of_birth: '1950-01-01',
+      memorable_word: 'redacted',
+      address_line_one: 'redacted',
+      address_line_two: 'redacted',
+      address_line_three: 'redacted',
+      town: 'redacted',
+      postcode: 'redacted',
+      notes: 'redacted'
+    )
+  end
+
+  def redact_audits(appointment)
+    appointment.audits.destroy_all
+  end
+
+  def redact_activities(appointment)
+    appointment.activities.where(
+      type: %w(
+        AuditActivity
+        ReminderActivity
+        SmsReminderActivity
+        SmsCancellationActivity
+        DropActivity
+        DroppedSummaryDocumentActivity
+      )
+    ).destroy_all
+  end
+
+  attr_reader :reference
+end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -232,6 +232,12 @@ class Appointment < ApplicationRecord
     gdpr_consent == '' ? 'No response' : gdpr_consent.titleize
   end
 
+  def self.for_redaction
+    where
+      .not(first_name: 'redacted')
+      .where('created_at < ?', 2.years.ago.beginning_of_day)
+  end
+
   def self.for_organisation(user)
     return where('1 = 1') if user.tp_agent?
 
@@ -309,7 +315,7 @@ class Appointment < ApplicationRecord
   end
 
   def format_name
-    self.first_name = first_name.titleize if first_name
+    self.first_name = first_name.titleize if first_name != 'redacted'
     self.last_name  = last_name.titleize  if last_name
   end
 

--- a/lib/tasks/confidentiality.rake
+++ b/lib/tasks/confidentiality.rake
@@ -1,38 +1,11 @@
 namespace :confidentiality do
   desc 'Redact customer details from an appointment reference REFERENCE'
   task redact: :environment do
-    appointment = Appointment.find(ENV.fetch('REFERENCE'))
+    Redactor.new(ENV.fetch('REFERENCE')).call
+  end
 
-    ActiveRecord::Base.transaction do
-      Appointment.without_auditing do
-        appointment.update(
-          first_name: 'redacted',
-          last_name: 'redacted',
-          email: 'redacted@example.com',
-          phone: '00000000000',
-          mobile: '00000000000',
-          date_of_birth: '1950-01-01',
-          memorable_word: 'redacted',
-          address_line_one: 'redacted',
-          address_line_two: 'redacted',
-          address_line_three: 'redacted',
-          town: 'redacted',
-          postcode: 'redacted',
-          notes: 'redacted'
-        )
-      end
-
-      appointment.audits.delete_all
-      appointment.activities.where(
-        type: %w(
-          AuditActivity
-          ReminderActivity
-          SmsReminderActivity
-          SmsCancellationActivity
-          DropActivity
-          DroppedSummaryDocumentActivity
-        )
-      ).delete_all
-    end
+  desc 'Redact records older than 2 years'
+  task gdpr: :environment do
+    Redactor.redact_for_gdpr
   end
 end

--- a/spec/lib/redactor_spec.rb
+++ b/spec/lib/redactor_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe Redactor do
+  describe '.redact_for_gdpr' do
+    it 'redacts records yet to be redacted, greater than 2 years old' do
+      travel_to '2018-02-28 10:00' do
+        @redacted = create(:appointment, first_name: 'redacted', created_at: Time.current)
+        @included = create(:appointment, created_at: Time.current)
+      end
+
+      travel_to '2020-01-01 10:00' do
+        @excluded = create(:appointment, created_at: Time.current)
+      end
+
+      travel_to '2020-03-31 10:00' do
+        described_class.redact_for_gdpr
+      end
+
+      # was redacted
+      expect(@included.reload.created_at).not_to eq(@included.updated_at)
+      # was already redacted so not updated
+      expect(@redacted.reload.created_at).to eq(@redacted.updated_at)
+      # was outside the date range so not updated
+      expect(@excluded.reload.created_at).to eq(@excluded.updated_at)
+    end
+  end
+
+  describe '#call' do
+    it 'redacts all personally identifying information' do
+      appointment = create(:appointment)
+      redactor    = described_class.new(appointment.id)
+
+      redactor.call
+
+      expect(appointment.reload).to have_attributes(
+        first_name: 'redacted',
+        last_name: 'redacted',
+        email: 'redacted@example.com',
+        phone: '00000000000',
+        mobile: '00000000000',
+        date_of_birth: '1950-01-01'.to_date,
+        memorable_word: 'redacted',
+        address_line_one: 'redacted',
+        address_line_two: 'redacted',
+        address_line_three: 'redacted',
+        town: 'redacted',
+        postcode: 'redacted',
+        notes: 'redacted'
+      )
+
+      expect(appointment.audits).to be_empty
+      # all activities except `AssignmentActivity` will be redacted
+      expect(appointment.activities.map(&:class).map(&:name)).to eq(%w(AssignmentActivity CreateActivity))
+    end
+  end
+end


### PR DESCRIPTION
Can redact a single appointment instance by `REFERENCE` or can now
redact all records older than 2 years for GDPR purposes.