### PR TITLE
Log a 'drop activity' for invalid emails

### DIFF
--- a/app/jobs/customer_update_job.rb
+++ b/app/jobs/customer_update_job.rb
@@ -7,6 +7,8 @@ class CustomerUpdateJob < ActiveJob::Base
     send_email(appointment, message)
 
     CustomerUpdateActivity.from(appointment, message)
+  rescue Net::SMTPSyntaxError
+    DropActivity.from_invalid_email(appointment)
   end
 
   private

--- a/app/models/drop_activity.rb
+++ b/app/models/drop_activity.rb
@@ -9,6 +9,10 @@ class DropActivity < Activity
     end
   end
 
+  def self.from_invalid_email(appointment)
+    from('undeliverable', 'The email is invalid', 'booking_created', appointment)
+  end
+
   def self.owner(appointment, message_type)
     return appointment.agent if message_type == 'booking_created'
   end

--- a/spec/jobs/customer_update_job_spec.rb
+++ b/spec/jobs/customer_update_job_spec.rb
@@ -11,4 +11,16 @@ RSpec.describe CustomerUpdateJob, '#perform' do
     assert_no_enqueued_jobs
     expect(CustomerUpdateActivity.count).to be_zero
   end
+
+  context 'when the email is janky' do
+    it 'logs an activity' do
+      appointment = create(:appointment)
+
+      allow(AppointmentMailer).to receive(:updated).and_raise(Net::SMTPSyntaxError)
+
+      described_class.new.perform(appointment, CustomerUpdateActivity::UPDATED_MESSAGE)
+
+      expect(appointment.activities.first).to be_a(DropActivity)
+    end
+  end
 end


### PR DESCRIPTION
When the email attempted causes an SMTP error we ought to log an
activity so the agent or other owner gets an opportunity to correct the
underlying issue.