### PR TITLE
Display a banner for DC pension unsure customers

### DIFF
--- a/app/helpers/appointment_helper.rb
+++ b/app/helpers/appointment_helper.rb
@@ -1,4 +1,11 @@
 module AppointmentHelper
+  def display_dc_pot_unsure_banner?(appointment)
+    return if appointment.dc_pot_confirmed?
+    return if appointment.tp_guider? || appointment.tpas_guider?
+
+    true
+  end
+
   def processed_tick(appointment)
     return unless appointment.processed_at?
 

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -208,6 +208,10 @@ class Appointment < ApplicationRecord
     guider&.ni?
   end
 
+  def tp_guider?
+    guider&.tp?
+  end
+
   def agent_is_pension_wise_api?
     agent && agent.pension_wise_api?
   end

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -4,6 +4,12 @@
   { title: "Edit appointment for #{@appointment.name}" }
 ) %>
 
+<% if display_dc_pot_unsure_banner?(@appointment) %>
+  <div class="alert alert-warning t-dc-pot-unsure" role="alert">
+    <p>The customer was <strong>unsure</strong> if they had a DC pension</p>
+  </div>
+<% end %>
+
 <% if @appointment.imported? %>
   <div class="alert alert-warning t-appointment-was-imported-message" role="alert">
     <p>

--- a/spec/features/guider_edits_an_appointment_spec.rb
+++ b/spec/features/guider_edits_an_appointment_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Guider edits an appointment' do
   scenario 'Successfully editing an appointment' do
-    given_the_user_is_a_guider do
+    given_the_user_is_a_guider(organisation: :cas) do
       and_they_have_an_appointment
       when_they_attempt_to_edit_the_appointment
       then_they_see_the_existing_details
@@ -14,7 +14,7 @@ RSpec.feature 'Guider edits an appointment' do
   end
 
   def and_they_have_an_appointment
-    @appointment = create(:appointment, guider: current_user)
+    @appointment = create(:appointment, guider: current_user, dc_pot_confirmed: false)
   end
 
   def when_they_attempt_to_edit_the_appointment
@@ -39,6 +39,8 @@ RSpec.feature 'Guider edits an appointment' do
     expect(@page.notes.value).to eq(@appointment.notes)
     expect(@page.gdpr_consent_yes).to be_checked
     expect(@page.status.value).to eq(@appointment.status)
+
+    expect(@page).to have_dc_pot_unsure_banner
   end
 
   def when_they_modify_the_appointment

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -3,6 +3,7 @@ module Pages
     set_url '/appointments/{id}/edit'
 
     element :flash_of_success,                      '.alert-success'
+    element :dc_pot_unsure_banner,                  '.t-dc-pot-unsure'
     element :appointment_was_imported_message,      '.t-appointment-was-imported-message'
     element :guider,                                '.t-guider'
     element :date_time,                             '.t-appointment-date-time'


### PR DESCRIPTION
When the customer is unsure they have a DC pension we display a banner
to alert anyone viewing the appointment.