### PR TITLE
Default `lloyds_signposted` to false

### DIFF
--- a/app/forms/api/v1/appointment.rb
+++ b/app/forms/api/v1/appointment.rb
@@ -53,7 +53,7 @@ module Api
           pension_provider: 'n/a',
           agent: agent,
           smarter_signposted: smarter_signposted,
-          lloyds_signposted: lloyds_signposted
+          lloyds_signposted: lloyds_signposted || false
         }
       end
     end

--- a/spec/forms/api/v1/appointment_spec.rb
+++ b/spec/forms/api/v1/appointment_spec.rb
@@ -33,4 +33,10 @@ RSpec.describe Api::V1::Appointment, '#create' do
       second.join
     end.to raise_error(ActiveRecord::RecordNotUnique)
   end
+
+  it 'defaults `lloyds_signposted` to false when not provided' do
+    appointment = described_class.new({})
+
+    expect(appointment.model.lloyds_signposted).to be(false)
+  end
 end


### PR DESCRIPTION
There was an issue where incompatible versions did not function
correctly.