### PR TITLE
Add a filter for `processed` appointments

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -133,7 +133,7 @@ class AppointmentsController < ApplicationController
   def search_params
     params
       .fetch(:search, {})
-      .permit(:q, :date_range)
+      .permit(:q, :date_range, :processed)
       .merge(current_user: current_user)
   end
 

--- a/app/forms/search.rb
+++ b/app/forms/search.rb
@@ -5,8 +5,9 @@ class Search
   attr_accessor :q
   attr_accessor :date_range
   attr_accessor :current_user
+  attr_writer :processed
 
-  def results
+  def results # rubocop:disable MethodLength
     range = date_range
             .to_s
             .split(' - ')
@@ -16,7 +17,14 @@ class Search
       q,
       range.first.try(:beginning_of_day),
       range.last.try(:end_of_day),
-      current_user
+      current_user,
+      processed
     ).search
+  end
+
+  def processed
+    return '' if current_user.tpas?
+
+    @processed || 'no'
   end
 end

--- a/app/models/appointment_search.rb
+++ b/app/models/appointment_search.rb
@@ -1,14 +1,16 @@
 class AppointmentSearch
-  def initialize(query, start_at, end_at, current_user)
+  def initialize(query, start_at, end_at, current_user, processed)
     @query = query
     @start_at = start_at
     @end_at = end_at
     @current_user = current_user
+    @processed = processed
   end
 
   def search
     results = @query.present? ? search_with_query : search_without_query
     results = within_date_range(results)
+    results = processed_for_current_user(results)
 
     for_current_user(results)
   end
@@ -16,6 +18,16 @@ class AppointmentSearch
   private
 
   attr_reader :current_user
+
+  def processed_for_current_user(results)
+    return results if current_user.tpas? || @processed.blank?
+
+    if @processed == 'yes'
+      results.where.not(processed_at: nil)
+    else
+      results.where(processed_at: nil)
+    end
+  end
 
   def for_current_user(results)
     return results if current_user.tp_agent?

--- a/app/views/appointments/search.html.erb
+++ b/app/views/appointments/search.html.erb
@@ -31,6 +31,13 @@
       )
     %>
   </div>
+  <% unless current_user.tpas? %>
+  <div class="form-group">
+    <label>Processed</label>
+    <label><%= f.radio_button :processed, 'no', class: 't-processed-no' %> No</label>
+    <label><%= f.radio_button :processed, 'yes', class: 't-processed-yes' %> Yes</label>
+  </div>
+  <% end %>
   <div class="form-group">
     <%= f.submit 'Search', class: 't-search btn btn-primary' %>
   </div>

--- a/spec/features/agent_searches_for_appointments_spec.rb
+++ b/spec/features/agent_searches_for_appointments_spec.rb
@@ -1,6 +1,20 @@
 require 'rails_helper'
 
 RSpec.feature 'Agent searches for appointments' do
+  scenario 'TPAS users do not see `processed` filters' do
+    given_the_user_is_an_agent(organisation: :tpas) do
+      when_they_view_the_search
+      then_they_do_not_see_the_processed_filters
+    end
+  end
+
+  scenario 'Other users see `processed` filters' do
+    given_the_user_is_an_agent(organisation: :cas) do
+      when_they_view_the_search
+      then_they_see_the_processed_filters
+    end
+  end
+
   scenario 'Searching as a TP agent' do
     given_appointments_exist_across_multiple_organisations
     given_the_user_is_an_agent(organisation: :tp) do
@@ -56,6 +70,20 @@ RSpec.feature 'Agent searches for appointments' do
       when_they_search_for_a_name
       then_they_can_see_those_filtered_appointments_only
     end
+  end
+
+  def when_they_view_the_search
+    @page = Pages::Search.new.tap(&:load)
+  end
+
+  def then_they_do_not_see_the_processed_filters
+    expect(@page).to have_no_processed_no
+    expect(@page).to have_no_processed_yes
+  end
+
+  def then_they_see_the_processed_filters
+    expect(@page).to have_processed_no
+    expect(@page).to have_processed_yes
   end
 
   def given_appointments_exist_across_multiple_organisations

--- a/spec/features/resource_manager_processes_an_appointment_spec.rb
+++ b/spec/features/resource_manager_processes_an_appointment_spec.rb
@@ -22,12 +22,21 @@ RSpec.feature 'Resource manager processes an appointment' do
 
   scenario 'Viewing processed/unprocessed appointments in search results' do
     given_the_user_is_a_resource_manager(organisation: :cas) do
-      and_an_appointment_exists_for(:cas)
-      and_a_processed_appointment_exists_for(:cas)
+      and_appointments_exist_for(:cas)
+      and_processed_appointments_exist_for(:cas)
       when_they_view_the_appointments
-      then_one_appointment_is_processed
-      and_the_other_is_not_processed
+      then_two_appointments_are_unprocessed
+      when_they_set_the_processed_filter
+      then_two_appointments_are_processed
     end
+  end
+
+  def and_appointments_exist_for(organisation)
+    create_list(:appointment, 2, organisation: organisation)
+  end
+
+  def and_processed_appointments_exist_for(organisation)
+    create_list(:appointment, 2, :processed, organisation: organisation)
   end
 
   def and_a_processed_appointment_exists_for(organisation)
@@ -39,8 +48,19 @@ RSpec.feature 'Resource manager processes an appointment' do
     @page.load
   end
 
-  def then_one_appointment_is_processed
-    expect(@page).to have_processed(count: 1)
+  def then_two_appointments_are_processed
+    expect(@page).to have_results(count: 2)
+    expect(@page).to have_processed(count: 2)
+  end
+
+  def then_two_appointments_are_unprocessed
+    expect(@page).to have_results(count: 2)
+    expect(@page).to have_no_processed
+  end
+
+  def when_they_set_the_processed_filter
+    @page.processed_yes.set(true)
+    @page.search.click
   end
 
   def and_the_other_is_not_processed

--- a/spec/models/appointment_search_spec.rb
+++ b/spec/models/appointment_search_spec.rb
@@ -8,12 +8,23 @@ RSpec.describe AppointmentSearch, type: :model do
       @appointments = [
         create(:appointment, first_name: 'Stefan', last_name: 'Löfven', created_at: from + 2.seconds),
         create(:appointment, first_name: 'Angela', last_name: 'Merkel', created_at: from + 1.second),
-        create(:appointment, first_name: 'Adrian', last_name: 'Hasler', created_at: from)
+        create(:appointment, first_name: 'Adrian', last_name: 'Hasler', created_at: from, processed_at: Time.current)
       ]
     end
 
-    def results(q, start_at, end_at, current_user = create(:agent))
-      described_class.new(q, start_at, end_at, current_user).search
+    def results(q, start_at, end_at, current_user = create(:agent), processed = '')
+      described_class.new(q, start_at, end_at, current_user, processed).search
+    end
+
+    context 'for a non-tpas user' do
+      it 'respects the `processed` flag' do
+        processed   = create(:appointment, organisation: :cas, processed_at: Time.current)
+        unprocessed = create(:appointment, organisation: :cas)
+        cas_agent   = create(:agent, :cas)
+
+        expect(results(nil, nil, nil, cas_agent, 'yes')).to eq([processed])
+        expect(results(nil, nil, nil, cas_agent, 'no')).to eq([unprocessed])
+      end
     end
 
     it 'returns all results' do

--- a/spec/support/pages/search.rb
+++ b/spec/support/pages/search.rb
@@ -4,6 +4,8 @@ module Pages
 
     element :q,          '.t-q'
     element :date_range, '.t-date-range'
+    element :processed_no, '.t-processed-no'
+    element :processed_yes, '.t-processed-yes'
     element :search,     '.t-search'
     element :rebook,     '.t-rebook'
 


### PR DESCRIPTION
Defaults to all appointments for TPAS and shows filters for other
organisations. Defaults to 'no' for the organisations it applies to.