### PR TITLE
Add BSL video checkbox for appointments

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -166,7 +166,8 @@ class AppointmentsController < ApplicationController
       :county,
       :postcode,
       :gdpr_consent,
-      :smarter_signposted
+      :smarter_signposted,
+      :bsl_video
     ]
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/jobs/sms_appointment_reminder_job.rb
+++ b/app/jobs/sms_appointment_reminder_job.rb
@@ -1,7 +1,8 @@
 require 'notifications/client'
 
 class SmsAppointmentReminderJob < SmsJobBase
-  TEMPLATE_ID = '14d350d2-f962-4daa-b3b8-e6c3696864c0'.freeze
+  STANDARD_TEMPLATE_ID = '14d350d2-f962-4daa-b3b8-e6c3696864c0'.freeze
+  BSL_TEMPLATE_ID      = '6bedd37b-c75c-44f5-bed3-3ec5eb5bb564'.freeze
 
   def perform(appointment)
     return unless api_key
@@ -15,12 +16,20 @@ class SmsAppointmentReminderJob < SmsJobBase
   def send_sms_reminder(appointment)
     sms_client.send_sms(
       phone_number: appointment.canonical_sms_number,
-      template_id: TEMPLATE_ID,
+      template_id: template_for(appointment),
       reference: appointment.to_param,
       personalisation: {
         date: "#{appointment.start_at.to_s(:govuk_date_short)} (#{appointment.timezone})"
       }
     )
+  end
+
+  def template_for(appointment)
+    if appointment.bsl_video?
+      BSL_TEMPLATE_ID
+    else
+      STANDARD_TEMPLATE_ID
+    end
   end
 
   def create_activity(appointment)

--- a/app/jobs/sms_cancellation_success_job.rb
+++ b/app/jobs/sms_cancellation_success_job.rb
@@ -1,16 +1,27 @@
 class SmsCancellationSuccessJob < SmsJobBase
-  TEMPLATE_ID = 'fd90b779-03e1-471d-b9e4-34afa9622410'.freeze
+  STANDARD_TEMPLATE_ID = 'fd90b779-03e1-471d-b9e4-34afa9622410'.freeze
+  BSL_TEMPLATE_ID      = '43fb57ed-1abe-4115-81ca-10f5042e23ca'.freeze
 
   def perform(appointment)
     return unless api_key
 
     sms_client.send_sms(
       phone_number: appointment.canonical_sms_number,
-      template_id: TEMPLATE_ID,
+      template_id: template_for(appointment),
       reference: appointment.to_param,
       personalisation: {
         date: "#{appointment.start_at.to_s(:govuk_date_short)} (#{appointment.timezone})"
       }
     )
+  end
+
+  private
+
+  def template_for(appointment)
+    if appointment.bsl_video?
+      BSL_TEMPLATE_ID
+    else
+      STANDARD_TEMPLATE_ID
+    end
   end
 end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -25,6 +25,7 @@ class Appointment < ApplicationRecord
     type_of_appointment
     where_you_heard
     gdpr_consent
+    bsl_video
   ).freeze
 
   enum status: %i(

--- a/app/views/appointments/_personal_details_form.html.erb
+++ b/app/views/appointments/_personal_details_form.html.erb
@@ -55,6 +55,8 @@
     <%= f.text_field :postcode, autocomplete: 'off', class: 't-postcode' %>
 
     <h2 class="h3">Additional information and marketing</h2>
+    <%= f.check_box :bsl_video, class: 't-bsl-video', label: 'BSL video appointment?' %>
+
     <% if current_user.tpas? || current_user.administrator? %>
       <%= f.check_box :smarter_signposted, class: 't-smarter-signposted', label: 'Smarter signposting referral?' %>
     <% end %>

--- a/app/views/appointments/preview.html.erb
+++ b/app/views/appointments/preview.html.erb
@@ -39,6 +39,7 @@
   <%= f.hidden_field :county %>
   <%= f.hidden_field :postcode %>
   <%= f.hidden_field :smarter_signposted %>
+  <%= f.hidden_field :bsl_video %>
 
   <div class="t-preview appointment-preview">
     <div class="row">

--- a/app/views/shared/email/_appointment_details.html.erb
+++ b/app/views/shared/email/_appointment_details.html.erb
@@ -22,12 +22,14 @@
   </strong>
 <% end %>
 
-<%= p do %>
-  Your phone number:
-  <br>
-  <strong class="emphasize">
-    <%= @appointment.phone %>
-  </strong>
+<% unless @appointment.bsl_video? %>
+  <%= p do %>
+    Your phone number:
+    <br>
+    <strong class="emphasize">
+      <%= @appointment.phone %>
+    </strong>
+  <% end %>
 <% end %>
 
 <%= p do %>
@@ -46,16 +48,32 @@
   </strong>
 <% end %>
 
-<%= p do %>
-  A trained guidance specialist will call you on the number above. They’ll repeat the memorable word so you know you're speaking to Pension Wise.
-<% end %>
+<% if @appointment.bsl_video? %>
+  <%= p do %>
+    This is a video appointment with a British Sign Language interpreter.
+  <% end %>
 
-<%= p do %>
-  <strong>
-    If you miss the call, you’ll need to book another appointment.
-  </strong>
-<% end %>
+  <%= p do %>
+    You will be sent further information and a link to access your video
+    appointment that only you and the guidance specialist can join. They’ll
+    repeat the memorable word so you know you’re speaking to Pension Wise.
+  <% end %>
 
-<%= p do %>
-  Call 0800 138 3944 or email us to change or cancel your booking
+  <%= p do %>
+    Email us to change or cancel your booking.
+  <% end %>
+<% else %>
+  <%= p do %>
+    A trained guidance specialist will call you on the number above. They’ll repeat the memorable word so you know you're speaking to Pension Wise.
+  <% end %>
+
+  <%= p do %>
+    <strong>
+      If you miss the call, you’ll need to book another appointment.
+    </strong>
+  <% end %>
+
+  <%= p do %>
+    Call 0800 138 3944 or email us to change or cancel your booking
+  <% end %>
 <% end %>

--- a/app/views/shared/email/_appointment_details.text.erb
+++ b/app/views/shared/email/_appointment_details.text.erb
@@ -7,8 +7,10 @@ Time:
 Appointment lasts:
 45 to 60 minutes
 
+<% unless @appointment.bsl_video? %>
 Your phone number:
 <%= @appointment.phone %>
+<% end %>
 
 Memorable word:
 <%= @appointment.memorable_word(obscure: true) %>
@@ -16,8 +18,16 @@ Memorable word:
 Reference number:
 <%= @appointment.id %>
 
+<% if @appointment.bsl_video? %>
+This is a video appointment with a British Sign Language interpreter.
+
+You should have received further information and a link to access your video appointment that only you and the guidance specialist can join. They’ll repeat the memorable word so you know you're speaking to Pension Wise.
+
+Email us if you need this information resent or to change or cancel your booking. You may be asked for your booking reference number.
+<% else %>
 A trained guidance specialist will call you on the number above. They'll repeat the memorable word so you know you're speaking to Pension Wise.
 
 If you miss the call, you'll need to book another appointment.
 
 Call 0800 138 3944 or email us to change or cancel your booking.
+<% end %>

--- a/db/migrate/20200924145011_add_bsl_video_to_appointments.rb
+++ b/db/migrate/20200924145011_add_bsl_video_to_appointments.rb
@@ -1,0 +1,5 @@
+class AddBslVideoToAppointments < ActiveRecord::Migration[6.0]
+  def change
+    add_column :appointments, :bsl_video, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_16_092614) do
+ActiveRecord::Schema.define(version: 2020_09_24_145011) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 2020_07_16_092614) do
     t.boolean "accessibility_requirements", default: false, null: false
     t.datetime "processed_at"
     t.boolean "smarter_signposted", default: false
+    t.boolean "bsl_video", default: false, null: false
     t.index ["start_at"], name: "index_appointments_on_start_at"
   end
 

--- a/spec/features/agent_manages_appointments_spec.rb
+++ b/spec/features/agent_manages_appointments_spec.rb
@@ -218,6 +218,7 @@ RSpec.feature 'Agent manages appointments' do
     @page.town.set(options[:town]) if options[:town]
     @page.postcode.set(options[:postcode]) if options[:postcode]
     @page.smarter_signposted.set(options[:smarter_signposted]) if options[:smarter_signposted]
+    @page.bsl_video.set(true)
 
     @page.preview_appointment.click
   end
@@ -277,6 +278,7 @@ RSpec.feature 'Agent manages appointments' do
     expect(appointment.where_you_heard).to eq(17)
     expect(appointment).to be_accessibility_requirements
     expect(appointment).to be_smarter_signposted if smarter_signposted
+    expect(appointment).to be_bsl_video
   end
 
   def and_the_customer_gets_an_email_confirmation

--- a/spec/jobs/sms_appointment_reminder_job_spec.rb
+++ b/spec/jobs/sms_appointment_reminder_job_spec.rb
@@ -4,20 +4,43 @@ RSpec.describe SmsAppointmentReminderJob, '#perform' do
   let(:appointment) { create(:appointment, created_at: 1.day.ago) }
   let(:client) { double(Notifications::Client, send_sms: true) }
 
-  it 'sends an SMS' do
-    travel_to(Time.zone.parse('2018-07-03 12:00')) do
-      expect(client).to receive(:send_sms).with(
-        phone_number: '07715 930 444',
-        template_id: SmsAppointmentReminderJob::TEMPLATE_ID,
-        reference: appointment.to_param,
-        personalisation: {
-          date: a_string_matching(/12:00pm, .* \(BST\)/)
-        }
-      )
+  context 'for non-BSL appointments' do
+    it 'sends an SMS with the standard template' do
+      travel_to(Time.zone.parse('2018-07-03 12:00')) do
+        expect(client).to receive(:send_sms).with(
+          phone_number: '07715 930 444',
+          template_id: SmsAppointmentReminderJob::STANDARD_TEMPLATE_ID,
+          reference: appointment.to_param,
+          personalisation: {
+            date: a_string_matching(/12:00pm, .* \(BST\)/)
+          }
+        )
 
-      described_class.new.perform(appointment)
+        described_class.new.perform(appointment)
 
-      expect(appointment.activities.find_by(type: 'SmsReminderActivity')).to be
+        expect(appointment.activities.find_by(type: 'SmsReminderActivity')).to be
+      end
+    end
+  end
+
+  context 'for BSL video appointments' do
+    it 'sends an SMS with the BSL template' do
+      appointment.bsl_video = true
+
+      travel_to(Time.zone.parse('2018-07-03 12:00')) do
+        expect(client).to receive(:send_sms).with(
+          phone_number: '07715 930 444',
+          template_id: SmsAppointmentReminderJob::BSL_TEMPLATE_ID,
+          reference: appointment.to_param,
+          personalisation: {
+            date: a_string_matching(/12:00pm, .* \(BST\)/)
+          }
+        )
+
+        described_class.new.perform(appointment)
+
+        expect(appointment.activities.find_by(type: 'SmsReminderActivity')).to be
+      end
     end
   end
 

--- a/spec/jobs/sms_appointment_reminder_job_spec.rb
+++ b/spec/jobs/sms_appointment_reminder_job_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SmsAppointmentReminderJob, '#perform' do
           template_id: SmsAppointmentReminderJob::STANDARD_TEMPLATE_ID,
           reference: appointment.to_param,
           personalisation: {
-            date: a_string_matching(/12:00pm, .* \(BST\)/)
+            date: a_string_matching(/12:00pm, .*/)
           }
         )
 
@@ -33,7 +33,7 @@ RSpec.describe SmsAppointmentReminderJob, '#perform' do
           template_id: SmsAppointmentReminderJob::BSL_TEMPLATE_ID,
           reference: appointment.to_param,
           personalisation: {
-            date: a_string_matching(/12:00pm, .* \(BST\)/)
+            date: a_string_matching(/12:00pm, .*/)
           }
         )
 

--- a/spec/jobs/sms_cancellation_success_job_spec.rb
+++ b/spec/jobs/sms_cancellation_success_job_spec.rb
@@ -4,17 +4,36 @@ RSpec.describe SmsCancellationSuccessJob, '#perform' do
   let(:appointment) { create(:appointment, start_at: Time.zone.parse('2019-01-01 13:00 UTC')) }
   let(:client) { double(Notifications::Client, send_sms: true) }
 
-  it 'sends an SMS' do
-    expect(client).to receive(:send_sms).with(
-      phone_number: '07715 930 444',
-      template_id: SmsCancellationSuccessJob::TEMPLATE_ID,
-      reference: appointment.to_param,
-      personalisation: {
-        date: '1:00pm, 1 Jan 2019 (GMT)'
-      }
-    )
+  context 'for a standard appointment' do
+    it 'sends an SMS with the appropriate template' do
+      expect(client).to receive(:send_sms).with(
+        phone_number: '07715 930 444',
+        template_id: SmsCancellationSuccessJob::STANDARD_TEMPLATE_ID,
+        reference: appointment.to_param,
+        personalisation: {
+          date: '1:00pm, 1 Jan 2019 (GMT)'
+        }
+      )
 
-    described_class.new.perform(appointment)
+      described_class.new.perform(appointment)
+    end
+  end
+
+  context 'for a BSL appointment' do
+    it 'sends an SMS with the appropriate template' do
+      appointment.bsl_video = true
+
+      expect(client).to receive(:send_sms).with(
+        phone_number: '07715 930 444',
+        template_id: SmsCancellationSuccessJob::BSL_TEMPLATE_ID,
+        reference: appointment.to_param,
+        personalisation: {
+          date: '1:00pm, 1 Jan 2019 (GMT)'
+        }
+      )
+
+      described_class.new.perform(appointment)
+    end
   end
 
   before do

--- a/spec/mailers/appointment_mailer_spec.rb
+++ b/spec/mailers/appointment_mailer_spec.rb
@@ -135,6 +135,14 @@ RSpec.describe AppointmentMailer, type: :mailer do
     describe 'rendering the body' do
       let(:body) { subject.body.encoded }
 
+      context 'when the appointment is BSL video based' do
+        it 'includes the video appointment specifics' do
+          appointment.bsl_video = true
+
+          expect(body).to include('British Sign Language')
+        end
+      end
+
       it 'includes the date' do
         expect(body).to include('23 October 2016')
       end
@@ -157,6 +165,10 @@ RSpec.describe AppointmentMailer, type: :mailer do
 
       it 'includes the reference number' do
         expect(body).to include(appointment.id.to_s)
+      end
+
+      it 'includes the phone specifics' do
+        expect(body).to include('call you on the number')
       end
     end
   end
@@ -238,6 +250,24 @@ RSpec.describe AppointmentMailer, type: :mailer do
 
     describe 'rendering the body' do
       let(:body) { subject.body.encoded }
+
+      context 'when the appointment is BSL video based' do
+        before do
+          appointment.bsl_video = true
+        end
+
+        it 'includes the video appointment specifics' do
+          expect(body).to include('British Sign Language')
+        end
+
+        it 'does not include the customer phone number' do
+          expect(body).not_to include(appointment.phone)
+        end
+      end
+
+      it 'includes the phone specifics' do
+        expect(body).to include('call you on the number')
+      end
 
       it 'includes the date' do
         expect(body).to include('23 October 2016')

--- a/spec/support/pages/new_appointment.rb
+++ b/spec/support/pages/new_appointment.rb
@@ -29,6 +29,7 @@ module Pages
     element :town, '.t-town'
     element :postcode, '.t-postcode'
     element :smarter_signposted, '.t-smarter-signposted'
+    element :bsl_video, '.t-bsl-video'
 
     element :availability_calendar_off, '.t-availability-calendar-off'
     element :availability_calendar_on, '.t-availability-calendar-on'


### PR DESCRIPTION
This lets the agent signal that this is going to be a BSL video based
appointment.