### PR TITLE
Printed confirmations via Notify

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -119,6 +119,7 @@ class AppointmentsController < ApplicationController
   def send_notifications(appointment)
     AdjustmentNotificationsJob.perform_later(appointment) if appointment.adjustments?
     CustomerUpdateJob.perform_later(appointment, CustomerUpdateActivity::CONFIRMED_MESSAGE)
+    PrintedConfirmationJob.perform_later(appointment)
     AppointmentCreatedNotificationsJob.perform_later(appointment)
     PrintedThirdPartyConsentFormJob.perform_later(appointment)
     EmailThirdPartyConsentFormJob.perform_later(appointment)

--- a/app/jobs/printed_confirmation_job.rb
+++ b/app/jobs/printed_confirmation_job.rb
@@ -1,0 +1,26 @@
+class PrintedConfirmationJob < NotifyJobBase
+  TEMPLATE_ID = '0d35b423-5e0f-456b-a36b-699f951a3be3'.freeze
+  RESCHEDULE_TEMPLATE_ID = '343292a1-2158-450b-8e82-b9097150e5b2'.freeze
+
+  def perform(appointment)
+    return unless api_key(appointment.schedule_type) && appointment.print_confirmation?
+
+    personalisation = PrintedConfirmationPresenter.new(appointment).to_h
+
+    client = Notifications::Client.new(api_key(appointment.schedule_type))
+
+    client.send_letter(
+      template_id: template_id(appointment),
+      reference: appointment.to_param,
+      personalisation: personalisation
+    )
+
+    PrintedConfirmationActivity.from(appointment)
+  end
+
+  private
+
+  def template_id(appointment)
+    appointment.rescheduled_at? ? RESCHEDULE_TEMPLATE_ID : TEMPLATE_ID
+  end
+end

--- a/app/lib/notifier.rb
+++ b/app/lib/notifier.rb
@@ -1,4 +1,4 @@
-class Notifier
+class Notifier # rubocop:disable ClassLength
   NOTIFY_RESOURCE_MANAGER_ATTRIBUTES = %w(
     first_name
     last_name
@@ -57,6 +57,7 @@ class Notifier
     end
 
     DueDiligenceReferenceNumberJob.perform_now(appointment) if due_diligence_appointment_complete?
+    PrintedConfirmationJob.perform_later(appointment) if appointment_rescheduled?
     PrintedThirdPartyConsentFormJob.perform_later(appointment) if requires_printed_consent_form?
     EmailThirdPartyConsentFormJob.perform_later(appointment) if requires_email_consent_form?
     BslCustomerExitPollJob.set(wait: 24.hours).perform_later(appointment) if bsl_appointment_complete?

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -176,6 +176,10 @@ class Appointment < ApplicationRecord
     internal_availability.present? && internal_availability == '1'
   end
 
+  def print_confirmation?
+    address? && !email?
+  end
+
   def sms_confirmation?
     nudge_confirmation == 'sms'
   end

--- a/app/models/printed_confirmation_activity.rb
+++ b/app/models/printed_confirmation_activity.rb
@@ -1,0 +1,12 @@
+class PrintedConfirmationActivity < Activity
+  def self.from(appointment)
+    create!(
+      appointment_id: appointment.id,
+      message: appointment.rescheduled_at? ? 'rescheduled' : 'confirmation'
+    )
+  end
+
+  def owner_required?
+    false
+  end
+end

--- a/app/presenters/printed_confirmation_presenter.rb
+++ b/app/presenters/printed_confirmation_presenter.rb
@@ -1,0 +1,38 @@
+class PrintedConfirmationPresenter
+  def initialize(appointment)
+    @appointment = appointment
+  end
+
+  def to_h # rubocop:disable AbcSize, MethodLength
+    {
+      reference: appointment.to_param,
+      date: date,
+      time: time,
+      phone: appointment.phone,
+      memorable_word: appointment.memorable_word(obscure: true),
+      address_line_1: fullname,
+      address_line_2: appointment.address_line_one,
+      address_line_3: appointment.address_line_two,
+      address_line_4: appointment.address_line_three,
+      address_line_5: appointment.town,
+      address_line_6: appointment.county,
+      address_line_7: appointment.postcode
+    }
+  end
+
+  private
+
+  def fullname
+    "#{appointment.first_name} #{appointment.last_name}"
+  end
+
+  def date
+    appointment.start_at.to_date.to_s(:govuk_date)
+  end
+
+  def time
+    "#{appointment.start_at.to_time.to_s(:govuk_time)} #{appointment.timezone}" # rubocop:disable Rails/Date
+  end
+
+  attr_reader :appointment
+end

--- a/app/views/activities/_printed_confirmation_activity.html.erb
+++ b/app/views/activities/_printed_confirmation_activity.html.erb
@@ -1,0 +1,5 @@
+<% content_for(:activity_message, flush: true) do %>
+  <span class="glyphicon glyphicon-print" aria-hidden="true"></span>
+  <strong>The system</strong> sent a <%= printed_confirmation_activity.message %> letter
+<% end %>
+<%= render 'activities/activity', activity: printed_confirmation_activity, details: details, hide: hide %>

--- a/spec/features/agent_manages_appointments_spec.rb
+++ b/spec/features/agent_manages_appointments_spec.rb
@@ -200,6 +200,7 @@ RSpec.feature 'Agent manages appointments' do
       and_the_customer_gets_an_email_confirmation
       and_a_printed_consent_form_job_is_enqueued
       and_an_email_consent_form_job_is_enqueued
+      and_a_printed_confirmation_job_is_enqueued
     end
   end
 
@@ -566,6 +567,10 @@ RSpec.feature 'Agent manages appointments' do
 
   def and_a_printed_consent_form_job_is_enqueued
     assert_enqueued_jobs(1, only: PrintedThirdPartyConsentFormJob)
+  end
+
+  def and_a_printed_confirmation_job_is_enqueued
+    assert_enqueued_jobs(1, only: PrintedConfirmationJob)
   end
 
   def and_an_email_consent_form_job_is_enqueued

--- a/spec/jobs/printed_confirmation_job_spec.rb
+++ b/spec/jobs/printed_confirmation_job_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe PrintedConfirmationJob, '#perform' do
+  let(:appointment) { build_stubbed(:appointment) }
+  let(:client) { double(Notifications::Client, send_letter: true) }
+
+  context 'when an email is present' do
+    it 'does not send a letter' do
+      expect(client).to_not receive(:send_letter)
+
+      described_class.new.perform(appointment)
+    end
+  end
+
+  context 'when an address is present' do
+    let(:appointment) do
+      create(
+        :appointment,
+        :with_address,
+        first_name: 'Daisy',
+        last_name: 'George',
+        start_at: Time.zone.parse('2022-07-27 13:00')
+      )
+    end
+
+    it 'sends a letter' do
+      expect(client).to receive(:send_letter).with(
+        template_id: PrintedConfirmationJob::TEMPLATE_ID,
+        reference: appointment.to_param,
+        personalisation: {
+          reference: appointment.to_param,
+          date: '27 July 2022',
+          time: '1:00pm BST',
+          phone: '0208 252 4758',
+          memorable_word: 'l*****e',
+          address_line_1: 'Daisy George',
+          address_line_2: '10 Some Road',
+          address_line_3: 'Some Street',
+          address_line_4: 'Somewhere',
+          address_line_5: 'Some Town',
+          address_line_6: 'Some County',
+          address_line_7: 'E3 3NN'
+        }
+      )
+
+      described_class.new.perform(appointment)
+
+      expect(appointment.activities.first).to be_an(PrintedConfirmationActivity)
+    end
+
+    context 'when the appointment was rescheduled' do
+      it 'uses the rescheduling template ID instead' do
+        appointment.rescheduled_at = Time.current
+
+        expect(client).to receive(:send_letter).with(
+          hash_including(
+            template_id: PrintedConfirmationJob::RESCHEDULE_TEMPLATE_ID
+          )
+        )
+
+        described_class.new.perform(appointment)
+      end
+    end
+  end
+
+  before do
+    ENV['PENSION_WISE_NOTIFY_API_KEY'] = 'blahblah'
+
+    allow(Notifications::Client).to receive(:new).and_return(client)
+  end
+
+  after do
+    ENV.delete('PENSION_WISE_NOTIFY_API_KEY')
+  end
+end

--- a/spec/lib/notifier_spec.rb
+++ b/spec/lib/notifier_spec.rb
@@ -134,6 +134,16 @@ RSpec.describe Notifier, '#call' do
 
       subject.call
     end
+
+    context 'with a postal address' do
+      it 'enqueues a printed confirmation' do
+        appointment.update_attribute(:start_at, Time.zone.parse('2022-07-27 13:00'))
+
+        expect(PrintedConfirmationJob).to receive(:perform_later).with(appointment)
+
+        subject.call
+      end
+    end
   end
 
   context 'when the appointment is without an associated email' do


### PR DESCRIPTION
Adds print confirmations for new appointments and reschedules via
notify. This will ultimately replace the batch process for printing once
it's brought in-house.