### PR TITLE
Send an exit poll email to BSL customers

### DIFF
--- a/app/jobs/bsl_customer_exit_poll_job.rb
+++ b/app/jobs/bsl_customer_exit_poll_job.rb
@@ -1,0 +1,9 @@
+class BslCustomerExitPollJob < ApplicationJob
+  queue_as :default
+
+  def perform(appointment)
+    AppointmentMailer.bsl_customer_exit_poll(appointment)
+
+    BslCustomerExitPollActivity.from(appointment)
+  end
+end

--- a/app/lib/notifier.rb
+++ b/app/lib/notifier.rb
@@ -31,14 +31,25 @@ class Notifier
     Array(appointment.previous_changes.fetch('guider_id', appointment.guider_id))
   end
 
-  def notify_customer
+  def notify_customer # rubocop:disable AbcSize
     if appointment_cancelled?
       CustomerUpdateJob.perform_later(appointment, CustomerUpdateActivity::CANCELLED_MESSAGE)
     elsif appointment_missed?
       CustomerUpdateJob.perform_later(appointment, CustomerUpdateActivity::MISSED_MESSAGE)
     elsif appointment_details_changed? && appointment.future?
       CustomerUpdateJob.perform_later(appointment, CustomerUpdateActivity::UPDATED_MESSAGE)
+    elsif bsl_appointment_complete?
+      BslCustomerExitPollJob.set(wait: 24.hours).perform_later(appointment)
     end
+  end
+
+  def bsl_appointment_complete?
+    appointment.bsl_video? && appointment_complete?
+  end
+
+  def appointment_complete?
+    appointment.previous_changes.slice('status').present? &&
+      appointment.complete?
   end
 
   def appointment_details_changed?

--- a/app/mailers/appointment_mailer.rb
+++ b/app/mailers/appointment_mailer.rb
@@ -65,6 +65,14 @@ class AppointmentMailer < ApplicationMailer
     mail to: @appointment.email
   end
 
+  def bsl_customer_exit_poll(appointment)
+    return unless appointment.email?
+
+    mailgun_headers('bsl_exit_poll', appointment.id)
+    @appointment = appointment
+    mail to: @appointment.email
+  end
+
   def consent_form(appointment)
     return unless appointment.email_consent?
 

--- a/app/models/bsl_customer_exit_poll_activity.rb
+++ b/app/models/bsl_customer_exit_poll_activity.rb
@@ -1,0 +1,9 @@
+class BslCustomerExitPollActivity < Activity
+  def self.from(appointment)
+    create!(appointment_id: appointment.id)
+  end
+
+  def owner_required?
+    false
+  end
+end

--- a/app/views/activities/_bsl_customer_exit_poll_activity.html.erb
+++ b/app/views/activities/_bsl_customer_exit_poll_activity.html.erb
@@ -1,0 +1,5 @@
+<% content_for(:activity_message, flush: true) do %>
+  <span class="glyphicon glyphicon-envelope" aria-hidden="true"></span>
+  <strong>The system</strong> sent an exit poll email to <strong><%= bsl_customer_exit_poll_activity.appointment.name %></strong>
+<% end %>
+<%= render 'activities/activity', activity: bsl_customer_exit_poll_activity, details: details, hide: hide %>

--- a/app/views/appointment_mailer/bsl_customer_exit_poll.html.erb
+++ b/app/views/appointment_mailer/bsl_customer_exit_poll.html.erb
@@ -1,0 +1,23 @@
+<h1 style="color: #0B0C0C !important;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-weight: 700;font-size: 20px;line-height: 1.111111111;padding: 15px 0;">
+  We’d appreciate your feedback
+</h1>
+
+<%= p do %>
+  Dear <%= @appointment.first_name %>,
+<% end %>
+
+<%= p do %>
+  You recently had a Pension Wise appointment with <%= @appointment.guider.name %> on <%= @appointment.start_at.to_date.to_s(:govuk_date) %>.
+<% end %>
+
+<%= p do %>
+  This is a new service and we’d appreciate your feedback on how it went:
+<% end %>
+
+<%= p do %>
+  <a href="https://www.pensionwise.gov.uk/bsl-exit-poll">www.pensionwise.gov.uk/bsl-exit-poll</a>
+<% end %>
+
+<%= p do %>
+  The information you provide on this feedback form will be shared with our Pension Wise partners for service improvement.
+<% end %>

--- a/app/views/appointment_mailer/bsl_customer_exit_poll.text.erb
+++ b/app/views/appointment_mailer/bsl_customer_exit_poll.text.erb
@@ -1,0 +1,11 @@
+We’d appreciate your feedback
+
+Dear <%= @appointment.first_name %>,
+
+You recently had a Pension Wise appointment with <%= @appointment.guider.name %> on <%= @appointment.start_at.to_date.to_s(:govuk_date) %>.
+
+This is a new service and we’d appreciate your feedback on how it went:
+
+https://www.pensionwise.gov.uk/bsl-exit-poll
+
+The information you provide on this feedback form will be shared with our Pension Wise partners for service improvement.

--- a/spec/jobs/bsl_customer_exit_poll_job_spec.rb
+++ b/spec/jobs/bsl_customer_exit_poll_job_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe BslCustomerExitPollJob, '#perform_now' do
+  it 'sends the exit poll email and logs an activity' do
+    appointment = build_stubbed(:appointment, bsl_video: true)
+
+    expect(AppointmentMailer).to receive(:bsl_customer_exit_poll).with(appointment)
+    expect(BslCustomerExitPollActivity).to receive(:from).with(appointment)
+
+    described_class.perform_now(appointment)
+  end
+end

--- a/spec/lib/notifier_spec.rb
+++ b/spec/lib/notifier_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe Notifier, '#call' do
     allow(mailer).to receive(:deliver)
   end
 
+  context 'when a BSL appointment is completed' do
+    it 'enqueues the BSL exit poll job to run in 24 hours' do
+      scheduler = double(perform_later: true)
+      appointment.update(bsl_video: true, status: :complete)
+
+      expect(BslCustomerExitPollJob).to receive(:set).with(wait: 24.hours).and_return(scheduler)
+      expect(scheduler).to receive(:perform_later).with(appointment)
+
+      subject.call
+    end
+  end
+
   context 'when the appointment is rescheduled' do
     it 'enqueues the rescheduled notifications' do
       new_guider = create(:guider)

--- a/spec/mailers/appointment_mailer_spec.rb
+++ b/spec/mailers/appointment_mailer_spec.rb
@@ -12,6 +12,25 @@ RSpec.describe AppointmentMailer, type: :mailer do
     )
   end
 
+  describe 'BSL customer exit poll' do
+    let(:mailgun_headers) { JSON.parse(mail['X-Mailgun-Variables'].value) }
+    let(:appointment) { build_stubbed(:appointment, bsl_video: true) }
+
+    subject(:mail) { described_class.bsl_customer_exit_poll(appointment) }
+
+    it 'sends to the customer email' do
+      expect(mail.to).to eq(['someone@example.com'])
+    end
+
+    it 'renders the mailgun specific headers' do
+      expect(mailgun_headers).to include('message_type' => 'bsl_exit_poll', 'appointment_id' => appointment.id)
+    end
+
+    it 'renders the exit poll vanity URL' do
+      expect(subject.body.encoded).to match('https://www.pensionwise.gov.uk/bsl-exit-poll')
+    end
+  end
+
   describe 'Customer email consent form' do
     let(:mailgun_headers) { JSON.parse(mail['X-Mailgun-Variables'].value) }
     let(:appointment) { build_stubbed(:appointment, :third_party_booking, :email_consent_form_requested) }

--- a/spec/mailers/previews/appointment_mailer_preview.rb
+++ b/spec/mailers/previews/appointment_mailer_preview.rb
@@ -59,6 +59,10 @@ class AppointmentMailerPreview < ActionMailer::Preview
     )
   end
 
+  def bsl_customer_exit_poll
+    AppointmentMailer.bsl_customer_exit_poll(random_appointment)
+  end
+
   private
 
   def random_appointment


### PR DESCRIPTION
When a BSL appointment is marked complete, an email containing a link to
the exit poll will be scheduled for delivery in 24 hours.