### PR TITLE
Exclude secondary statuses from tracking

### DIFF
--- a/app/assets/javascripts/modules/form-change-monitor.es6
+++ b/app/assets/javascripts/modules/form-change-monitor.es6
@@ -8,7 +8,7 @@
 
       this.initialFormFingerprint = '';
       this.formElements = this.$el.find(
-        'input:not([type=hidden]), select, textarea'
+        'input:not([type=hidden]), select:not([data-no-tracking=true]), textarea'
       );
       this.setInitialFormFingerprint();
       this.bindEvents();

--- a/app/views/appointments/_personal_details_form.html.erb
+++ b/app/views/appointments/_personal_details_form.html.erb
@@ -167,7 +167,7 @@
           { class: 't-status', data: { module: 'secondary-status', options: Appointment::SECONDARY_STATUSES.to_json, 'initial-secondary-status' => @appointment.secondary_status } }
         )
       %>
-      <%= f.select(:secondary_status, [], {}, { class: 't-secondary-status js-secondary-status' }) %>
+    <%= f.select(:secondary_status, [], {}, { class: 't-secondary-status js-secondary-status', data: { 'no-tracking' => true }}) %>
     <% end %>
 
   </div>

--- a/spec/features/resource_manager_modifies_appointments_spec.rb
+++ b/spec/features/resource_manager_modifies_appointments_spec.rb
@@ -14,6 +14,14 @@ RSpec.feature 'Resource manager modifies appointments' do
     end
   end
 
+  scenario 'Do not track changes to secondary statuses', js: true do
+    given_the_user_is_a_resource_manager do
+      and_there_is_an_appointment
+      when_they_edit_the_appointment_secondary_status
+      then_they_can_navigate_away_without_warning
+    end
+  end
+
   scenario 'Reassigning the chosen guider alerts both guiders', js: true do
     # create the guiders and appointments up front
     when_there_are_appointments_for_multiple_guiders
@@ -107,6 +115,23 @@ RSpec.feature 'Resource manager modifies appointments' do
         then_they_can_see_the_bookable_slot
       end
     end
+  end
+
+  def and_there_is_an_appointment
+    @appointment = create(:appointment, status: :cancelled_by_customer, secondary_status: '15')
+  end
+
+  def when_they_edit_the_appointment_secondary_status
+    @page = Pages::EditAppointment.new
+    @page.load(id: @appointment.id)
+
+    @page.secondary_status.select('Customer forgot')
+  end
+
+  def then_they_can_navigate_away_without_warning
+    @page.click_on('Appointment search')
+
+    expect(@page).to be_displayed
   end
 
   def and_there_is_a_holiday_for_one_guider


### PR DESCRIPTION
These were triggering the change notifications incorrectly due to how
they are bound upon load.