### PR TITLE
Add small pots option for TPAS users

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -205,7 +205,8 @@ class AppointmentsController < ApplicationController
       :email_consent,
       :lloyds_signposted,
       :schedule_type,
-      :referrer
+      :referrer,
+      :small_pots
     ]
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -128,6 +128,7 @@ class Appointment < ApplicationRecord
   validates :dc_pot_confirmed, inclusion: [true, false]
   validates :accessibility_requirements, inclusion: [true, false]
   validates :third_party_booking, inclusion: [true, false]
+  validates :small_pots, inclusion: [true, false]
   validates :data_subject_name, presence: true, if: :third_party_booking?
   validates :data_subject_date_of_birth, presence: true, if: :require_data_subject_date_of_birth?
   validates :notes, presence: true, if: :validate_adjustment_needs?

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -44,6 +44,7 @@ class Appointment < ApplicationRecord
     lloyds_signposted
     unique_reference_number
     referrer
+    small_pots
   ).freeze
 
   enum status: %i(

--- a/app/views/appointments/_personal_details_form.html.erb
+++ b/app/views/appointments/_personal_details_form.html.erb
@@ -156,6 +156,10 @@
      <%= f.check_box :bsl_video, class: 't-bsl-video', label: 'BSL video appointment?', disabled: bsl_video_disabled?(current_user) %>
     <% end %>
 
+    <% if current_user.tpas? && @appointment.pension_wise? %>
+      <%= f.check_box :small_pots, class: 't-small-pots', label: 'Small pots appointment?' %>
+    <% end %>
+
     <% if (current_user.tpas? || current_user.administrator?) && !@appointment.due_diligence? %>
       <%= f.check_box :smarter_signposted, class: 't-smarter-signposted', label: 'Smarter signposting referral?' %>
     <% end %>

--- a/app/views/appointments/preview.html.erb
+++ b/app/views/appointments/preview.html.erb
@@ -44,6 +44,7 @@
   <%= f.hidden_field :bsl_video %>
   <%= f.hidden_field :schedule_type %>
   <%= f.hidden_field :referrer %>
+  <%= f.hidden_field :small_pots %>
 
   <%= f.hidden_field :data_subject_name %>
   <%= f.hidden_field :data_subject_date_of_birth %>
@@ -173,6 +174,12 @@
               <tr>
                 <td class="active"><b>Lloyds Banking Group referral?</b></td>
                 <td><%= @appointment.lloyds_signposted? ? 'Yes' : 'No' %></td>
+              </tr>
+              <% end %>
+              <% if @appointment.small_pots? %>
+              <tr>
+                <td class="active"><b>Small pots appointment?</b></td>
+                <td><%= @appointment.small_pots? ? 'Yes' : 'No' %></td>
               </tr>
               <% end %>
             <% end %>

--- a/db/migrate/20211123180605_add_small_pots_to_appointments.rb
+++ b/db/migrate/20211123180605_add_small_pots_to_appointments.rb
@@ -1,0 +1,5 @@
+class AddSmallPotsToAppointments < ActiveRecord::Migration[6.0]
+  def change
+    add_column :appointments, :small_pots, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_03_165658) do
+ActiveRecord::Schema.define(version: 2021_11_23_180605) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -106,6 +106,7 @@ ActiveRecord::Schema.define(version: 2021_11_03_165658) do
     t.string "schedule_type", default: "pension_wise", null: false
     t.string "unique_reference_number", default: "", null: false
     t.string "referrer", default: "", null: false
+    t.boolean "small_pots", default: false, null: false
     t.index ["guider_id", "start_at"], name: "unique_slot_guider_in_appointment", unique: true, where: "((status <> ALL (ARRAY[6, 7, 8])) AND (start_at > '2021-04-21 00:00:00'::timestamp without time zone))"
     t.index ["guider_id"], name: "index_appointments_on_guider_id"
     t.index ["start_at", "end_at", "guider_id"], name: "index_appointments_on_start_at_and_end_at_and_guider_id"

--- a/spec/features/booking_due_diligence_appointments_spec.rb
+++ b/spec/features/booking_due_diligence_appointments_spec.rb
@@ -143,6 +143,7 @@ RSpec.feature 'Booking due diligence appointments', js: true do
     expect(@page).to have_no_gdpr_consent_yes
     expect(@page).to have_no_gdpr_consent_no
     expect(@page).to have_no_gdpr_consent_no_response
+    expect(@page).to have_no_small_pots
     expect(@page).to have_text('Postal address')
     expect(@page).to_not have_text('Confirmation address')
 

--- a/spec/support/pages/new_appointment.rb
+++ b/spec/support/pages/new_appointment.rb
@@ -49,6 +49,7 @@ module Pages
     element :smarter_signposted, '.t-smarter-signposted'
     element :bsl_video, '.t-bsl-video'
     element :lloyds_signposted, '.t-lloyds-signposted'
+    element :small_pots, '.t-small-pots'
 
     element :availability_calendar_off, '.t-availability-calendar-off'
     element :availability_calendar_on, '.t-availability-calendar-on'


### PR DESCRIPTION
TPAS users can specify a small pots appointment option otherwise it
defaults to false. This cannot be specified in combination with due
diligence appointments.