### PR TITLE
Send to CAS alias when necessary

### DIFF
--- a/app/jobs/adjustment_notifications_job.rb
+++ b/app/jobs/adjustment_notifications_job.rb
@@ -12,6 +12,8 @@ class AdjustmentNotificationsJob < ApplicationJob
   def recipients_for(appointment)
     if appointment.tpas_guider?
       Array('supervisors@maps.org.uk')
+    elsif appointment.cas_guider?
+      CAS_RECIPIENTS
     else
       appointment.resource_managers.pluck(:email)
     end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,3 @@
 class ApplicationJob < ActiveJob::Base
+  CAS_RECIPIENTS = Array('CAS_PWBooking@cas.org.uk').freeze
 end

--- a/app/jobs/appointment_cancelled_notifications_job.rb
+++ b/app/jobs/appointment_cancelled_notifications_job.rb
@@ -15,6 +15,8 @@ class AppointmentCancelledNotificationsJob < ApplicationJob
   private
 
   def recipients_for(appointment)
+    return CAS_RECIPIENTS if appointment.cas_guider?
+
     appointment.resource_managers.pluck(:email)
   end
 end

--- a/app/jobs/appointment_rescheduled_notifications_job.rb
+++ b/app/jobs/appointment_rescheduled_notifications_job.rb
@@ -15,6 +15,8 @@ class AppointmentRescheduledNotificationsJob < ApplicationJob
   private
 
   def recipients_for(appointment)
+    return CAS_RECIPIENTS if appointment.cas_guider?
+
     appointment.resource_managers.pluck(:email)
   end
 end

--- a/spec/jobs/adjustment_notifications_job_spec.rb
+++ b/spec/jobs/adjustment_notifications_job_spec.rb
@@ -1,11 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe AdjustmentNotificationsJob, '#perform' do
-  context 'when the guider is TPAS' do
-    it 'sends to the supervisors mailbox' do
-      resource_manager = 'test@example.org.uk'
-      appointment = double(:appointment, tpas_guider?: false)
-      allow(appointment).to receive_message_chain(:resource_managers, :pluck).and_return([resource_manager])
+  context 'when the guider is CAS' do
+    it 'sends to their alias' do
+      resource_manager = 'CAS_PWBooking@cas.org.uk'
+      appointment      = double(:appointment, cas_guider?: true, tpas_guider?: false)
 
       expect(AppointmentMailer).to receive(:adjustment)
         .with(appointment, resource_manager)
@@ -16,7 +15,21 @@ RSpec.describe AdjustmentNotificationsJob, '#perform' do
   end
 
   context 'when the guider is not TPAS' do
-    it 'sends a notification email to associated resource managers' do
+    it 'sends to the associated resource managers' do
+      resource_manager = 'test@example.org.uk'
+      appointment = double(:appointment, tpas_guider?: false, cas_guider?: false)
+      allow(appointment).to receive_message_chain(:resource_managers, :pluck).and_return([resource_manager])
+
+      expect(AppointmentMailer).to receive(:adjustment)
+        .with(appointment, resource_manager)
+        .and_return(double(deliver_later: true))
+
+      subject.perform(appointment)
+    end
+  end
+
+  context 'when the guider is TPAS' do
+    it 'sends to the configured alias' do
       resource_manager = 'supervisors@maps.org.uk'
       appointment      = double(:appointment, tpas_guider?: true)
 

--- a/spec/jobs/appointment_cancelled_notifications_job_spec.rb
+++ b/spec/jobs/appointment_cancelled_notifications_job_spec.rb
@@ -1,6 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe AppointmentCancelledNotificationsJob do
+  context 'when the guider is from CAS' do
+    it 'sends to the alias' do
+      appointment = create(:appointment, organisation: :cas)
+
+      expect(AppointmentMailer).to receive(:resource_manager_appointment_cancelled)
+        .with(appointment, 'CAS_PWBooking@cas.org.uk')
+        .and_return(double(deliver_later: true))
+
+      subject.perform(appointment)
+    end
+  end
+
   context 'when the guider is from TPAS' do
     it 'does nothing' do
       appointment = create(:appointment, organisation: :tpas)

--- a/spec/jobs/appointment_rescheduled_notifications_job_spec.rb
+++ b/spec/jobs/appointment_rescheduled_notifications_job_spec.rb
@@ -1,6 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe AppointmentRescheduledNotificationsJob do
+  context 'when the guider is from CAS' do
+    it 'sends to the alias' do
+      appointment = create(:appointment, organisation: :cas)
+
+      expect(AppointmentMailer).to receive(:resource_manager_appointment_rescheduled)
+        .with(appointment, 'CAS_PWBooking@cas.org.uk')
+        .and_return(double(deliver_later: true))
+
+      subject.perform(appointment)
+    end
+  end
+
   context 'when the guider is from TPAS' do
     it 'does nothing' do
       appointment = create(:appointment, organisation: :tpas)


### PR DESCRIPTION
Rather than send to individual resource managers, we can send these
email notifications to the given CAS alias.