### PR TITLE
Restrict who can access BSL video

### DIFF
--- a/app/helpers/appointment_helper.rb
+++ b/app/helpers/appointment_helper.rb
@@ -1,4 +1,14 @@
 module AppointmentHelper
+  def bsl_video_visible?(current_user)
+    current_user.administrator? || current_user.tp? || current_user.lancs_west?
+  end
+
+  def bsl_video_disabled?(current_user)
+    return false if current_user.administrator? || current_user.lancs_west?
+
+    true
+  end
+
   def display_dc_pot_unsure_banner?(appointment)
     return if appointment.dc_pot_confirmed?
     return if appointment.tp_guider? || appointment.tpas_guider?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,6 +60,10 @@ class User < ApplicationRecord
     organisation_content_id == Provider::NI.id
   end
 
+  def lancs_west?
+    organisation_content_id == Provider::LANCS_WEST.id
+  end
+
   def tp_agent?
     tp? && agent?
   end

--- a/app/views/appointments/_personal_details_form.html.erb
+++ b/app/views/appointments/_personal_details_form.html.erb
@@ -55,7 +55,9 @@
     <%= f.text_field :postcode, autocomplete: 'off', class: 't-postcode' %>
 
     <h2 class="h3">Additional information and marketing</h2>
-    <%= f.check_box :bsl_video, class: 't-bsl-video', label: 'BSL video appointment?' %>
+    <% if bsl_video_visible?(current_user) %>
+     <%= f.check_box :bsl_video, class: 't-bsl-video', label: 'BSL video appointment?', disabled: bsl_video_disabled?(current_user) %>
+    <% end %>
 
     <% if current_user.tpas? || current_user.administrator? %>
       <%= f.check_box :smarter_signposted, class: 't-smarter-signposted', label: 'Smarter signposting referral?' %>


### PR DESCRIPTION
BSL video should only be visible to Lancs West and admins for
modification and to TP as readonly.