### PR TITLE
Notify resource managers by email on drops

### DIFF
--- a/app/forms/drop_form.rb
+++ b/app/forms/drop_form.rb
@@ -8,6 +8,7 @@ class DropForm
   IGNORED_MESSAGE_TYPES = %w(
     adjustment
     accessibility_adjustment
+    resource_manager_email_dropped
     resource_manager_appointment_created
     resource_manager_appointment_cancelled
     resource_manager_appointment_rescheduled
@@ -41,6 +42,8 @@ class DropForm
       message_type,
       appointment
     )
+
+    EmailDropNotificationsJob.perform_later(appointment)
   end
 
   private

--- a/app/jobs/email_drop_notifications_job.rb
+++ b/app/jobs/email_drop_notifications_job.rb
@@ -1,0 +1,15 @@
+class EmailDropNotificationsJob < ApplicationJob
+  queue_as :default
+
+  def perform(appointment)
+    recipients_for(appointment).each do |recipient|
+      AppointmentMailer.resource_manager_email_dropped(appointment, recipient).deliver_later
+    end
+  end
+
+  private
+
+  def recipients_for(appointment)
+    appointment.resource_managers.pluck(:email).without(appointment.email)
+  end
+end

--- a/app/mailers/appointment_mailer.rb
+++ b/app/mailers/appointment_mailer.rb
@@ -1,6 +1,12 @@
 class AppointmentMailer < ApplicationMailer
   default subject: -> { @appointment.subject }, from: -> { @appointment.from }
 
+  def resource_manager_email_dropped(appointment, recipient)
+    mailgun_headers('resource_manager_email_dropped', appointment.id)
+    @appointment = decorate(appointment)
+    mail to: recipient, subject: @appointment.subject('Email Failure')
+  end
+
   def resource_manager_appointment_rescheduled(appointment, recipient)
     mailgun_headers('resource_manager_appointment_rescheduled', appointment.id)
     @appointment = decorate(appointment)

--- a/app/views/appointment_mailer/resource_manager_email_dropped.html.erb
+++ b/app/views/appointment_mailer/resource_manager_email_dropped.html.erb
@@ -1,0 +1,15 @@
+<h1 style="color: #0F19A0 !important;font-family: Calibri, Arial, sans-serif;margin: 15px 0;font-weight: 700;font-size: 20px;line-height: 1.111111111;padding: 15px 0;">
+  The email to <%= mail_to @appointment.email, "#{@appointment.first_name} #{@appointment.last_name}" %> failed to deliver.
+</h1>
+
+<%= p do %>
+  Reference number:
+  <br>
+  <strong class="emphasize">
+    <%= @appointment.id %>
+  </strong>
+<% end %>
+
+<%= p do %>
+  <%= link_to 'View the appointment', edit_appointment_url(@appointment) %>
+<% end %>

--- a/app/views/appointment_mailer/resource_manager_email_dropped.text.erb
+++ b/app/views/appointment_mailer/resource_manager_email_dropped.text.erb
@@ -1,0 +1,6 @@
+The email to <%= @appointment.email %> failed to deliver.
+
+Reference number:
+<%= @appointment.id %>
+
+<%= edit_appointment_url(@appointment) %>

--- a/spec/forms/drop_form_spec.rb
+++ b/spec/forms/drop_form_spec.rb
@@ -71,13 +71,15 @@ RSpec.describe DropForm, '#create_activity' do
     end
 
     context 'when everything is validated' do
-      it 'creates the drop activity' do
+      it 'creates the drop activity and enqueues the notifications job' do
         expect(DropActivity).to receive(:from).with(
           params['event'],
           params['description'],
           params['message_type'],
           appointment
         )
+
+        expect(EmailDropNotificationsJob).to receive(:perform_later).with(appointment)
 
         subject.create_activity
       end

--- a/spec/jobs/email_drop_notifications_job_spec.rb
+++ b/spec/jobs/email_drop_notifications_job_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe EmailDropNotificationsJob, '#perform' do
+  context 'for a regular appointment' do
+    it 'sends notifications to the associated resource managers' do
+      resource_manager = 'dave@example.com'
+      appointment = double(:appointment, email: 'bob@example.com')
+      allow(appointment).to receive_message_chain(:resource_managers, :pluck).and_return([resource_manager])
+
+      expect(AppointmentMailer).to receive(:resource_manager_email_dropped)
+        .with(appointment, resource_manager)
+        .and_return(double(deliver_later: true))
+
+      subject.perform(appointment)
+    end
+  end
+
+  context 'for an appointment placed by a resource manager' do
+    it 'ensures an email loop is never created' do
+      resource_manager = 'dave@example.com'
+      appointment = double(:appointment, email: resource_manager)
+      allow(appointment).to receive_message_chain(:resource_managers, :pluck).and_return([resource_manager])
+
+      expect(AppointmentMailer).to_not receive(:resource_manager_email_dropped)
+
+      subject.perform(appointment)
+    end
+  end
+end

--- a/spec/mailers/appointment_mailer_spec.rb
+++ b/spec/mailers/appointment_mailer_spec.rb
@@ -83,6 +83,31 @@ RSpec.describe AppointmentMailer, type: :mailer do
     end
   end
 
+  describe 'Resource Manager Email Failure' do
+    let(:mailgun_headers) { JSON.parse(subject['X-Mailgun-Variables'].value) }
+    let(:appointment) { build_stubbed(:appointment) }
+    let(:body) { subject.body.encoded }
+
+    subject { described_class.resource_manager_email_dropped(appointment, 'dave@example.com') }
+
+    it 'renders the headers' do
+      expect(subject.to).to eq(['dave@example.com'])
+      expect(subject.subject).to eq('Pension Wise Email Failure')
+    end
+
+    it 'renders the mailgun specific headers' do
+      expect(mailgun_headers).to include(
+        'message_type'   => 'resource_manager_email_dropped',
+        'appointment_id' => appointment.id
+      )
+    end
+
+    it 'includes the body specifics' do
+      expect(body).to include(appointment.email)
+      expect(body).to match(%q(http://localhost:3001/appointments/\d+/edit))
+    end
+  end
+
   describe 'Resource Manager Appointment Rescheduled' do
     subject(:mail) { described_class.resource_manager_appointment_rescheduled(appointment, resource_manager) }
 

--- a/spec/mailers/previews/appointment_mailer_preview.rb
+++ b/spec/mailers/previews/appointment_mailer_preview.rb
@@ -1,5 +1,14 @@
 # Preview all emails at http://localhost:3000/rails/mailers/appointment_mailer
 class AppointmentMailerPreview < ActionMailer::Preview
+  def resource_manager_email_dropped
+    appointment = random_appointment
+
+    AppointmentMailer.resource_manager_email_dropped(
+      appointment,
+      appointment.resource_managers.first.email
+    )
+  end
+
   def resource_manager_appointment_created
     appointment = random_appointment
 


### PR DESCRIPTION
When customer emails are bounced/dropped we now notify resource managers
by email.