### PR TITLE
Ensure reschedules respect grace period override

### DIFF
--- a/app/controllers/bookable_slots_controller.rb
+++ b/app/controllers/bookable_slots_controller.rb
@@ -33,7 +33,7 @@ class BookableSlotsController < ApplicationController
   end
 
   def filtered_user
-    return current_user unless rescheduling?
+    return current_user unless rescheduling? && current_user.tp?
 
     appointment = Appointment.find(params[:id])
     appointment.guider

--- a/spec/features/resource_manager_reschedules_an_appointment_spec.rb
+++ b/spec/features/resource_manager_reschedules_an_appointment_spec.rb
@@ -25,6 +25,28 @@ RSpec.feature 'Resource manager reschedules an appointment', js: true do
     end
   end
 
+  scenario 'Rescheduling calendar respects resource manager grace period reduction' do
+    given_the_user_is_a_resource_manager do
+      travel_to '2021-05-11 13:00 UTC' do
+        and_there_is_an_appointment
+        and_there_are_available_slots_tomorrow
+        when_they_attempt_to_reschedule_the_appointment
+        then_they_see_the_available_slots_tomorrow
+      end
+    end
+  end
+
+  def and_there_are_available_slots_tomorrow
+    create(:bookable_slot, guider: @appointment.guider, start_at: Time.zone.parse('2021-05-12 09:00'))
+  end
+
+  def then_they_see_the_available_slots_tomorrow
+    @page.wait_until_slots_visible
+
+    expect(@page).to have_slots(count: 1)
+    expect(@page.slots.first).to have_text('09:00')
+  end
+
   def and_there_is_an_appointment
     @appointment = create(:appointment)
   end

--- a/spec/support/pages/reschedule_appointment.rb
+++ b/spec/support/pages/reschedule_appointment.rb
@@ -10,6 +10,7 @@ module Pages
     element :availability_calendar_on, '.t-availability-calendar-on'
     element :guider, '.t-guider'
     element :ad_hoc_start_at, '.t-ad-hoc-start-at'
+    elements :slots, '.fc-time-grid-event'
 
     def ad_hoc_start_at(value)
       execute_script("$('.t-ad-hoc-start-at').val('#{value}')")


### PR DESCRIPTION
Resource managers should be able to book appointments earlier than the
grace period and a recent change introduced a regression that this will
fix.