### PR TITLE
Allow agents to book Lloyds signposted referrals

### DIFF
--- a/app/assets/javascripts/modules/calendars/appointment-availability.es6
+++ b/app/assets/javascripts/modules/calendars/appointment-availability.es6
@@ -34,12 +34,30 @@
 
       this.init();
       this.displayErrorBorder();
+      this.bindSubscriptions();
     }
 
     init() {
       this.$selectedStart = $('.js-selected-start');
       this.$selectedEnd = $('.js-selected-end');
       this.selectedEventColour = 'green';
+    }
+
+    bindSubscriptions() {
+      $.subscribe('lloyds-availability-selected', this.handleAvailabilityFilter.bind(this));
+    }
+
+    handleAvailabilityFilter(e, selected) {
+      this.$el.fullCalendar('removeEventSources');
+
+      if (selected) {
+        this.$el.fullCalendar('addEventSource', this.$el.data('lloyds-slots-path'));
+      }
+      else {
+        this.$el.fullCalendar('addEventSource', this.$el.data('available-slots-path'));
+      }
+
+      this.$el.fullCalendar('refetchEvents');
     }
 
     eventClick(event, jsEvent) {

--- a/app/assets/javascripts/modules/calendars/appointment-availability.es6
+++ b/app/assets/javascripts/modules/calendars/appointment-availability.es6
@@ -4,12 +4,14 @@
 
   class AppointmentAvailabilityCalendar extends Calendar {
     start(el) {
+      let lloydsSignposted = !!$('.js-lloyds-signposted').prop('checked');
+
       this.config = {
         defaultView: 'agendaWeek',
         columnFormat: 'ddd D/M',
         slotDuration: '00:30:00',
         eventBorderColor: '#000',
-        events: el.data('available-slots-path'),
+        events: this.getEventsUrl(lloydsSignposted, el),
         defaultDate: moment(el.data('default-date')),
         header: {
           'right': 'agendaDay agendaThreeDay agendaWeek today jumpToDate prev,next'
@@ -41,6 +43,15 @@
       this.$selectedStart = $('.js-selected-start');
       this.$selectedEnd = $('.js-selected-end');
       this.selectedEventColour = 'green';
+    }
+
+    getEventsUrl(signposted, el) {
+      if(signposted) {
+        return el.data('lloyds-slots-path');
+      }
+      else {
+        return el.data('available-slots-path');
+      }
     }
 
     bindSubscriptions() {

--- a/app/assets/javascripts/modules/lloyds-signposter.es6
+++ b/app/assets/javascripts/modules/lloyds-signposter.es6
@@ -1,0 +1,22 @@
+/* global TapBase */
+{
+  'use strict';
+
+  class LloydsSignposter extends TapBase {
+    start(el) {
+      super.start(el);
+
+      this.init();
+    }
+
+    init() {
+      this.$el.on('change', this.handleChange.bind(this));
+    }
+
+    handleChange() {
+      $.publish('lloyds-availability-selected', !!this.$el.prop('checked'));
+    }
+  }
+
+  window.GOVUKAdmin.Modules.LloydsSignposter = LloydsSignposter;
+}

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -192,7 +192,8 @@ class AppointmentsController < ApplicationController
       :consent_postcode,
       :power_of_attorney_evidence,
       :data_subject_consent_evidence,
-      :email_consent
+      :email_consent,
+      :lloyds_signposted
     ]
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/controllers/bookable_slots_controller.rb
+++ b/app/controllers/bookable_slots_controller.rb
@@ -13,6 +13,15 @@ class BookableSlotsController < ApplicationController
     )
   end
 
+  def lloyds
+    render json: BookableSlot.with_guider_count(
+      current_user,
+      Time.zone.parse(params[:start]),
+      Time.zone.parse(params[:end]),
+      lloyds: true
+    )
+  end
+
   def scoped_to_me?
     params.key?(:mine)
   end

--- a/app/controllers/bookable_slots_controller.rb
+++ b/app/controllers/bookable_slots_controller.rb
@@ -7,7 +7,7 @@ class BookableSlotsController < ApplicationController
 
   def available
     render json: BookableSlot.with_guider_count(
-      current_user,
+      filtered_user,
       Time.zone.parse(params[:start]),
       Time.zone.parse(params[:end])
     )
@@ -15,10 +15,10 @@ class BookableSlotsController < ApplicationController
 
   def lloyds
     render json: BookableSlot.with_guider_count(
-      current_user,
+      filtered_user,
       Time.zone.parse(params[:start]),
       Time.zone.parse(params[:end]),
-      lloyds: true
+      lloyds: !rescheduling?
     )
   end
 
@@ -27,6 +27,17 @@ class BookableSlotsController < ApplicationController
   end
 
   private
+
+  def rescheduling?
+    params[:rescheduling] == 'true'
+  end
+
+  def filtered_user
+    return current_user unless rescheduling?
+
+    appointment = Appointment.find(params[:id])
+    appointment.guider
+  end
 
   def bookable_slots
     slots = BookableSlot

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -38,6 +38,7 @@ class Appointment < ApplicationRecord
     email_consent_form_required
     email_consent
     generated_consent_form
+    lloyds_signposted
   ).freeze
 
   enum status: %i(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,6 +68,12 @@ class User < ApplicationRecord
     tp? && agent?
   end
 
+  def lloyds_signposter?
+    return true if tp_agent? || administrator?
+
+    Provider.lloyds_providers.map(&:id).include?(organisation_content_id)
+  end
+
   def organisation
     Provider.find(organisation_content_id)&.name
   end

--- a/app/views/appointments/_availability_calendar.html.erb
+++ b/app/views/appointments/_availability_calendar.html.erb
@@ -4,11 +4,17 @@
 <% end %>
 
 <%= render 'shared/nojs' %>
+
+<% if current_user.lloyds_signposter? %>
+  <%= form.check_box :lloyds_signposted, label: 'Lloyds Banking Group referral?', class: 't-lloyds-signposted', data: { module: 'lloyds-signposter' } %>
+<% end %>
+
 <div
   id="AppointmentAvailabilityCalendar"
   class="appointment-availability-calendar"
   data-module="appointment-availability-calendar"
   data-available-slots-path="<%= available_bookable_slots_path %>"
+  data-lloyds-slots-path="<%= lloyds_bookable_slots_path %>"
   data-default-date="<%= BookableSlot.next_valid_start_date(current_user) %>"
 ></div>
 <%= form.hidden_field :start_at, class: 't-start-at js-selected-start' %>

--- a/app/views/appointments/_availability_calendar.html.erb
+++ b/app/views/appointments/_availability_calendar.html.erb
@@ -6,7 +6,7 @@
 <%= render 'shared/nojs' %>
 
 <% if current_user.lloyds_signposter? %>
-  <%= form.check_box :lloyds_signposted, label: 'Lloyds Banking Group referral?', class: 't-lloyds-signposted', data: { module: 'lloyds-signposter' } %>
+  <%= form.check_box :lloyds_signposted, label: 'Lloyds Banking Group referral?', class: 't-lloyds-signposted js-lloyds-signposted', data: { module: 'lloyds-signposter' } %>
 <% end %>
 
 <div

--- a/app/views/appointments/_availability_calendar.html.erb
+++ b/app/views/appointments/_availability_calendar.html.erb
@@ -6,15 +6,15 @@
 <%= render 'shared/nojs' %>
 
 <% if current_user.lloyds_signposter? %>
-  <%= form.check_box :lloyds_signposted, label: 'Lloyds Banking Group referral?', class: 't-lloyds-signposted js-lloyds-signposted', data: { module: 'lloyds-signposter' } %>
+  <%= form.check_box :lloyds_signposted, label: 'Lloyds Banking Group referral?', class: 't-lloyds-signposted js-lloyds-signposted', disabled: rescheduling, data: { module: 'lloyds-signposter' } %>
 <% end %>
 
 <div
   id="AppointmentAvailabilityCalendar"
   class="appointment-availability-calendar"
   data-module="appointment-availability-calendar"
-  data-available-slots-path="<%= available_bookable_slots_path %>"
-  data-lloyds-slots-path="<%= lloyds_bookable_slots_path %>"
+  data-available-slots-path="<%= available_bookable_slots_path(rescheduling: rescheduling, id: @appointment.id) %>"
+  data-lloyds-slots-path="<%= lloyds_bookable_slots_path(rescheduling: rescheduling, id: @appointment.id) %>"
   data-default-date="<%= BookableSlot.next_valid_start_date(current_user) %>"
 ></div>
 <%= form.hidden_field :start_at, class: 't-start-at js-selected-start' %>

--- a/app/views/appointments/_schedule_form.html.erb
+++ b/app/views/appointments/_schedule_form.html.erb
@@ -33,10 +33,10 @@
       </div>
     </div>
     <div id="availability-calendar-on">
-      <%= render 'availability_calendar', form: form %>
+      <%= render 'availability_calendar', form: form, rescheduling: rescheduling %>
     </div>
   <% else %>
     <%= hidden_field_tag :scheduled, true %>
-    <%= render 'availability_calendar', form: form %>
+    <%= render 'availability_calendar', form: form, rescheduling: rescheduling %>
   <% end %>
 </div>

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -19,7 +19,7 @@
   <hr>
 
   <div class="row form-group">
-    <%= render 'schedule_form', form: f %>
+    <%= render 'schedule_form', form: f, rescheduling: false %>
   </div>
 
   <div class="row form-group">

--- a/app/views/appointments/preview.html.erb
+++ b/app/views/appointments/preview.html.erb
@@ -40,6 +40,7 @@
   <%= f.hidden_field :county %>
   <%= f.hidden_field :postcode %>
   <%= f.hidden_field :smarter_signposted %>
+  <%= f.hidden_field :lloyds_signposted %>
   <%= f.hidden_field :bsl_video %>
 
   <%= f.hidden_field :data_subject_name %>
@@ -163,6 +164,12 @@
             <tr>
               <td class="active"><b>Smarter signposted referral?</b></td>
               <td><%= @appointment.smarter_signposted? ? 'Yes' : 'No' %></td>
+            </tr>
+            <% end %>
+            <% if current_user.lloyds_signposter? %>
+            <tr>
+              <td class="active"><b>Lloyds Banking Group referral?</b></td>
+              <td><%= @appointment.lloyds_signposted? ? 'Yes' : 'No' %></td>
             </tr>
             <% end %>
           </tbody>

--- a/app/views/appointments/reschedule.html.erb
+++ b/app/views/appointments/reschedule.html.erb
@@ -9,7 +9,7 @@
 <%= render 'shared/required_fields_note' %>
 <%= form_for [@appointment], url: appointment_update_reschedule_path(@appointment), layout: :basic do |f| %>
   <div class="row form-group">
-    <%= render 'schedule_form', form: f %>
+    <%= render 'schedule_form', form: f, rescheduling: true %>
   </div>
   <div class="row form-group">
     <div class="col-md-12">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,7 +66,10 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     get 'merged', on: :collection
   end
   resources :bookable_slots, only: :index do
-    get 'available', on: :collection
+    collection do
+      get 'available'
+      get 'lloyds'
+    end
   end
 
   resources :groups, only: %i(index destroy)

--- a/spec/features/agent_manages_appointments_spec.rb
+++ b/spec/features/agent_manages_appointments_spec.rb
@@ -14,6 +14,8 @@ RSpec.feature 'Agent manages appointments' do
         then_they_see_all_availability
         when_they_choose_lloyds
         then_they_see_lloyds_availability
+        when_they_submit_with_errors
+        then_they_see_lloyds_availability
       end
     end
   end
@@ -207,6 +209,14 @@ RSpec.feature 'Agent manages appointments' do
       when_they_edit_the_appointment
       then_they_see_that_the_appointment_was_imported
     end
+  end
+
+  def when_they_submit_with_errors
+    @page.date_of_birth_day.set '23'
+    @page.date_of_birth_month.set '10'
+    @page.date_of_birth_year.set '1930'
+
+    @page.preview_appointment.click
   end
 
   def and_slots_exist_for_lloyds

--- a/spec/support/pages/new_appointment.rb
+++ b/spec/support/pages/new_appointment.rb
@@ -46,11 +46,14 @@ module Pages
     element :postcode, '.t-postcode'
     element :smarter_signposted, '.t-smarter-signposted'
     element :bsl_video, '.t-bsl-video'
+    element :lloyds_signposted, '.t-lloyds-signposted'
 
     element :availability_calendar_off, '.t-availability-calendar-off'
     element :availability_calendar_on, '.t-availability-calendar-on'
     element :guider, '.t-guider'
     element :ad_hoc_start_at, '.t-ad-hoc-start-at'
+
+    elements :calendar_events, '.fc-event'
 
     def ad_hoc_start_at(value)
       execute_script("$('.t-ad-hoc-start-at').val('#{value}')")


### PR DESCRIPTION
Grants the permitted users the rights to refer an appointment from the
LLoyds Banking Group. Selecting the option will filter the availability
down to the correctly enrolled guiders/providers. Placing an appointment
flags for Lloyds as per the customer bookings.