### PR TITLE
Reposition now redundant options

### DIFF
--- a/app/lib/where_you_heard.rb
+++ b/app/lib/where_you_heard.rb
@@ -1,10 +1,6 @@
 class WhereYouHeard
   OPTIONS = {
     '0'  => 'Unspecified',
-    '19' => 'Media - Pensions Awareness Day',
-    '20' => 'Media - Leaving planning retirement finances to two years before retirement',
-    '21' => 'Money and Pensions Service Webinar on Pensions Awareness Day website',
-    '22' => 'Virtual 121 sessions on Pensions Awareness Day website',
     '1'  => 'An employer',
     '2'  => 'A Pension Provider',
     '3'  => 'Internet search',
@@ -22,6 +18,10 @@ class WhereYouHeard
     '15' => 'Citizens Advice',
     '16' => 'Relative/Friend/Colleague',
     '18' => 'Jobcentre Plus',
+    '19' => 'Media - Pensions Awareness Day',
+    '20' => 'Media - Leaving planning retirement finances to two years before retirement',
+    '21' => 'Money and Pensions Service Webinar on Pensions Awareness Day website',
+    '22' => 'Virtual 121 sessions on Pensions Awareness Day website',
     '17' => 'Other'
   }.freeze
 


### PR DESCRIPTION
Moves these options down the order so they are still visible for
existing appointments but less prominent for new appointments.