### PR TITLE
Ensure allocation does not error

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -145,6 +145,8 @@ class Appointment < ApplicationRecord
     if via_slot
       allocate_slot(agent)
     else
+      return unless start_at?
+
       self.end_at = start_at + APPOINTMENT_LENGTH_MINUTES
     end
   end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -403,6 +403,14 @@ RSpec.describe Appointment, type: :model do
       BusinessDays.from_now(5).change(hour: 10, min: 30, second: 0)
     end
 
+    context 'adhoc' do
+      it 'does not error when no `start_at` was specified' do
+        appointment = build(:appointment, start_at: nil, end_at: nil)
+
+        expect { appointment.allocate(via_slot: false) }.not_to raise_error
+      end
+    end
+
     context 'when booking as a TPAS agent' do
       it 'excludes TP guiders' do
         tpas_resource_manager = create(:resource_manager, :tpas)


### PR DESCRIPTION
This was previously erroring when the resource manager did not provide
an adhoc start date/time.