### PR TITLE
Add road safety warning

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -220,6 +220,10 @@ class Appointment < ApplicationRecord
     errors.key?(:guider) || errors.key?(:start_at)
   end
 
+  def mobile?
+    phone.start_with?('07') || mobile.start_with?('07')
+  end
+
   def mark_batch_processed!
     transaction do
       touch(:batch_processed_at)

--- a/app/views/appointments/preview.html.erb
+++ b/app/views/appointments/preview.html.erb
@@ -120,6 +120,24 @@
           </tbody>
         </table>
 
+        <% if @appointment.mobile? %>
+          <div class="alert alert-warning t-road-safety-banner">
+            <p>
+              In the interest of road safety we will not deliver a Pension Wise appointment
+              if you are driving. This also includes the use of hands-free devices as the
+              Royal Society for the Prevention of Accidents (RoSPA) considers that using a
+              hands-free phone while driving is a significant distraction that can
+              substantially increases the risk of crashing.
+            </p>
+            <p>
+              Please ensure you are not driving at the time of your appointment. If we become
+              aware that you are driving during an appointment, we cannot continue. We will
+              ask you to either pull over in a safe, legal and convenient place, or if this
+              is not possible, we will advise to you rebook your appointment
+            </p>
+          </div>
+        <% end %>
+
         <p class="alert alert-warning">
           Full details on our privacy policy, including the customers rights in
           regards to their personal data, can be found on the Pension Wise website

--- a/spec/features/agent_manages_appointments_spec.rb
+++ b/spec/features/agent_manages_appointments_spec.rb
@@ -205,7 +205,7 @@ RSpec.feature 'Agent manages appointments' do
     @page.last_name.set 'Person'
     @page.email.set options[:email] || 'email@example.org'
     @page.phone.set '0208 252 4729'
-    @page.mobile.set '+447715 930 459'
+    @page.mobile.set '07715 930 459'
     @page.memorable_word.set 'lozenge'
     @page.accessibility_requirements.set true
     @page.notes.set 'something'
@@ -237,12 +237,13 @@ RSpec.feature 'Agent manages appointments' do
     expect(@page.preview).to have_content 'Some Person'
     expect(@page.preview).to have_content 'email@example.org'
     expect(@page.preview).to have_content '0208 252 4729'
-    expect(@page.preview).to have_content '+447715 930 459'
+    expect(@page.preview).to have_content '07715 930 459'
     expect(@page.preview).to have_content 'lozenge'
     expect(@page.preview).to have_content 'something'
     expect(@page.preview).to have_content 'Customer research consent Yes'
     expect(@page.preview).to have_content 'Standard'
     expect(@page.preview).to have_content 'Smarter signposted referral? Yes' if smarter_signposted
+    expect(@page).to have_road_safety_banner
   end
 
   def and_they_fill_in_their_appointment_details_without_an_email
@@ -266,7 +267,7 @@ RSpec.feature 'Agent manages appointments' do
     expect(appointment.last_name).to eq 'Person'
     expect(appointment.email).to eq 'email@example.org'
     expect(appointment.phone).to eq '0208 252 4729'
-    expect(appointment.mobile).to eq '+447715 930 459'
+    expect(appointment.mobile).to eq '07715 930 459'
     expect(appointment.memorable_word).to eq 'lozenge'
     expect(appointment.notes).to eq 'something'
     expect(appointment.gdpr_consent).to eq 'yes'
@@ -326,7 +327,7 @@ RSpec.feature 'Agent manages appointments' do
     @page.last_name.set 'Name'
     @page.email.set 'something@example.org'
     @page.phone.set '02082524729'
-    @page.mobile.set '+447715930459'
+    @page.mobile.set '07715930459'
     @page.memorable_word.set 'orange'
     @page.notes.set 'no notes'
     @page.gdpr_consent_yes.set true
@@ -357,7 +358,7 @@ RSpec.feature 'Agent manages appointments' do
     expect(appointment.last_name).to eq 'Name'
     expect(appointment.email).to eq 'something@example.org'
     expect(appointment.phone).to eq '02082524729'
-    expect(appointment.mobile).to eq '+447715930459'
+    expect(appointment.mobile).to eq '07715930459'
     expect(appointment.memorable_word).to eq 'orange'
     expect(appointment.notes).to eq 'no notes'
     expect(appointment.gdpr_consent).to eq 'yes'

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -1,6 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe Appointment, type: :model do
+  describe '#mobile?' do
+    context 'when the appointment has mobileish number' do
+      it 'is true' do
+        appointment = build_stubbed(:appointment, phone: '07715930485', mobile: '')
+        expect(appointment).to be_mobile
+
+        appointment = build_stubbed(:appointment, phone: '', mobile: '0771675849')
+        expect(appointment).to be_mobile
+      end
+    end
+
+    context 'when neither the phone or mobile fields are mobileish' do
+      it 'is false' do
+        appointment = build_stubbed(:appointment, phone: '0208 252 4888', mobile: '')
+        expect(appointment).not_to be_mobile
+      end
+    end
+  end
+
   describe '#cancel!' do
     it 'does not audit any changes' do
       appointment = create(:appointment)

--- a/spec/support/pages/preview_appointment.rb
+++ b/spec/support/pages/preview_appointment.rb
@@ -2,6 +2,7 @@ module Pages
   class PreviewAppointment < Base
     set_url '/appointments/preview'
 
+    element :road_safety_banner,  '.t-road-safety-banner'
     element :confirm_appointment, '.t-confirm-appointment'
     element :edit_appointment,    '.t-edit-appointment'
     element :preview,             '.t-preview'


### PR DESCRIPTION
A road safety warning appears in the preview stage when the customer has
a mobileish number against their appointment.