### PR TITLE
Temporarily exclude CAS slots from API respinse

### DIFF
--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -53,12 +53,13 @@ class BookableSlot < ApplicationRecord
       .without_holidays
   end
 
-  def self.grouped(organisation_id = nil) # rubocop:disable Metrics/AbcSize
+  def self.grouped(organisation_id = nil) # rubocop:disable Metrics/AbcSize, MethodLength
     from = next_valid_start_date
     to   = BusinessDays.from_now(40).end_of_day
 
     scope = bookable(from, to).within_date_range(from, to, organisation_limit: true)
     scope = scope.joins(:guider).where(users: { organisation_content_id: organisation_id }) if organisation_id
+    scope = scope.joins(:guider).where.not(users: { organisation_content_id: Provider::CAS.id })
 
     scope
       .select("#{quoted_table_name}.start_at::date as start_date")

--- a/spec/features/scheduled_reporting_summary_spec.rb
+++ b/spec/features/scheduled_reporting_summary_spec.rb
@@ -25,8 +25,8 @@ RSpec.feature 'Scheduled reporting summary' do
 
   def then_the_availability_is_summarised_correctly
     expect(ReportingSummary.find_by(organisation: 'CAS')).to have_attributes(
-      four_week_availability: true,
-      first_available_slot_on: '2018-04-28'.to_date
+      four_week_availability: false,
+      first_available_slot_on: nil
     )
 
     expect(ReportingSummary.find_by(organisation: 'Lancs West')).to have_attributes(

--- a/spec/requests/bookable_slots_api_spec.rb
+++ b/spec/requests/bookable_slots_api_spec.rb
@@ -26,6 +26,9 @@ RSpec.describe 'GET /api/v1/bookable_slots' do
     # included since the window is now 8 weeks
     create(:bookable_slot, start_at: 7.weeks.from_now)
 
+    # excluded temporarily as it's from CAS
+    create(:bookable_slot, :cas, start_at: 8.weeks.from_now)
+
     # falls after the booking window
     create(:bookable_slot, start_at: 9.weeks.from_now)
   end


### PR DESCRIPTION
This will ensure CAS can add slots that won't be immediately filled by
customer demand.