### PR TITLE
Extend close-of-play to 9pm

### DIFF
--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -17,7 +17,7 @@ class BookableSlot < ApplicationRecord
   def self.next_valid_start_date(user = nil)
     return Time.zone.now.advance(hours: 1) if user && user.resource_manager?
 
-    BusinessDays.from_now(1).change(hour: 18, min: 30).in_time_zone('London')
+    BusinessDays.from_now(1).change(hour: 21, min: 0).in_time_zone('London')
   end
 
   def self.find_available_slot(start_at, agent)

--- a/spec/models/bookable_slot_spec.rb
+++ b/spec/models/bookable_slot_spec.rb
@@ -59,12 +59,12 @@ RSpec.describe BookableSlot, type: :model do
       it 'respects timezones eg DST/BST' do
         # DST
         travel_to '2020-01-01 13:00' do
-          expect(BookableSlot.next_valid_start_date(user)).to eq('2020-01-02 18:30 UTC'.to_time.in_time_zone('London'))
+          expect(BookableSlot.next_valid_start_date(user)).to eq('2020-01-02 21:00 UTC'.to_time.in_time_zone('London'))
         end
 
         # BST
         travel_to '2020-04-14 13:00' do
-          expect(BookableSlot.next_valid_start_date(user)).to eq('2020-04-15 18:30 UTC'.to_time.in_time_zone('London'))
+          expect(BookableSlot.next_valid_start_date(user)).to eq('2020-04-15 21:00 UTC'.to_time.in_time_zone('London'))
         end
       end
     end


### PR DESCRIPTION
Effectively set the CoP to 9pm. This was 6:30pm previously and would
cause confusion among some delivery providers.