### PR TITLE
Check slot overlaps holiday

### DIFF
--- a/app/assets/javascripts/modules/calendars/company.es6
+++ b/app/assets/javascripts/modules/calendars/company.es6
@@ -250,7 +250,8 @@ class CompanyCalendar extends Calendar {
           &&
           (
             slots[slot].start.isBetween(holidays[holiday].start, holidays[holiday].end, null, '[)') ||
-            slots[slot].end.isBetween(holidays[holiday].start, holidays[holiday].end, null, '(]')
+            slots[slot].end.isBetween(holidays[holiday].start, holidays[holiday].end, null, '(]') ||
+            holidays[holiday].start.isBetween(slots[slot].start, slots[slot].end, null, '[]')
           )
         ) {
           $(`#${slots[slot].elementId}`).addClass('fc-bgevent--bookable-slot-over-holiday');


### PR DESCRIPTION
Previously this logic only checked if a holiday overlapped a slot. For
example: if a slot for 13:50-14:50 existed and a holiday for the same
guider existed from 14:00-14:20, the slot would appear available. It now
checks whether both events overlap to ensure this doesn't happen.

Elsewhere where availability calculations are made by overlapping slots,
holidays and appointments were always unaffected as they use application
logic, not calendar JS logic.