### PR TITLE
Send an SMS customer exit poll when possible

### DIFF
--- a/app/jobs/bsl_customer_exit_poll_job.rb
+++ b/app/jobs/bsl_customer_exit_poll_job.rb
@@ -1,9 +1,30 @@
-class BslCustomerExitPollJob < ApplicationJob
+class BslCustomerExitPollJob < NotifyJobBase
+  BSL_EXIT_POLL_SMS_TEMPLATE_ID = 'ae1ad874-9626-4e8c-afe9-e3867aa43986'.freeze
+
   queue_as :default
 
   def perform(appointment)
-    AppointmentMailer.bsl_customer_exit_poll(appointment)
+    if appointment.mobile?
+      send_sms(appointment)
+    else
+      AppointmentMailer.bsl_customer_exit_poll(appointment)
+    end
 
     BslCustomerExitPollActivity.from(appointment)
+  end
+
+  private
+
+  def send_sms(appointment)
+    client = Notifications::Client.new(api_key(appointment.schedule_type))
+
+    client.send_sms(
+      phone_number: appointment.canonical_sms_number,
+      template_id: BSL_EXIT_POLL_SMS_TEMPLATE_ID,
+      reference: appointment.to_param,
+      personalisation: {
+        date: "#{appointment.start_at.to_s(:govuk_date_short)} (#{appointment.timezone})"
+      }
+    )
   end
 end

--- a/app/jobs/bsl_customer_exit_poll_job.rb
+++ b/app/jobs/bsl_customer_exit_poll_job.rb
@@ -4,11 +4,9 @@ class BslCustomerExitPollJob < NotifyJobBase
   queue_as :default
 
   def perform(appointment)
-    if appointment.mobile?
-      send_sms(appointment)
-    else
-      AppointmentMailer.bsl_customer_exit_poll(appointment)
-    end
+    send_sms(appointment) if appointment.mobile?
+
+    AppointmentMailer.bsl_customer_exit_poll(appointment) if appointment.email?
 
     BslCustomerExitPollActivity.from(appointment)
   end

--- a/app/views/activities/_bsl_customer_exit_poll_activity.html.erb
+++ b/app/views/activities/_bsl_customer_exit_poll_activity.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:activity_message, flush: true) do %>
   <span class="glyphicon glyphicon-envelope" aria-hidden="true"></span>
-  <strong>The system</strong> sent an exit poll email to <strong><%= bsl_customer_exit_poll_activity.appointment.name %></strong>
+  <strong>The system</strong> sent an exit poll to <strong><%= bsl_customer_exit_poll_activity.appointment.name %></strong>
 <% end %>
 <%= render 'activities/activity', activity: bsl_customer_exit_poll_activity, details: details, hide: hide %>

--- a/spec/jobs/bsl_customer_exit_poll_job_spec.rb
+++ b/spec/jobs/bsl_customer_exit_poll_job_spec.rb
@@ -1,12 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe BslCustomerExitPollJob, '#perform_now' do
-  it 'sends the exit poll email and logs an activity' do
-    appointment = build_stubbed(:appointment, bsl_video: true)
+  context 'when no mobile number is present' do
+    it 'sends the exit poll email and logs an activity' do
+      appointment = build_stubbed(:appointment, bsl_video: true, mobile: '')
 
-    expect(AppointmentMailer).to receive(:bsl_customer_exit_poll).with(appointment)
-    expect(BslCustomerExitPollActivity).to receive(:from).with(appointment)
+      expect(AppointmentMailer).to receive(:bsl_customer_exit_poll).with(appointment)
+      expect(BslCustomerExitPollActivity).to receive(:from).with(appointment)
 
-    described_class.perform_now(appointment)
+      described_class.perform_now(appointment)
+    end
+  end
+
+  context 'when a mobile number is present' do
+    it 'sends the exit poll SMS and logs an activity' do
+      appointment = create(:appointment, bsl_video: true, start_at: Time.zone.parse('2022-06-30 13:00 UTC'))
+
+      client = double(Notifications::Client, send_sms: true)
+      allow(Notifications::Client).to receive(:new).and_return(client)
+
+      expect(client).to receive(:send_sms).with(
+        phone_number: '07715 930 444',
+        template_id: BslCustomerExitPollJob::BSL_EXIT_POLL_SMS_TEMPLATE_ID,
+        reference: appointment.to_param,
+        personalisation: {
+          date: '1:00pm, 30 Jun 2022 (BST)'
+        }
+      )
+
+      described_class.perform_now(appointment)
+    end
   end
 end


### PR DESCRIPTION
For BSL customers an exit poll is sent 24 hours after their appointment
is marked completed. This change will send an SMS version of the exit
poll if a mobile number is present, otherwise it will fall back on the
email version of the exit poll.