### PR TITLE
Removing this holiday to shift CAS slots

### DIFF
--- a/config/initializers/working_hours.rb
+++ b/config/initializers/working_hours.rb
@@ -1,5 +1,4 @@
 WorkingHours::Config.holidays = %w(
   10/04/2020
-  08/05/2020
   25/05/2020
 ).map(&:to_date)


### PR DESCRIPTION
CAS have a handful of slots free on Saturday that would otherwise have
been skipped by the grace period.