### PR TITLE
Ensure LBGPTL appointments have valid guiders

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -148,6 +148,7 @@ class Appointment < ApplicationRecord
   validate :validate_mobile_digits, if: :tp_agent?
   validate :email_consent_valid, if: :email_consent_form_required?
   validate :validate_secondary_status
+  validate :validate_lloyds_signposted_guider_allocated, if: :lloyds_signposted?, on: :create
 
   before_validation :format_name, on: :create
   before_create :track_initial_status
@@ -531,6 +532,10 @@ class Appointment < ApplicationRecord
     agent && !agent.pension_wise_api?
   end
 
+  def cita?
+    guider&.cita?
+  end
+
   def validate_adjustment_needs?
     date = created_at || Time.zone.today
 
@@ -602,6 +607,10 @@ class Appointment < ApplicationRecord
         errors.add(:secondary_status, "Contact centre agents should only select 'Cancelled prior to appointment'")
       end
     end
+  end
+
+  def validate_lloyds_signposted_guider_allocated
+    errors.add(:guider, 'The guider is not from an LBGPTL schedule') unless cita?
   end
 
   class << self

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,6 +64,10 @@ class User < ApplicationRecord
     organisation_content_id == Provider::LANCS_WEST.id
   end
 
+  def cita?
+    Provider.lloyds_providers.map(&:id).include?(organisation_content_id)
+  end
+
   def tp_agent?
     tp? && agent?
   end
@@ -71,7 +75,7 @@ class User < ApplicationRecord
   def lloyds_signposter?
     return true if tp_agent? || administrator?
 
-    Provider.lloyds_providers.map(&:id).include?(organisation_content_id)
+    cita?
   end
 
   def organisation

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -227,6 +227,21 @@ RSpec.describe Appointment, type: :model do
       build_stubbed(:appointment)
     end
 
+    context 'when the appointment is marked for LBGPTL' do
+      let(:subject) { build(:appointment) }
+
+      it 'only permits CITA guiders' do
+        subject.lloyds_signposted = true
+        subject.guider = build_stubbed(:guider, :tpas)
+
+        expect(subject).to be_invalid
+
+        subject.guider = build_stubbed(:guider, :waltham_forest)
+
+        expect(subject).to be_valid
+      end
+    end
+
     context 'when the status would require a secondary status' do
       before { subject.created_at = Time.current }
 

--- a/spec/requests/appointments_api_spec.rb
+++ b/spec/requests/appointments_api_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'POST /api/v1/appointments' do
   end
 
   def and_a_bookable_slot_exists_for_the_given_appointment_date
-    @bookable_slot = create(:bookable_slot, start_at: Time.zone.parse('2017-01-13 12:10'))
+    @bookable_slot = create(:bookable_slot, :wallsend, start_at: Time.zone.parse('2017-01-13 12:10'))
   end
 
   def and_a_resource_manager_exists


### PR DESCRIPTION
This validation will ensure upon creation that an appointment flagged
for LBGPTL can never be allocated to guiders outside of the CITA
organisations.