### PR TITLE
Improve duplicates display

### DIFF
--- a/app/controllers/duplicates_controller.rb
+++ b/app/controllers/duplicates_controller.rb
@@ -1,0 +1,5 @@
+class DuplicatesController < ApplicationController
+  def index
+    @appointment = Appointment.for_organisation(current_user).find(params[:appointment_id])
+  end
+end

--- a/app/helpers/appointment_helper.rb
+++ b/app/helpers/appointment_helper.rb
@@ -1,8 +1,4 @@
 module AppointmentHelper
-  def organisation_name(appointment)
-    Provider.find(appointment.guider.organisation_content_id)&.name
-  end
-
   def bsl_video_visible?(current_user)
     current_user.administrator? || current_user.tp? || current_user.lancs_west?
   end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -151,7 +151,7 @@ class Appointment < ApplicationRecord
           start_at: start_at.beginning_of_day..start_at.end_of_day
         )
         .order(:id)
-        .take(5)
+        .take(10)
   end
 
   def potential_duplicates?

--- a/app/models/email_lookup.rb
+++ b/app/models/email_lookup.rb
@@ -1,0 +1,2 @@
+class EmailLookup < ApplicationRecord
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -44,6 +44,10 @@ class Provider
     @cita
   end
 
+  def email
+    EmailLookup.find_by(organisation_id: id)&.email
+  end
+
   def self.find(id)
     ALL_ORGANISATIONS.find { |organisation| organisation.id == id }
   end

--- a/app/presenters/duplicate_presenter.rb
+++ b/app/presenters/duplicate_presenter.rb
@@ -1,0 +1,33 @@
+class DuplicatePresenter < SimpleDelegator
+  def timestamp
+    "#{created_at.to_date.to_s(:govuk_date_short)}, #{created_at.in_time_zone('London').to_s(:govuk_time)}"
+  end
+
+  def organisation_name
+    provider.name
+  end
+
+  def start
+    "#{start_at.to_date.to_s(:govuk_date_short)}, #{start_at.to_s(:govuk_time)}"
+  end
+
+  def agent_name
+    if agent.pension_wise_api?
+      'Pension Wise Website'
+    else
+      agent.name
+    end
+  end
+
+  def status
+    super.humanize
+  end
+
+  delegate :email, to: :provider
+
+  private
+
+  def provider
+    @provider ||= Provider.find(guider.organisation_content_id)
+  end
+end

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -30,19 +30,7 @@
 
 <% if @appointment.potential_duplicates? %>
   <div class="alert alert-warning" role="alert">
-    <p>
-      This appointment may be a duplicate of:
-    </p>
-    <ul>
-      <% @appointment.potential_duplicates.each do |appointment| %>
-        <li>
-          <%= link_to "##{appointment.id}", edit_appointment_path(id: appointment) %><br>
-          Organisation: <em><%= organisation_name(appointment) %></em><br>
-          Appointment date/time: <em><%= appointment.start_at.to_date.to_s(:govuk_date_short) %>, <%= appointment.start_at.to_s(:govuk_time) %></em><br>
-          Created: <em><%= appointment.created_at.to_date.to_s(:govuk_date_short) %>, <%= appointment.created_at.to_s(:govuk_time) %></em>
-        </li>
-      <% end %>
-    </ul>
+    <p>This appointment <strong><%= link_to 'may be duplicated', appointment_duplicates_path(@appointment) %></strong></p>
   </div>
 <% end %>
 

--- a/app/views/duplicates/index.html.erb
+++ b/app/views/duplicates/index.html.erb
@@ -1,0 +1,33 @@
+<% content_for(:page_title, t('service.title', page_title: "Duplicates for Appointment ##{@appointment.id}")) %>
+<%= breadcrumb(
+  { title: 'Edit Appointment', path: edit_appointment_path(@appointment.id) },
+  { title: "Duplicates for Appointment ##{@appointment.id}" }
+) %>
+
+<h1>Duplicates for Appointment #<%= @appointment.id %></h1>
+
+<table class="table table-striped table-bordered">
+  <thead>
+    <tr>
+      <th>Reference</th>
+      <th>Organisation</th>
+      <th>Appointment date/time</th>
+      <th>Status</th>
+      <th>Created by</th>
+      <th>Created</th>
+    </tr>
+  </thead>
+  <tbody>
+  <% @appointment.potential_duplicates.each do |duplicate| %>
+    <% @duplicate = DuplicatePresenter.new(duplicate) %>
+    <tr class="t-duplicate">
+      <td><%= @duplicate.id %></td>
+      <td><%= @duplicate.organisation_name %> <small><%= @duplicate.email %></small></td>
+      <td><%= @duplicate.start %></td>
+      <td><%= @duplicate.status %></td>
+      <td><%= @duplicate.agent_name %></td>
+      <td><%= @duplicate.timestamp %></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     resource :consent, only: :show
     resource :process, only: :create
     resources :changes, only: :index
+    resources :duplicates, only: :index
 
     post :preview, on: :collection
     patch :batch_update, on: :collection

--- a/db/migrate/20210223123516_create_email_lookups.rb
+++ b/db/migrate/20210223123516_create_email_lookups.rb
@@ -1,0 +1,10 @@
+class CreateEmailLookups < ActiveRecord::Migration[6.0]
+  def change
+    create_table :email_lookups do |t|
+      t.string :organisation_id, null: false, unique: true
+      t.string :email, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_16_104738) do
+ActiveRecord::Schema.define(version: 2021_02_23_123516) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -134,6 +134,13 @@ ActiveRecord::Schema.define(version: 2021_02_16_104738) do
     t.datetime "updated_at", null: false
     t.index ["guider_id"], name: "index_bookable_slots_on_guider_id"
     t.index ["start_at", "end_at"], name: "index_bookable_slots_on_start_at_and_end_at"
+  end
+
+  create_table "email_lookups", force: :cascade do |t|
+    t.string "organisation_id", null: false
+    t.string "email", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "group_assignments", id: false, force: :cascade do |t|

--- a/spec/features/guider_views_duplicate_appointments_spec.rb
+++ b/spec/features/guider_views_duplicate_appointments_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.feature 'Guider views duplicate appointments' do
+  scenario 'Viewing an appointment with duplicates' do
+    given_the_user_is_a_guider do
+      and_an_appointment_with_duplicates_exists
+      when_they_view_the_duplicates
+      then_they_see_the_required_information
+    end
+  end
+
+  def and_an_appointment_with_duplicates_exists
+    @appointment = create_list(:appointment, 2, first_name: 'Bob', last_name: 'McDuplicated').first
+  end
+
+  def when_they_view_the_duplicates
+    @page = Pages::DuplicateAppointments.new
+    @page.load(id: @appointment.id)
+  end
+
+  def then_they_see_the_required_information
+    expect(@page).to be_displayed
+
+    expect(@page).to have_duplicates(count: 1)
+  end
+end

--- a/spec/support/pages/duplicate_appointments.rb
+++ b/spec/support/pages/duplicate_appointments.rb
@@ -1,0 +1,7 @@
+module Pages
+  class DuplicateAppointments < Base
+    set_url '/appointments/{id}/duplicates'
+
+    elements :duplicates, '.t-duplicate'
+  end
+end


### PR DESCRIPTION
Moves the duplicates off the edit screen and into a separate page for
easier viewing by an agent.