### PR TITLE
Begin switch to webdrivers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: ruby
 addons:
   postgresql: '9.4'
+  chrome: stable
 services:
 - redis-server
 - postgresql

--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,6 @@ source 'https://rubygems.org' do
     gem 'pry-byebug'
     gem 'pusher-fake'
     gem 'rspec-rails'
-    gem 'rspec-retry'
     gem 'rubocop', '0.46.0'
     gem 'site_prism'
     gem 'thin'

--- a/Gemfile
+++ b/Gemfile
@@ -76,8 +76,10 @@ source 'https://rubygems.org' do
     gem 'chronic'
     gem 'coveralls', require: false
     gem 'database_rewinder'
-    gem 'poltergeist', '1.11.0'
+    gem 'poltergeist'
     gem 'scss_lint', require: false
+    gem 'selenium-webdriver'
+    gem 'webdrivers'
     gem 'webmock'
     gem 'webrick'
   end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -403,8 +403,6 @@ GEM
       rspec-expectations (~> 3.9)
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
-    rspec-retry (0.6.1)
-      rspec-core (> 3.3)
     rspec-support (3.9.2)
     rubocop (0.46.0)
       parser (>= 2.3.1.1, < 3.0)
@@ -568,7 +566,6 @@ DEPENDENCIES
   rails-assets-qTip2!
   rails-assets-zloirock--core-js (= 2.5.1)!
   rspec-rails!
-  rspec-retry!
   rubocop (= 0.46.0)!
   sassc-rails!
   scss_lint!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,15 +120,17 @@ GEM
     byebug (11.0.1)
     capitalize-names (1.0.6)
       activesupport (>= 3)
-    capybara (2.18.0)
+    capybara (3.29.0)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
     case_transform (0.2)
       activesupport
+    childprocess (4.1.0)
     chronic (0.10.2)
     cliver (0.3.2)
     coderay (1.1.2)
@@ -241,8 +243,8 @@ GEM
     mimemagic (0.3.10)
       nokogiri (~> 1)
       rake
-    mini_mime (1.0.2)
-    mini_portile2 (2.5.0)
+    mini_mime (1.1.2)
+    mini_portile2 (2.6.1)
     minitest (5.14.2)
     msgpack (1.3.3)
     multi_json (1.15.0)
@@ -254,8 +256,8 @@ GEM
     net-ssh (5.2.0)
     newrelic_rpm (6.15.0)
     nio4r (2.5.8)
-    nokogiri (1.11.1)
-      mini_portile2 (~> 2.5.0)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     notifications-ruby-client (5.1.1)
       jwt (>= 1.5, < 3)
@@ -283,8 +285,8 @@ GEM
     pg (1.2.3)
     phantomjs (2.1.1.0)
     plek (2.1.1)
-    poltergeist (1.11.0)
-      capybara (~> 2.1)
+    poltergeist (1.18.1)
+      capybara (>= 2.1, < 4)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
     postgres-copy (1.4.1)
@@ -312,7 +314,7 @@ GEM
       multi_json (~> 1.6)
       thin (~> 1.5)
     pusher-signature (0.1.8)
-    racc (1.5.2)
+    racc (1.6.0)
     rack (2.2.3)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
@@ -378,11 +380,13 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     redis (4.4.0)
+    regexp_parser (1.8.2)
     request_store (1.4.1)
       rack (>= 1.4)
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rexml (3.2.5)
     rspec-core (3.9.1)
       rspec-support (~> 3.9.1)
     rspec-expectations (3.9.1)
@@ -409,6 +413,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.10.0)
+    rubyzip (2.3.2)
     safe_yaml (1.0.5)
     sass (3.7.3)
       sass-listen (~> 4.0.0)
@@ -429,6 +434,10 @@ GEM
       sass (~> 3.5, >= 3.5.5)
     select2-rails (4.0.3)
       thor (~> 0.14)
+    selenium-webdriver (4.0.3)
+      childprocess (>= 0.5, < 5.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2)
     sidekiq (6.2.1)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
@@ -481,12 +490,16 @@ GEM
       rack (>= 2.0.6)
     warden-oauth2 (0.0.1)
       warden
+    webdrivers (5.0.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0)
     webmock (3.8.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.4.2)
-    websocket-driver (0.7.3)
+    websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     working_hours (1.1.4)
@@ -535,7 +548,7 @@ DEPENDENCIES
   pg!
   phantomjs!
   plek!
-  poltergeist (= 1.11.0)!
+  poltergeist!
   postgres-copy!
   princely!
   pry-byebug!
@@ -560,6 +573,7 @@ DEPENDENCIES
   sassc-rails!
   scss_lint!
   select2-rails!
+  selenium-webdriver!
   sidekiq!
   sinatra!
   site_prism!
@@ -567,6 +581,7 @@ DEPENDENCIES
   sprockets-es6!
   thin!
   uglifier (>= 1.3.0)!
+  webdrivers!
   webmock!
   webrick!
   working_hours!

--- a/spec/features/guider_views_appointments_spec.rb
+++ b/spec/features/guider_views_appointments_spec.rb
@@ -43,7 +43,9 @@ RSpec.feature 'Guider views appointments' do
     end
   end
 
-  scenario 'Guider views their own appointments and is notified of appointment changes', js: true do
+  scenario 'Guider views their own appointments and is notified of appointment changes',
+           js: true,
+           driver: :poltergeist do
     given_the_requisite_data
 
     travel_to @appointment.start_at do

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Activity notification alerts', js: true do
     create(:guider)
   end
 
-  scenario 'A new high priority activity occurs' do
+  scenario 'A new high priority activity occurs', driver: :poltergeist do
     given_a_browser_session_for(guider, agent) do
       when_they_are_on_their_dashboard
     end

--- a/spec/features/resource_manager_manages_guiders_spec.rb
+++ b/spec/features/resource_manager_manages_guiders_spec.rb
@@ -56,7 +56,9 @@ RSpec.feature 'Resource manager manages guiders' do
   end
 
   def when_they_remove_a_group
-    @page.groups.first.remove.click
+    accept_confirm do
+      @page.groups.first.remove.click
+    end
   end
 
   def then_the_group_is_unassigned_from_those_guiders
@@ -81,7 +83,7 @@ RSpec.feature 'Resource manager manages guiders' do
 
   def when_they_create_a_new_group
     # simulate the select.js behaviour correctly
-    @page.group.send_keys(%i(t r a i n e e s enter))
+    @page.group.send_keys('TRAINEES', :enter)
     # wait until the new group / tag is selected
     @page.wait_until_chosen_group_visible
 

--- a/spec/features/resource_manager_manages_holidays_spec.rb
+++ b/spec/features/resource_manager_manages_holidays_spec.rb
@@ -90,7 +90,7 @@ RSpec.feature 'Resource manager manages holidays' do
     end
   end
 
-  scenario 'Deletes a holiday', js: true, retry: 3 do
+  scenario 'Deletes a holiday', js: true, retry: 3, driver: :poltergeist do
     given_the_user_is_a_resource_manager do
       travel_to today do
         and_there_are_guiders_with_multiple_day_holidays

--- a/spec/features/resource_manager_manages_holidays_spec.rb
+++ b/spec/features/resource_manager_manages_holidays_spec.rb
@@ -79,7 +79,7 @@ RSpec.feature 'Resource manager manages holidays' do
     end
   end
 
-  scenario 'Views holidays', js: true, retry: 3 do
+  scenario 'Views holidays', js: true do
     given_the_user_is_a_resource_manager do
       travel_to today do
         and_there_are_some_holidays
@@ -90,7 +90,7 @@ RSpec.feature 'Resource manager manages holidays' do
     end
   end
 
-  scenario 'Deletes a holiday', js: true, retry: 3, driver: :poltergeist do
+  scenario 'Deletes a holiday', js: true, driver: :poltergeist do
     given_the_user_is_a_resource_manager do
       travel_to today do
         and_there_are_guiders_with_multiple_day_holidays

--- a/spec/features/resource_manager_manages_schedules_spec.rb
+++ b/spec/features/resource_manager_manages_schedules_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Resource manager manages schedules' do
     allow(GenerateBookableSlotsForUserJob).to receive(:perform_later)
   end
 
-  scenario 'Successfully adds a new schedule', js: true do
+  scenario 'Successfully adds a new schedule', js: true, driver: :poltergeist do
     given_the_user_is_a_resource_manager do
       and_there_is_a_guider
       and_they_add_a_new_schedule
@@ -18,7 +18,7 @@ RSpec.feature 'Resource manager manages schedules' do
     end
   end
 
-  scenario 'Successfully updates a schedule', js: true do
+  scenario 'Successfully updates a schedule', js: true, driver: :poltergeist do
     given_the_user_is_a_resource_manager do
       and_there_is_a_guider
       and_the_guider_has_a_schedule_that_can_be_modified
@@ -53,7 +53,7 @@ RSpec.feature 'Resource manager manages schedules' do
     end
   end
 
-  scenario 'Adds a mid shift schedule', js: true do
+  scenario 'Adds a mid shift schedule', js: true, driver: :poltergeist do
     given_the_user_is_a_resource_manager do
       and_there_is_a_guider
       and_they_add_a_new_schedule

--- a/spec/features/resource_manager_modifies_appointments_spec.rb
+++ b/spec/features/resource_manager_modifies_appointments_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'Resource manager modifies appointments' do
     end
   end
 
-  scenario 'Reassigning the chosen guider alerts both guiders', js: true, driver: :poltergeist, retry: 3 do
+  scenario 'Reassigning the chosen guider alerts both guiders', js: true, driver: :poltergeist do
     # create the guiders and appointments up front
     when_there_are_appointments_for_multiple_guiders
 
@@ -86,7 +86,7 @@ RSpec.feature 'Resource manager modifies appointments' do
     end
   end
 
-  scenario 'Viewing holidays for all guiders', js: true, retry: 3 do
+  scenario 'Viewing holidays for all guiders', js: true do
     given_the_user_is_a_resource_manager do
       and_there_is_a_holiday_for_all_guiders
       travel_to @holiday.start_at do
@@ -96,7 +96,7 @@ RSpec.feature 'Resource manager modifies appointments' do
     end
   end
 
-  scenario 'Creating a holiday for one guider', js: true, retry: 3, driver: :poltergeist do
+  scenario 'Creating a holiday for one guider', js: true, driver: :poltergeist do
     given_the_user_is_a_resource_manager do
       travel_to BusinessDays.from_now(1) do
         and_there_is_a_guider

--- a/spec/features/resource_manager_modifies_appointments_spec.rb
+++ b/spec/features/resource_manager_modifies_appointments_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'Resource manager modifies appointments' do
     end
   end
 
-  scenario 'Reassigning the chosen guider alerts both guiders', js: true do
+  scenario 'Reassigning the chosen guider alerts both guiders', js: true, driver: :poltergeist do
     # create the guiders and appointments up front
     when_there_are_appointments_for_multiple_guiders
 
@@ -96,7 +96,7 @@ RSpec.feature 'Resource manager modifies appointments' do
     end
   end
 
-  scenario 'Creating a holiday for one guider', js: true, retry: 3 do
+  scenario 'Creating a holiday for one guider', js: true, retry: 3, driver: :poltergeist do
     given_the_user_is_a_resource_manager do
       travel_to BusinessDays.from_now(1) do
         and_there_is_a_guider
@@ -270,7 +270,7 @@ RSpec.feature 'Resource manager modifies appointments' do
   end
 
   def and_click_a_link_while_dismissing_the_warning
-    dismiss_confirm('You have unsaved changes - Save, or undo the changes.') do
+    dismiss_confirm do
       @page.find('.navbar-brand').click
     end
   end
@@ -297,8 +297,8 @@ RSpec.feature 'Resource manager modifies appointments' do
     holiday = @page.calendar.holidays.first
     expect(holiday[:resourceId]).to eq @guider.id
     expect(holiday[:title]).to eq 'Holiday Title'
-    expect(holiday[:start]).to eq "#{date}T09:00:00.000Z"
-    expect(holiday[:end]).to eq "#{date}T09:10:00.000Z"
+    expect(holiday[:start][:_i]).to eq "#{date}T09:00:00.000Z"
+    expect(holiday[:end][:_i]).to eq "#{date}T09:10:00.000Z"
 
     expect(Holiday.count).to eq 1
   end

--- a/spec/features/resource_manager_modifies_appointments_spec.rb
+++ b/spec/features/resource_manager_modifies_appointments_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'Resource manager modifies appointments' do
     end
   end
 
-  scenario 'Reassigning the chosen guider alerts both guiders', js: true, driver: :poltergeist do
+  scenario 'Reassigning the chosen guider alerts both guiders', js: true, driver: :poltergeist, retry: 3 do
     # create the guiders and appointments up front
     when_there_are_appointments_for_multiple_guiders
 

--- a/spec/features/resource_manager_modifies_appointments_spec.rb
+++ b/spec/features/resource_manager_modifies_appointments_spec.rb
@@ -47,6 +47,8 @@ RSpec.feature 'Resource manager modifies appointments' do
     given_a_browser_session_for(@ben, @jan) do
       then_they_are_notified_of_the_change
     end
+
+    wait_for_ajax_to_complete
   end
 
   scenario 'Rescheduling an appointment notifies the guider and customer', js: true do
@@ -301,5 +303,11 @@ RSpec.feature 'Resource manager modifies appointments' do
     expect(holiday[:end][:_i]).to eq "#{date}T09:10:00.000Z"
 
     expect(Holiday.count).to eq 1
+  end
+
+  def wait_for_ajax_to_complete
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      loop until page.evaluate_script('jQuery.active').zero?
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,4 +35,5 @@ RSpec.configure do |config|
   config.include ActionView::Helpers::DateHelper
 
   config.before(:each) { ActionMailer::Base.deliveries.clear }
+  config.after(:each) { GDS::SSO.test_user = nil }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-require 'rspec/retry'
-
 RSpec.configure do |config|
   config.order = :random
 
@@ -12,7 +10,4 @@ RSpec.configure do |config|
   end
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
-
-  config.verbose_retry = true
-  config.display_try_failure_messages = true
 end

--- a/spec/support/chrome.rb
+++ b/spec/support/chrome.rb
@@ -1,0 +1,20 @@
+require 'capybara'
+require 'selenium/webdriver'
+require 'webdrivers/chromedriver'
+
+Capybara.register_driver :chrome_headless do |app|
+  browser_options = ::Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+    opts.args << '--window-size=2500,2500'
+    opts.args << '--force-device-scale-factor=0.95'
+    opts.args << '--headless'
+    opts.args << '--disable-gpu'
+    opts.args << '--disable-site-isolation-trials'
+    opts.args << '--no-sandbox'
+  end
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: browser_options)
+end
+
+Capybara.default_max_wait_time = 10 if ENV['TRAVIS']
+Capybara.server = :puma, { Silent: true }
+Capybara.javascript_driver = :chrome_headless

--- a/spec/support/poltergeist.rb
+++ b/spec/support/poltergeist.rb
@@ -10,6 +10,3 @@ Capybara.register_driver :poltergeist do |app|
     phantomjs: Phantomjs.path
   )
 end
-
-Capybara.javascript_driver = :poltergeist
-Capybara.default_max_wait_time = 10 if ENV['TRAVIS']

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -12,7 +12,7 @@ module UserHelpers
     GDS::SSO.test_user
   end
 
-  def given_a_browser_session_for(*users) # rubocop:disable Metrics/MethodLength
+  def given_a_browser_session_for(*users)
     users.each do |user|
       begin
         existing_session      = Capybara.session_name
@@ -22,7 +22,6 @@ module UserHelpers
         yield
       ensure
         Capybara.session_name = existing_session
-        GDS::SSO.test_user    = nil
       end
     end
   end
@@ -30,8 +29,6 @@ module UserHelpers
   def given_the_user(type, organisation = :tpas)
     GDS::SSO.test_user = create(type, organisation)
     yield
-  ensure
-    GDS::SSO.test_user = nil
   end
 
   def given_the_user_is_a_business_analyst(&block)

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,3 +1,6 @@
 require 'webmock/rspec'
 
-WebMock.disable_net_connect!(allow_localhost: true)
+WebMock.disable_net_connect!(
+  allow_localhost: true,
+  allow: 'chromedriver.storage.googleapis.com'
+)

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -2,5 +2,6 @@ require 'webmock/rspec'
 
 WebMock.disable_net_connect!(
   allow_localhost: true,
-  allow: 'chromedriver.storage.googleapis.com'
+  allow: 'chromedriver.storage.googleapis.com',
+  net_http_connect_on_start: true # workaround "socket(2) too many open files"
 )


### PR DESCRIPTION
PhantomJS has been dead for a long time and for various reasons we were
still pinned to old versions of the supporting testing libraries. This
change begins the migration towards chrome-driver instead. Some of the
specs are still tagged with the poltergeist driver, these can be
resolved as time goes by.