### PR TITLE
Add a tooltip to the calendar

### DIFF
--- a/app/assets/javascripts/modules/calendars/appointment-availability.es6
+++ b/app/assets/javascripts/modules/calendars/appointment-availability.es6
@@ -102,6 +102,7 @@
 
       // force the events to have hrefs to allow them to be focusable via tabbing
       element.attr('href', '#');
+      element.attr('title', `${event.start.format('HH:mm')} ${event.guiders} guider(s)`);
 
       element.html(`
         <span class="sr-only">${event.start.format('dddd, MMMM Do YYYY')}</span>


### PR DESCRIPTION
When booking availability is displayed the slots can be 'crushed' and
some information is lost. Adding a title will trigger a helpful hint
containing the time and number of total guiders. This particularly
affects TP agents as they see availability across all guiders.