### PR TITLE
Differentiate completed PSG appointments

### DIFF
--- a/app/assets/stylesheets/components/_calendars.scss
+++ b/app/assets/stylesheets/components/_calendars.scss
@@ -225,6 +225,10 @@ $guider-row-height: 120px;
 .fc-event--due-diligence {
   @include striped($calendar-appointment-due-diligence-background);
   z-index: 3;
+
+  &.fc--past {
+    @include striped(lighten($calendar-appointment-due-diligence-background, 20%));
+  }
 };
 
 .fc--past {


### PR DESCRIPTION
Lightens and stripes PSG appointments with the same shade of purple that
would usually apply to future appointments, to make them more easily
differentiated in the various calendar views.