### PR TITLE
Remove 12 factor gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,5 @@ source 'https://rubygems.org' do
 
   group :staging, :production do
     gem 'lograge'
-    gem 'rails_12factor'
   end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,11 +329,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (6.0.2.2)
       actionpack (= 6.0.2.2)
       activesupport (= 6.0.2.2)
@@ -517,7 +512,6 @@ DEPENDENCIES
   rails-assets-pusher!
   rails-assets-qTip2!
   rails-assets-zloirock--core-js (= 2.5.1)!
-  rails_12factor!
   rspec-rails!
   rspec-retry!
   rubocop (= 0.46.0)!


### PR DESCRIPTION
This hasn't been needed since Rails 5 and now causes deprecation
messages in Rails 6.