### PR TITLE
Ensure slots are correctly allocated

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -27,11 +27,12 @@ class AppointmentsController < ApplicationController
     @appointment.end_at = nil
   end
 
-  def update_reschedule # rubocop:disable AbcSize
+  def update_reschedule # rubocop:disable AbcSize, MethodLength
     @appointment = Appointment.find(params[:appointment_id])
+    @prior_guider = @appointment.guider
     @appointment.assign_attributes(update_reschedule_params)
     @appointment.mark_rescheduled!
-    @appointment.allocate(via_slot: calendar_scheduling?, agent: current_user)
+    @appointment.allocate(via_slot: calendar_scheduling?, agent: @prior_guider)
 
     if @appointment.save
       Notifier.new(@appointment, current_user).call

--- a/spec/models/bookable_slot_spec.rb
+++ b/spec/models/bookable_slot_spec.rb
@@ -19,6 +19,22 @@ RSpec.describe BookableSlot, type: :model do
     build_stubbed(:guider)
   end
 
+  describe '.find_available_slot' do
+    it 'returns a slot for the correct organisation' do
+      start_at = Time.zone.parse('2021-05-26 13:00')
+
+      %i(tp cas ni wallsend lancs_west).each do |provider|
+        create(:bookable_slot, provider, start_at: start_at)
+      end
+
+      @expected = create(:bookable_slot, :derbyshire_districts, start_at: start_at)
+
+      @allocated = BookableSlot.find_available_slot(start_at, @expected.guider)
+
+      expect(@allocated).to eq(@expected)
+    end
+  end
+
   describe '#next_valid_start_date' do
     context 'user is a guider / agent' do
       context 'outside of a bank holiday period' do


### PR DESCRIPTION
Ensures slots are allocated correctly for rescheduling. This will be
revisited shortly and tidied up but for now this fixes the underlying
issue.