### PR TITLE
Format common fields when displaying changes

### DIFF
--- a/app/presenters/audit_presenter.rb
+++ b/app/presenters/audit_presenter.rb
@@ -18,10 +18,28 @@ class AuditPresenter < SimpleDelegator
       after = value.last.to_s
 
       memo[field] = {
-        before: before.empty? ? '-' : before.humanize,
-        after: after.empty? ? '-' : after.humanize
+        before: before.empty? ? '-' : formatted_value(key, before),
+        after: after.empty? ? '-' : formatted_value(key, after)
       }
     end
+  end
+
+  def formatted_value(key, value)
+    formatter = "format_#{key}"
+
+    respond_to?(formatter) ? public_send(formatter, value) : value.humanize
+  end
+
+  def format_guider_id(value)
+    User.find(value).name
+  end
+
+  def format_agent_id(value)
+    User.find(value).name
+  end
+
+  def format_status(value)
+    Appointment.statuses.key(value.to_i)&.humanize
   end
 
   def self.wrap(objects)

--- a/spec/features/appointment_changes_spec.rb
+++ b/spec/features/appointment_changes_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Appointment audit trail' do
   scenario 'An agent changes an appointment and reviews the changes' do
     given_the_user_is_an_agent do
       and_there_is_an_appointment
-      when_they_change_the_name_on_the_appointment
+      when_they_change_the_appointment
       then_change_can_be_seen_in_an_audit_activity
       and_when_they_click_the_audit_activity
       then_they_are_on_the_changes_page
@@ -17,11 +17,12 @@ RSpec.feature 'Appointment audit trail' do
     @appointment = create(:appointment, first_name: @old_name)
   end
 
-  def when_they_change_the_name_on_the_appointment
+  def when_they_change_the_appointment
     @new_name = 'George'
     @edit_page = Pages::EditAppointment.new
     @edit_page.load(id: @appointment.id)
     @edit_page.first_name.set @new_name
+    @edit_page.status.select('Incomplete')
     @edit_page.submit.click
   end
 
@@ -40,8 +41,12 @@ RSpec.feature 'Appointment audit trail' do
   end
 
   def and_they_can_see_the_change_details
-    expect(@changes_page.changes_table.change_row).to have_text('First name')
-    expect(@changes_page.changes_table.change_row).to have_text(@old_name)
-    expect(@changes_page.changes_table.change_row).to have_text(@new_name)
+    expect(@changes_page.changes_table.change_rows.first).to have_text('First name')
+    expect(@changes_page.changes_table.change_rows.first).to have_text(@old_name)
+    expect(@changes_page.changes_table.change_rows.first).to have_text(@new_name)
+
+    expect(@changes_page.changes_table.change_rows.last).to have_text('Status')
+    expect(@changes_page.changes_table.change_rows.last).to have_text('Pending')
+    expect(@changes_page.changes_table.change_rows.last).to have_text('Incomplete')
   end
 end

--- a/spec/support/pages/appointment_changes.rb
+++ b/spec/support/pages/appointment_changes.rb
@@ -3,7 +3,7 @@ module Pages
     set_url '/appointments/{id}/changes'
 
     section :changes_table, '.t-changes-table' do
-      element :change_row, '.t-change-row'
+      elements :change_rows, '.t-change-row'
     end
   end
 end


### PR DESCRIPTION
If a formatter exists for a given key we can use this to format the
value presented to the user. For example, a guider ID of 1 becomes the
actual guider's name. Similarly the agent and also the status ordinal.