### PR TITLE
Only apply uniqueness after cut-off

### DIFF
--- a/db/migrate/20210421133500_add_date_criterion_to_unique_appointments_check.rb
+++ b/db/migrate/20210421133500_add_date_criterion_to_unique_appointments_check.rb
@@ -1,0 +1,16 @@
+class AddDateCriterionToUniqueAppointmentsCheck < ActiveRecord::Migration[6.0]
+  def up
+    execute <<-SQL
+      DROP INDEX IF EXISTS unique_slot_guider_in_appointment;
+
+      CREATE UNIQUE INDEX unique_slot_guider_in_appointment ON appointments (guider_id, start_at)
+      WHERE status NOT IN (6, 7, 8) and start_at > '2021-04-21 00:00';
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      DROP INDEX IF EXISTS unique_slot_guider_in_appointment;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_24_144158) do
+ActiveRecord::Schema.define(version: 2021_04_21_133500) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
 
@@ -81,8 +82,8 @@ ActiveRecord::Schema.define(version: 2021_03_24_144158) do
     t.datetime "batch_processed_at"
     t.datetime "rescheduled_at"
     t.string "gdpr_consent", default: "", null: false
-    t.string "pension_provider", default: "", null: false
     t.boolean "accessibility_requirements", default: false, null: false
+    t.string "pension_provider", default: "", null: false
     t.datetime "processed_at"
     t.boolean "smarter_signposted", default: false
     t.boolean "bsl_video", default: false, null: false
@@ -102,7 +103,7 @@ ActiveRecord::Schema.define(version: 2021_03_24_144158) do
     t.string "email_consent", default: "", null: false
     t.date "data_subject_date_of_birth"
     t.boolean "lloyds_signposted", default: false, null: false
-    t.index ["guider_id", "start_at"], name: "unique_slot_guider_in_appointment", unique: true, where: "(status <> ALL (ARRAY[6, 7, 8]))"
+    t.index ["guider_id", "start_at"], name: "unique_slot_guider_in_appointment", unique: true, where: "((status <> ALL (ARRAY[6, 7, 8])) AND (start_at > '2021-04-21 00:00:00'::timestamp without time zone))"
     t.index ["start_at"], name: "index_appointments_on_start_at"
   end
 
@@ -220,8 +221,6 @@ ActiveRecord::Schema.define(version: 2021_03_24_144158) do
     t.jsonb "permissions", default: "[]"
     t.integer "position", default: 0, null: false
     t.boolean "active", default: true, null: false
-    t.integer "casebook_guider_id"
-    t.integer "casebook_location_id"
     t.index ["permissions"], name: "index_users_on_permissions", using: :gin
   end
 

--- a/spec/forms/api/v1/appointment_spec.rb
+++ b/spec/forms/api/v1/appointment_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::Appointment, '#create' do
   it 'does not allow duplicate bookings' do
-    skip 'This seems to be time-dependent and needs addressing separately'
-
     @slot = create(:bookable_slot, start_at: 2.days.from_now.middle_of_day)
 
     @attributes = {


### PR DESCRIPTION
Allows preexisting 'duplicate' appointments to exist before today. Any
newly created 'duplicate' appointments will be disallowed in future.