### PR TITLE
Calculate two week availability for reporting

### DIFF
--- a/app/lib/scheduled_reporting_summary.rb
+++ b/app/lib/scheduled_reporting_summary.rb
@@ -3,10 +3,19 @@ class ScheduledReportingSummary
     Provider.all.each do |organisation|
       ReportingSummary.create!(
         organisation: organisation.name,
+        two_week_availability: two_week_available?(organisation.id),
         four_week_availability: four_week_available?(organisation.id),
         first_available_slot_on: first_available_slot_on(organisation.id)
       )
     end
+  end
+
+  def two_week_available?(organisation_id)
+    slot = first_available_slot_on(organisation_id)
+
+    return false unless slot
+
+    slot <= two_week_period
   end
 
   def four_week_available?(organisation_id)
@@ -22,6 +31,10 @@ class ScheduledReportingSummary
   end
 
   private
+
+  def two_week_period
+    BusinessDays.from_now(10)
+  end
 
   def four_week_period
     BusinessDays.from_now(20)

--- a/db/migrate/20210216104738_add_two_week_availability_to_scheduled_reporting_summaries.rb
+++ b/db/migrate/20210216104738_add_two_week_availability_to_scheduled_reporting_summaries.rb
@@ -1,0 +1,5 @@
+class AddTwoWeekAvailabilityToScheduledReportingSummaries < ActiveRecord::Migration[6.0]
+  def change
+    add_column :reporting_summaries, :two_week_availability, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_01_093604) do
+ActiveRecord::Schema.define(version: 2021_02_16_104738) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -169,6 +169,7 @@ ActiveRecord::Schema.define(version: 2020_12_01_093604) do
     t.date "first_available_slot_on"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "two_week_availability", default: false, null: false
   end
 
   create_table "schedules", id: :serial, force: :cascade do |t|

--- a/spec/factories/bookable_slots.rb
+++ b/spec/factories/bookable_slots.rb
@@ -23,5 +23,9 @@ FactoryBot.define do
     trait :lancs_west do
       guider { create(:guider, :lancs_west) }
     end
+
+    trait :derbyshire_districts do
+      guider { create(:guider, :derbyshire_districts) }
+    end
   end
 end

--- a/spec/features/scheduled_reporting_summary_spec.rb
+++ b/spec/features/scheduled_reporting_summary_spec.rb
@@ -21,32 +21,44 @@ RSpec.feature 'Scheduled reporting summary' do
     create(:bookable_slot, :ni, start_at: Time.zone.parse('2018-04-29 11:00'))
     create(:bookable_slot, :wallsend, start_at: Time.zone.parse('2018-04-29 11:00'))
     create(:bookable_slot, :lancs_west, start_at: Time.zone.parse('2018-04-29 11:00'))
+    create(:bookable_slot, :derbyshire_districts, start_at: Time.zone.parse('2018-05-12 11:00'))
   end
 
   def then_the_availability_is_summarised_correctly
     expect(ReportingSummary.find_by(organisation: 'CAS')).to have_attributes(
+      two_week_availability: true,
       four_week_availability: true,
       first_available_slot_on: '2018-04-28'.to_date
     )
 
     expect(ReportingSummary.find_by(organisation: 'Lancs West')).to have_attributes(
+      two_week_availability: true,
       four_week_availability: true,
       first_available_slot_on: '2018-04-29'.to_date
     )
 
     expect(ReportingSummary.find_by(organisation: 'Wallsend')).to have_attributes(
+      two_week_availability: true,
       four_week_availability: true,
       first_available_slot_on: '2018-04-29'.to_date
     )
 
     expect(ReportingSummary.find_by(organisation: 'NI')).to have_attributes(
+      two_week_availability: true,
       four_week_availability: true,
       first_available_slot_on: '2018-04-29'.to_date
     )
 
     expect(ReportingSummary.find_by(organisation: 'TP')).to have_attributes(
+      two_week_availability: true,
       four_week_availability: true,
       first_available_slot_on: '2018-04-27'.to_date
+    )
+
+    expect(ReportingSummary.find_by(organisation: 'Derbyshire Districts')).to have_attributes(
+      two_week_availability: false,
+      four_week_availability: true,
+      first_available_slot_on: '2018-05-12'.to_date
     )
   end
 
@@ -57,6 +69,7 @@ RSpec.feature 'Scheduled reporting summary' do
   def then_the_availability_is_summarised
     ReportingSummary.all.each do |entry|
       expect(entry).to have_attributes(
+        two_week_availability: false,
         four_week_availability: false,
         first_available_slot_on: nil
       )


### PR DESCRIPTION
Adds the two week availability flag for providers to accompany the
existing four week availability flag.