### PR TITLE
Display error banner upon update failures

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -48,6 +48,7 @@ class AppointmentsController < ApplicationController
       Notifier.new(@appointment, current_user).call
       redirect_to edit_appointment_path(@appointment), success: 'Appointment has been modified'
     else
+      flash[:danger] = 'The appointment has not been updated. Please correct the errors to continue.'
       render :edit
     end
   end

--- a/spec/features/agent_manages_appointments_spec.rb
+++ b/spec/features/agent_manages_appointments_spec.rb
@@ -5,6 +5,15 @@ RSpec.feature 'Agent manages appointments' do
 
   let(:day) { BusinessDays.from_now(5) }
 
+  scenario 'Attempting to update an appointment with invalid fields' do
+    given_the_user_is_a_resource_manager(organisation: :tpas) do
+      and_an_appointment_exists
+      when_they_edit_the_appointment
+      and_set_invalid_fields
+      then_they_see_an_error_banner
+    end
+  end
+
   scenario 'TPAS user viewing allocations calendar' do
     given_the_user_is_a_resource_manager(organisation: :tpas) do
       travel_to '2021-12-03 14:00' do
@@ -706,5 +715,18 @@ RSpec.feature 'Agent manages appointments' do
 
   def then_they_see_that_the_appointment_was_imported
     expect(@page).to have_appointment_was_imported_message
+  end
+
+  def and_an_appointment_exists
+    @appointment = create(:appointment)
+  end
+
+  def and_set_invalid_fields
+    @page.first_name.set ''
+    @page.submit.click
+  end
+
+  def then_they_see_an_error_banner
+    expect(@page).to have_flash_of_danger
   end
 end

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -3,6 +3,7 @@ module Pages
     set_url '/appointments/{id}/edit'
 
     element :flash_of_success,                      '.alert-success'
+    element :flash_of_danger,                       '.alert-danger'
     element :dc_pot_unsure_banner,                  '.t-dc-pot-unsure'
     element :appointment_was_imported_message,      '.t-appointment-was-imported-message'
     element :third_party_booked_banner,             '.t-third-party-booked'


### PR DESCRIPTION
This makes things much clearer to the agent when they've attempted to
update an appointment and the validation has failed. Especially when the
field with errors appears below the page fold.