### PR TITLE
Add a temporary task to reallocate appointments

### DIFF
--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -41,6 +41,16 @@ class BookableSlot < ApplicationRecord
     BusinessDays.from_now(1).change(hour: 18, min: 30)
   end
 
+  def self.find_from_available_provider(appointment)
+    scope = bookable.where(start_at: appointment.start_at)
+    scope = scope
+            .joins(:guider)
+            .where
+            .not(users: { organisation_content_id: appointment.guider.organisation_content_id })
+
+    scope.order('RANDOM()').first
+  end
+
   def self.find_available_slot(start_at, agent)
     scope = bookable.where(start_at: start_at)
     scope = scope.for_organisation(agent) if agent

--- a/lib/tasks/reassign.rake
+++ b/lib/tasks/reassign.rake
@@ -1,0 +1,40 @@
+namespace :reassign do
+  desc 'Attempt to reallocate appointments (REFERENCES=X,X,X) to (PROVIDER=X)'
+  task appointments: :environment do
+    provider_agent = User.find_by(organisation_content_id: ENV.fetch('PROVIDER'))
+
+    appointment_ids = ENV.fetch('REFERENCES').split(',')
+
+    appointment_ids.each do |id|
+      if source = Appointment.find(id) # rubocop:disable AssignmentInCondition
+        destination = BookableSlot.find_available_slot(source.start_at, provider_agent)
+
+        if destination
+          ActiveRecord::Base.transaction do
+            # block the underlying slot
+            Holiday.create!(
+              title: 'Reallocation block',
+              user: source.guider,
+              start_at: source.start_at,
+              end_at: source.end_at,
+              bank_holiday: false
+            )
+
+            # reallocate the appointment to the new guider
+            source.guider = destination.guider
+            source.save(validate: false)
+
+            # create activities and notify both guiders
+            Notifier.new(source).call
+
+            puts "Reallocated: #{id} to: #{source.guider.name}"
+          end
+        else
+          puts "Could not find an available slot matching #{id}"
+        end
+      else
+        puts "Appointment with reference #{id} was not found"
+      end
+    end
+  end
+end

--- a/lib/tasks/reassign.rake
+++ b/lib/tasks/reassign.rake
@@ -16,6 +16,24 @@ namespace :reassign do
     end
   end
 
+  desc 'Attempt to reallocate appointments to random available slots from other providers'
+  task random: :environment do
+    appointment_ids = ENV.fetch('REFERENCES').split(',')
+
+    appointment_ids.each do |id|
+      if source = Appointment.find(id)
+
+        if destination = BookableSlot.find_from_available_provider(source)
+          reassign_appointment(source, destination.guider)
+        else
+          puts "Could not find any slot matching #{id}"
+        end
+      else
+        puts "Appointment with reference #{id} was not found"
+      end
+    end
+  end
+
   desc 'Attempt to reallocate appointments (REFERENCES=X,X,X) to (PROVIDER=X)'
   task appointments: :environment do
     provider_agent = User.find_by(organisation_content_id: ENV.fetch('PROVIDER'))

--- a/lib/tasks/reassign.rake
+++ b/lib/tasks/reassign.rake
@@ -1,18 +1,20 @@
 # rubocop:disable AssignmentInCondition
 namespace :reassign do
-  desc 'Reallocate appointment REFERENCE=x to GUIDER=x'
+  desc 'Reallocate appointments REFERENCES=x to GUIDER=x'
   task appointment: :environment do
-    reference = ENV.fetch('REFERENCE')
-    guider_id = ENV.fetch('GUIDER')
+    references = ENV.fetch('REFERENCES').split(',')
+    guider_id  = ENV.fetch('GUIDER')
 
-    if source = Appointment.find(reference)
-      if guider = User.find(guider_id)
-        reassign_appointment(source, guider)
+    references.each do |reference|
+      if source = Appointment.find(reference)
+        if guider = User.find(guider_id)
+          reassign_appointment(source, guider)
+        else
+          puts "Could not find guider ID: #{guider_id}"
+        end
       else
-        puts "Could not find guider ID: #{guider_id}"
+        puts "Could not find appointment reference: #{reference}"
       end
-    else
-      puts "Could not find appointment reference: #{reference}"
     end
   end
 

--- a/lib/tasks/reassign.rake
+++ b/lib/tasks/reassign.rake
@@ -1,4 +1,21 @@
+# rubocop:disable AssignmentInCondition
 namespace :reassign do
+  desc 'Reallocate appointment REFERENCE=x to GUIDER=x'
+  task appointment: :environment do
+    reference = ENV.fetch('REFERENCE')
+    guider_id = ENV.fetch('GUIDER')
+
+    if source = Appointment.find(reference)
+      if guider = User.find(guider_id)
+        reassign_appointment(source, guider)
+      else
+        puts "Could not find guider ID: #{guider_id}"
+      end
+    else
+      puts "Could not find appointment reference: #{reference}"
+    end
+  end
+
   desc 'Attempt to reallocate appointments (REFERENCES=X,X,X) to (PROVIDER=X)'
   task appointments: :environment do
     provider_agent = User.find_by(organisation_content_id: ENV.fetch('PROVIDER'))
@@ -6,35 +23,39 @@ namespace :reassign do
     appointment_ids = ENV.fetch('REFERENCES').split(',')
 
     appointment_ids.each do |id|
-      if source = Appointment.find(id) # rubocop:disable AssignmentInCondition
+      if source = Appointment.find(id)
         destination = BookableSlot.find_available_slot(source.start_at, provider_agent)
 
         if destination
-          ActiveRecord::Base.transaction do
-            # block the underlying slot
-            Holiday.create!(
-              title: 'Reallocation block',
-              user: source.guider,
-              start_at: source.start_at,
-              end_at: source.end_at,
-              bank_holiday: false
-            )
-
-            # reallocate the appointment to the new guider
-            source.guider = destination.guider
-            source.save(validate: false)
-
-            # create activities and notify both guiders
-            Notifier.new(source).call
-
-            puts "Reallocated: #{id} to: #{source.guider.name}"
-          end
+          reassign_appointment(source, destination.guider)
         else
           puts "Could not find an available slot matching #{id}"
         end
       else
         puts "Appointment with reference #{id} was not found"
       end
+    end
+  end
+
+  def reassign_appointment(source, guider) # rubocop:disable MethodLength
+    ActiveRecord::Base.transaction do
+      # block the underlying slot
+      Holiday.create!(
+        title: 'Reallocation block',
+        user: source.guider,
+        start_at: source.start_at,
+        end_at: source.end_at,
+        bank_holiday: false
+      )
+
+      # reallocate the appointment to the new guider
+      source.guider = guider
+      source.save(validate: false)
+
+      # create activities and notify both guiders
+      Notifier.new(source).call
+
+      puts "Reallocated: #{source.id} to: #{guider.name}"
     end
   end
 end


### PR DESCRIPTION
This is a rough spike at a task we can use to urgently move allocated
appointments across providers.