### PR TITLE
Stop a race when placing appointments via the API

### DIFF
--- a/db/migrate/20210311122614_add_unique_check_for_appointments.rb
+++ b/db/migrate/20210311122614_add_unique_check_for_appointments.rb
@@ -1,0 +1,14 @@
+class AddUniqueCheckForAppointments < ActiveRecord::Migration[6.0]
+  def up
+    execute <<-SQL
+      CREATE UNIQUE INDEX unique_slot_guider_in_appointment ON appointments (guider_id, start_at)
+      WHERE status NOT IN (6, 7, 8);
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      DROP INDEX IF EXISTS unique_slot_guider_in_appointment;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_23_123516) do
+ActiveRecord::Schema.define(version: 2021_03_11_122614) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -101,6 +101,7 @@ ActiveRecord::Schema.define(version: 2021_02_23_123516) do
     t.boolean "email_consent_form_required", default: false, null: false
     t.string "email_consent", default: "", null: false
     t.date "data_subject_date_of_birth"
+    t.index ["guider_id", "start_at"], name: "unique_slot_guider_in_appointment", unique: true, where: "(status <> ALL (ARRAY[6, 7, 8]))"
     t.index ["start_at"], name: "index_appointments_on_start_at"
   end
 

--- a/spec/features/guider_views_their_activities_spec.rb
+++ b/spec/features/guider_views_their_activities_spec.rb
@@ -26,7 +26,10 @@ RSpec.feature 'Guider views their activities' do
   end
 
   def and_they_have_some_appointments
-    @appointments = create_list(:appointment, 2, guider: guider)
+    @appointments = [
+      create(:appointment, start_at: 2.hours.from_now, guider: guider),
+      create(:appointment, start_at: 3.hours.from_now, guider: guider)
+    ]
   end
 
   def and_they_have_no_appointments

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -66,8 +66,8 @@ RSpec.describe 'Activity notification alerts', js: true do
 end
 
 def and_they_have_an_appointment
-  start_at     = BusinessDays.from_now(10).change(hour: 9)
-  @appointment = create(:appointment, start_at: start_at, guider: guider, agent: agent)
+  start_at = BusinessDays.from_now(10).change(hour: 9)
+  @appointment ||= create(:appointment, start_at: start_at, guider: guider, agent: agent)
 end
 
 def when_they_are_on_their_dashboard
@@ -105,7 +105,7 @@ def then_they_can_see_no_high_priority_alerts_message
 end
 
 def then_they_can_see_the_high_priority_activity
-  expect(@page.activity_feed.high_priority_activities).to be_visible
+  expect(@page.activity_feed.high_priority_activities).to be_present
 end
 
 def and_when_they_resolve_the_high_priority_activity
@@ -113,5 +113,5 @@ def and_when_they_resolve_the_high_priority_activity
 end
 
 def then_the_high_priority_activity_is_resolved
-  expect(@page.activity_feed.high_priority_activities).to have_content('Resolved Successfully')
+  expect(@page.activity_feed.high_priority_activities.first).to have_content('Resolved Successfully')
 end

--- a/spec/features/resource_manager_modifies_appointments_spec.rb
+++ b/spec/features/resource_manager_modifies_appointments_spec.rb
@@ -185,8 +185,8 @@ RSpec.feature 'Resource manager modifies appointments' do
     @ben = create(:guider, name: 'Ben Lovell')
     @jan = create(:guider, name: 'Jan Schwifty')
 
-    @appointment = create(:appointment, guider: @ben)
-    @other_appointment = create(:appointment, guider: @jan)
+    @appointment = create(:appointment, guider: @ben, start_at: '2021-03-11 09:00'.to_time.in_time_zone)
+    @other_appointment = create(:appointment, guider: @jan, start_at: '2021-03-11 09:30'.to_time.in_time_zone)
   end
 
   def then_they_see_the_holiday_for_one_guider

--- a/spec/forms/api/v1/appointment_spec.rb
+++ b/spec/forms/api/v1/appointment_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Appointment, '#create' do
+  it 'does not allow duplicate bookings' do
+    @slot = create(:bookable_slot, start_at: 2.days.from_now.middle_of_day)
+
+    @attributes = {
+      start_at: @slot.start_at,
+      first_name: 'Daisy',
+      last_name: 'George',
+      email: 'daisy@example.com',
+      phone: '0208 252 4768',
+      memorable_word: 'spaceships',
+      date_of_birth: '1970-01-01',
+      dc_pot_confirmed: true,
+      where_you_heard: 1,
+      gdpr_consent: 'yes',
+      accessibility_requirements: false,
+      notes: '',
+      agent: create(:agent),
+      smarter_signposted: false
+    }
+
+    @first  = described_class.new(@attributes)
+    @second = described_class.new(@attributes)
+
+    expect do
+      first  = Thread.new { @first.create }
+      second = Thread.new { @second.create }
+
+      first.join
+      second.join
+    end.to raise_error(ActiveRecord::RecordNotUnique)
+  end
+end

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -50,7 +50,7 @@ module Pages
       element :further_activities, '.t-further-activities'
       element :audit_activity, '.t-audit-activity'
       element :hidden_activity, '.t-hidden-activity'
-      element :high_priority_activities, '.t-high-priority-activity'
+      elements :high_priority_activities, '.t-high-priority-activity'
       element :resolved_activities, '.t-resolved-activity'
       element :unresolved_activities, '.t-unresolved-activity'
       element :resolve_activity_button, '.t-resolve-activity'


### PR DESCRIPTION
If two customers contend for the same slot within the same second it can
cause a race between the allocation of the slot and the creation of the
appointment. This is especially common when a slot is the earliest
available in the current booking window, thus heavily contended.