### PR TITLE
Provide postcode as an address line

### DIFF
--- a/app/presenters/printed_third_party_consent_form_presenter.rb
+++ b/app/presenters/printed_third_party_consent_form_presenter.rb
@@ -14,7 +14,7 @@ class PrintedThirdPartyConsentFormPresenter
       address_line_4: appointment.consent_address_line_three,
       address_line_5: appointment.consent_town,
       address_line_6: appointment.consent_county,
-      postcode: appointment.consent_postcode
+      address_line_7: appointment.consent_postcode
     }
   end
 

--- a/spec/jobs/printed_third_party_consent_form_job_spec.rb
+++ b/spec/jobs/printed_third_party_consent_form_job_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe PrintedThirdPartyConsentFormJob, '#perform' do
           address_line_4: 'Somewhere',
           address_line_5: 'Some Town',
           address_line_6: 'Some County',
-          postcode: 'SS1 1SS'
+          address_line_7: 'SS1 1SS'
         }
       )
 


### PR DESCRIPTION
Notify recently altered their API and we now need to provide the
postcode data as an ordinal address line.