### PR TITLE
Add further requested fields to blob exports

### DIFF
--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -1,7 +1,7 @@
 namespace :export do
   QUERIES = {
     'MAPS_PWBLZ_TAPAPPOINT_' => 'id, guider_id, start_at, end_at, status, agent_id, rebooked_from_id, pension_provider,
-                                 where_you_heard, gdpr_consent, created_at, updated_at',
+                                 where_you_heard, gdpr_consent, created_at, updated_at, schedule_type',
     'MAPS_PWBLZ_TAPBKSLT_'   => 'id, guider_id, start_at, end_at, created_at, updated_at',
     'MAPS_PWBLZ_TAPHLD_'     => 'id, user_id, start_at, end_at, created_at, updated_at',
     'MAPS_PWBLZ_TAPREPSUM_'  => 'id, organisation, two_week_availability, four_week_availability,


### PR DESCRIPTION
Adds the field to discriminate between Pension Wise and PSG appointments
for the reporting platform ingestion.