### PR TITLE
Smarter signposting

### DIFF
--- a/app/controllers/api/v1/appointments_controller.rb
+++ b/app/controllers/api/v1/appointments_controller.rb
@@ -34,7 +34,8 @@ module Api
           :where_you_heard,
           :gdpr_consent,
           :accessibility_requirements,
-          :notes
+          :notes,
+          :smarter_signposted
         ).merge(agent: current_user)
       end
     end

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -165,7 +165,8 @@ class AppointmentsController < ApplicationController
       :town,
       :county,
       :postcode,
-      :gdpr_consent
+      :gdpr_consent,
+      :smarter_signposted
     ]
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/forms/api/v1/appointment.rb
+++ b/app/forms/api/v1/appointment.rb
@@ -16,7 +16,7 @@ module Api
       attr_accessor :accessibility_requirements
       attr_accessor :notes
       attr_accessor :agent
-      attr_writer   :smarter_signposted
+      attr_accessor :smarter_signposted
 
       attr_reader :model
 
@@ -32,10 +32,6 @@ module Api
       end
 
       delegate :errors, :accessibility_requirements?, to: :model
-
-      def smarter_signposted
-        @smarter_signposted || false
-      end
 
       private
 

--- a/app/forms/api/v1/appointment.rb
+++ b/app/forms/api/v1/appointment.rb
@@ -16,6 +16,7 @@ module Api
       attr_accessor :accessibility_requirements
       attr_accessor :notes
       attr_accessor :agent
+      attr_writer   :smarter_signposted
 
       attr_reader :model
 
@@ -31,6 +32,10 @@ module Api
       end
 
       delegate :errors, :accessibility_requirements?, to: :model
+
+      def smarter_signposted
+        @smarter_signposted || false
+      end
 
       private
 
@@ -49,7 +54,8 @@ module Api
           accessibility_requirements: accessibility_requirements,
           notes: notes,
           pension_provider: 'n/a',
-          agent: agent
+          agent: agent,
+          smarter_signposted: smarter_signposted
         }
       end
     end

--- a/app/views/appointments/_personal_details_form.html.erb
+++ b/app/views/appointments/_personal_details_form.html.erb
@@ -55,6 +55,10 @@
     <%= f.text_field :postcode, autocomplete: 'off', class: 't-postcode' %>
 
     <h2 class="h3">Additional information and marketing</h2>
+    <% if current_user.tpas? || current_user.administrator? %>
+      <%= f.check_box :smarter_signposted, class: 't-smarter-signposted', label: 'Smarter signposting referral?' %>
+    <% end %>
+
     <%= f.check_box :accessibility_requirements, class: 't-accessibility-requirements', label: 'Do you require an adjustment to access our service?' %>
     <%= f.text_area :notes, autocomplete: 'off', class: 't-notes', rows: 6, placeholder: 'Is the customer hard of hearing? Is English their first language? etc.' %>
     <div class="form-group">
@@ -63,10 +67,6 @@
             {}, { class: 't-where-you-heard form-control' }
       %>
     </div>
-
-    <% if current_user.tpas? || current_user.administrator? %>
-      <%= f.check_box :smarter_signposted, class: 't-smarter-signposted', label: 'Smarter signposting referral?' %>
-    <% end %>
 
     <%=
       f.select(

--- a/app/views/appointments/_personal_details_form.html.erb
+++ b/app/views/appointments/_personal_details_form.html.erb
@@ -64,6 +64,10 @@
       %>
     </div>
 
+    <% if current_user.tpas? || current_user.administrator? %>
+      <%= f.check_box :smarter_signposted, class: 't-smarter-signposted', label: 'Smarter signposting referral?' %>
+    <% end %>
+
     <%=
       f.select(
         :status,

--- a/app/views/appointments/preview.html.erb
+++ b/app/views/appointments/preview.html.erb
@@ -38,6 +38,7 @@
   <%= f.hidden_field :town %>
   <%= f.hidden_field :county %>
   <%= f.hidden_field :postcode %>
+  <%= f.hidden_field :smarter_signposted %>
 
   <div class="t-preview appointment-preview">
     <div class="row">
@@ -110,6 +111,12 @@
               <td class="active"><b>Type of appointment</b></td>
               <td><%= @appointment.type_of_appointment.humanize %></td>
             </tr>
+            <% if current_user.tpas? || current_user.administrator? %>
+            <tr>
+              <td class="active"><b>Smarter signposted referral?</b></td>
+              <td><%= @appointment.smarter_signposted? ? 'Yes' : 'No' %></td>
+            </tr>
+            <% end %>
           </tbody>
         </table>
 

--- a/db/migrate/20200716092614_add_smarter_signposted_to_appointments.rb
+++ b/db/migrate/20200716092614_add_smarter_signposted_to_appointments.rb
@@ -1,0 +1,5 @@
+class AddSmarterSignpostedToAppointments < ActiveRecord::Migration[6.0]
+  def change
+    add_column :appointments, :smarter_signposted, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20200716092614_add_smarter_signposted_to_appointments.rb
+++ b/db/migrate/20200716092614_add_smarter_signposted_to_appointments.rb
@@ -1,5 +1,5 @@
 class AddSmarterSignpostedToAppointments < ActiveRecord::Migration[6.0]
   def change
-    add_column :appointments, :smarter_signposted, :boolean, default: false, null: false
+    add_column :appointments, :smarter_signposted, :boolean, default: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -63,7 +63,7 @@ ActiveRecord::Schema.define(version: 2020_07_16_092614) do
     t.string "pension_provider", default: "", null: false
     t.boolean "accessibility_requirements", default: false, null: false
     t.datetime "processed_at"
-    t.boolean "smarter_signposted", default: false, null: false
+    t.boolean "smarter_signposted", default: false
     t.index ["start_at"], name: "index_appointments_on_start_at"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,19 +2,19 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200326124042) do
+ActiveRecord::Schema.define(version: 2020_07_16_092614) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
   enable_extension "pg_trgm"
+  enable_extension "plpgsql"
 
   create_table "activities", id: :serial, force: :cascade do |t|
     t.integer "appointment_id", null: false
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(version: 20200326124042) do
     t.string "pension_provider", default: "", null: false
     t.boolean "accessibility_requirements", default: false, null: false
     t.datetime "processed_at"
+    t.boolean "smarter_signposted", default: false, null: false
     t.index ["start_at"], name: "index_appointments_on_start_at"
   end
 

--- a/spec/requests/appointments_api_spec.rb
+++ b/spec/requests/appointments_api_spec.rb
@@ -3,6 +3,17 @@ require 'rails_helper'
 RSpec.describe 'POST /api/v1/appointments' do
   include ActiveJob::TestHelper
 
+  scenario 'creating a smarter-signposted appointment' do
+    travel_to '2017-01-10 12:00' do
+      given_the_user_is_a_pension_wise_api_user do
+        and_a_bookable_slot_exists_for_the_given_appointment_date
+        when_the_client_posts_a_smarter_signposted_appointment_request
+        then_the_service_responds_with_a_201
+        and_the_appointment_is_created_as_a_smarter_signposted_appointment
+      end
+    end
+  end
+
   scenario 'create a valid appointment' do
     travel_to '2017-01-10 12:00' do
       given_the_user_is_a_pension_wise_api_user do
@@ -83,6 +94,30 @@ RSpec.describe 'POST /api/v1/appointments' do
     }
 
     post api_v1_appointments_path, params: @payload, as: :json
+  end
+
+  def when_the_client_posts_a_smarter_signposted_appointment_request
+    @payload = {
+      'start_at'         => '2017-01-13T12:10:00.000Z',
+      'first_name'       => 'Rick',
+      'last_name'        => 'Sanchez',
+      'email'            => 'rick@example.com',
+      'phone'            => '02082524729',
+      'memorable_word'   => 'snootboop',
+      'date_of_birth'    => '1950-02-02',
+      'dc_pot_confirmed' => true,
+      'where_you_heard'  => '1',
+      'gdpr_consent'     => nil,
+      'accessibility_requirements' => true,
+      'notes' => 'I am hard of hearing',
+      'smarter_signposted' => true
+    }
+
+    post api_v1_appointments_path, params: @payload, as: :json
+  end
+
+  def and_the_appointment_is_created_as_a_smarter_signposted_appointment
+    expect(Appointment.last).to be_smarter_signposted
   end
 
   def then_the_service_responds_with_a_201

--- a/spec/support/pages/new_appointment.rb
+++ b/spec/support/pages/new_appointment.rb
@@ -28,6 +28,7 @@ module Pages
     element :address_line_one, '.t-address-line-one'
     element :town, '.t-town'
     element :postcode, '.t-postcode'
+    element :smarter_signposted, '.t-smarter-signposted'
 
     element :availability_calendar_off, '.t-availability-calendar-off'
     element :availability_calendar_on, '.t-availability-calendar-on'


### PR DESCRIPTION
This allows API clients, TPAS users or Pension Wise administrators to specify
when the given appointment was a 'smarter signposted' referral.