### PR TITLE
Don't require a data subject dob if age present

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -87,7 +87,7 @@ class Appointment < ApplicationRecord
   validates :accessibility_requirements, inclusion: [true, false]
   validates :third_party_booking, inclusion: [true, false]
   validates :data_subject_name, presence: true, if: :third_party_booking?
-  validates :data_subject_date_of_birth, presence: true, if: :third_party_booking?
+  validates :data_subject_date_of_birth, presence: true, if: :require_data_subject_date_of_birth?
   validates :notes, presence: true, if: :validate_adjustment_needs?
   validates :type_of_appointment, inclusion: %w(standard 50-54)
   validates :where_you_heard, inclusion: WhereYouHeard.options_for_inclusion, on: :create, unless: :rebooked_from_id?
@@ -402,9 +402,13 @@ class Appointment < ApplicationRecord
   end
 
   def data_subject_date_of_birth_valid
-    return unless third_party_booking?
+    return unless require_data_subject_date_of_birth?
 
     errors.add(:data_subject_date_of_birth, 'must be valid') if @data_subject_date_of_birth_invalid
+  end
+
+  def require_data_subject_date_of_birth?
+    third_party_booking? && data_subject_age.blank?
   end
 
   def date_of_birth_valid

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -223,6 +223,7 @@ RSpec.describe Appointment, type: :model do
           subject.third_party_booking = true
           subject.printed_consent_form_required = false
           subject.data_subject_name = 'Bob Bobson'
+          subject.data_subject_age = 50
           subject.data_subject_date_of_birth = '1950-01-01'.to_date
         end
 
@@ -232,10 +233,21 @@ RSpec.describe Appointment, type: :model do
           expect(subject).to be_invalid
         end
 
-        it 'requires a data subject date of birth' do
-          subject.data_subject_date_of_birth = nil
+        context 'when a data subject age was present' do
+          it 'does not require a date of birth' do
+            subject.data_subject_date_of_birth = nil
 
-          expect(subject).to be_invalid
+            expect(subject).to be_valid
+          end
+        end
+
+        context 'when no data subject age was present' do
+          it 'requires a data subject date of birth' do
+            subject.data_subject_age = nil
+            subject.data_subject_date_of_birth = nil
+
+            expect(subject).to be_invalid
+          end
         end
 
         context 'when a printed consent form is requested' do


### PR DESCRIPTION
This was an oversight that was causing issues when moving third party
appointments that had an associated data subject age created when that
was possible, prior to the introduction of the data subject date of
birth and related validations.