### PR TITLE
Accommodate timezones for grace period

### DIFF
--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -17,7 +17,7 @@ class BookableSlot < ApplicationRecord
   end
 
   def self.limit_by_organisation(from, to) # rubocop:disable MethodLength
-    tpas_start_at = BusinessDays.from_now(4).change(hour: 18, min: 30)
+    tpas_start_at = BusinessDays.from_now(4).change(hour: 18, min: 30).in_time_zone('London')
 
     joins(:guider)
       .where(
@@ -38,7 +38,7 @@ class BookableSlot < ApplicationRecord
   def self.next_valid_start_date(user = nil)
     return Time.zone.now.advance(hours: 1) if user && user.resource_manager?
 
-    BusinessDays.from_now(1).change(hour: 18, min: 30)
+    BusinessDays.from_now(1).change(hour: 18, min: 30).in_time_zone('London')
   end
 
   def self.find_available_slot(start_at, agent)

--- a/spec/models/bookable_slot_spec.rb
+++ b/spec/models/bookable_slot_spec.rb
@@ -55,6 +55,18 @@ RSpec.describe BookableSlot, type: :model do
           end
         end
       end
+
+      it 'respects timezones eg DST/BST' do
+        # DST
+        travel_to '2020-01-01 13:00' do
+          expect(BookableSlot.next_valid_start_date(user)).to eq('2020-01-02 18:30 UTC'.to_time.in_time_zone('London'))
+        end
+
+        # BST
+        travel_to '2020-04-14 13:00' do
+          expect(BookableSlot.next_valid_start_date(user)).to eq('2020-04-15 18:30 UTC'.to_time.in_time_zone('London'))
+        end
+      end
     end
 
     context 'user is a resource manager' do


### PR DESCRIPTION
Previously this was allowing appointments to be created on the same,
given business day, as the timezone offset was not being applied.