### PR TITLE
Improve slots API

### DIFF
--- a/app/controllers/api/v1/bookable_slots_controller.rb
+++ b/app/controllers/api/v1/bookable_slots_controller.rb
@@ -8,10 +8,14 @@ module Api
       end
 
       def index
-        render json: BookableSlot.grouped(filtered_provider_ids, schedule_type)
+        render json: BookableSlot.grouped(filtered_provider_ids, schedule_type, day)
       end
 
       private
+
+      def day
+        params[:day]
+      end
 
       def schedule_type
         @schedule_type = params.fetch(:schedule_type) { User::PENSION_WISE_SCHEDULE_TYPE }

--- a/spec/requests/bookable_slots_api_spec.rb
+++ b/spec/requests/bookable_slots_api_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe 'GET /api/v1/bookable_slots' do
     end
   end
 
+  scenario 'retrieving slots for a given day' do
+    travel_to '2017-01-09 12:00' do
+      given_bookable_slots_for_the_booking_window_exist
+      when_the_client_requests_bookable_slots_for_a_given_day
+      then_the_response_contains_unique_slots_for_the_given_day
+    end
+  end
+
   scenario 'retrieving DD slots for the booking window' do
     travel_to '2017-01-09 12:00' do
       given_bookable_slots_for_the_booking_window_exist
@@ -120,6 +128,20 @@ RSpec.describe 'GET /api/v1/bookable_slots' do
       expect(json['2017-01-16']).to eq(%w(2017-01-16T12:00:00.000Z 2017-01-16T15:00:00.000Z))
 
       expect(json.keys).to eq(%w(2017-01-13 2017-01-16 2017-02-27))
+    end
+  end
+
+  def when_the_client_requests_bookable_slots_for_a_given_day
+    get api_v1_bookable_slots_path(params: { day: '2017-01-16' }, as: :json)
+  end
+
+  def then_the_response_contains_unique_slots_for_the_given_day
+    expect(response).to be_ok
+
+    JSON.parse(response.body).tap do |json|
+      expect(json['2017-01-16']).to eq(%w(2017-01-16T12:00:00.000Z 2017-01-16T15:00:00.000Z))
+
+      expect(json.keys).to eq(%w(2017-01-16))
     end
   end
 end


### PR DESCRIPTION
Allows clients to specify a specific day for slots to limit the data
that is retrieved. By default we can just return the slots for the
window.