### PR TITLE
Return a single result regardless if processed

### DIFF
--- a/app/models/appointment_search.rb
+++ b/app/models/appointment_search.rb
@@ -10,9 +10,11 @@ class AppointmentSearch
   def search
     results = @query.present? ? search_with_query : search_without_query
     results = within_date_range(results)
-    results = processed_for_current_user(results)
+    results = for_current_user(results)
 
-    for_current_user(results)
+    return results if results.count == 1
+
+    processed_for_current_user(results)
   end
 
   private

--- a/spec/models/appointment_search_spec.rb
+++ b/spec/models/appointment_search_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe AppointmentSearch, type: :model do
 
         expect(results(nil, nil, nil, cas_agent, 'yes')).to eq([processed])
         expect(results(nil, nil, nil, cas_agent, 'no')).to eq([unprocessed])
+
+        # always return the only result by ID whether processed
+        expect(results(processed.to_param, nil, nil, cas_agent, 'no')).to eq([processed])
+        expect(results(processed.to_param, nil, nil, cas_agent, 'yes')).to eq([processed])
       end
     end
 


### PR DESCRIPTION
Directs to a single result regardless whether the appointment was
processed.