### PR TITLE
Ensure allocation respects internal/external

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -73,9 +73,13 @@ class AppointmentsController < ApplicationController
     end
   end
 
-  def preview
+  def preview # rubocop:disable MethodLength
     @appointment = Appointment.new(create_params.merge(agent: current_user))
-    @appointment.allocate(via_slot: calendar_scheduling?, agent: current_user, scoped: true)
+    @appointment.allocate(
+      via_slot: calendar_scheduling?,
+      agent: current_user,
+      scoped: !@appointment.internal_availability?
+    )
 
     if @appointment.valid?
       render :preview
@@ -84,9 +88,13 @@ class AppointmentsController < ApplicationController
     end
   end
 
-  def create
+  def create # rubocop:disable AbcSize, MethodLength
     @appointment = Appointment.new(create_params.merge(agent: current_user))
-    @appointment.allocate(via_slot: calendar_scheduling?, agent: current_user, scoped: true)
+    @appointment.allocate(
+      via_slot: calendar_scheduling?,
+      agent: current_user,
+      scoped: !@appointment.internal_availability?
+    )
     @appointment.copy_attachments!
 
     if creating? && @appointment.save

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -172,6 +172,10 @@ class Appointment < ApplicationRecord
     CustomerUpdateJob.perform_later(self, CustomerUpdateActivity::CONFIRMED_MESSAGE)
   end
 
+  def internal_availability?
+    internal_availability.present? && internal_availability == '1'
+  end
+
   def sms_confirmation?
     nudge_confirmation == 'sms'
   end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -472,7 +472,9 @@ class Appointment < ApplicationRecord
   end
 
   def allocate_slot(agent, scoped)
-    slot = BookableSlot.find_available_slot(start_at, agent, schedule_type, scoped)
+    args = agent&.tpas_agent? && pension_wise? && scoped ? { external: true } : {}
+
+    slot = BookableSlot.find_available_slot(start_at, agent, schedule_type, scoped, **args)
     self.guider = nil
     return unless slot
 

--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -46,9 +46,9 @@ class BookableSlot < ApplicationRecord
     end
   end
 
-  def self.find_available_slot(start_at, agent, schedule_type = User::PENSION_WISE_SCHEDULE_TYPE, scoped = true)
+  def self.find_available_slot(start_at, agent, schedule_type = User::PENSION_WISE_SCHEDULE_TYPE, scoped = true, external: false) # rubocop:disable LineLength
     scope = bookable.where(start_at: start_at)
-    scope = scope.for_organisation(agent, scoped: scoped) if agent
+    scope = scope.for_organisation(agent, scoped: scoped, external: external) if agent
     scope = for_schedule_type(schedule_type: schedule_type, scope: scope)
 
     scope.limit(1).order('RANDOM()').first

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -120,7 +120,7 @@
       </thead>
       <tbody>
         <tr class="booking-details__row">
-          <td class="booking-details__item"><b class="visible-xs-block">Guider</b><span class="glyphicon glyphicon-user" aria-hidden="true"></span> <span class="t-guider"><%= @appointment.guider.name %></span> <small><%= @appointment.guider.organisation %></small></td>
+          <td class="booking-details__item"><b class="visible-xs-block">Guider</b><span class="glyphicon glyphicon-user" aria-hidden="true"></span> <span class="t-guider"><%= @appointment.guider.name %> <small><%= @appointment.guider.organisation %></small></span> </td>
           <td class="booking-details__item"><b class="visible-xs-block">Appointment date/time</b><span class="glyphicon glyphicon-calendar" aria-hidden="true"></span> <span class="t-appointment-date-time"><%= @appointment.start_at.to_date.to_s(:govuk_date_short) %>, <%= @appointment.start_at.to_s(:govuk_time) %> - <%= @appointment.end_at.to_s(:govuk_time) %></span></td>
           <td class="booking-details__item"><b class="visible-xs-block">Appointment created</b><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span> <span class="t-created-date"><%= @appointment.created_at.in_time_zone('London').to_s(:govuk_date_short) %></span></td>
         </tr>

--- a/app/views/appointments/preview.html.erb
+++ b/app/views/appointments/preview.html.erb
@@ -13,6 +13,7 @@
 
 <%= form_for @appointment, layout: :basic do |f| %>
   <%= hidden_field_tag :scheduled, calendar_scheduling? %>
+  <%= f.hidden_field :internal_availability %>
   <%= f.hidden_field :rebooked_from_id %>
   <%= f.hidden_field :date_of_birth %>
   <%= f.hidden_field :start_at %>

--- a/spec/features/agent_manages_appointments_spec.rb
+++ b/spec/features/agent_manages_appointments_spec.rb
@@ -481,6 +481,7 @@ RSpec.feature 'Agent manages appointments' do
     @page.accessibility_requirements.set true
     @page.notes.set 'something'
     @page.gdpr_consent_yes.set true
+    @page.internal_availability.set true if @page.has_internal_availability?
     @page.start_at.set day.change(hour: 9, min: 30).to_s
     @page.end_at.set day.change(hour: 10, min: 40).to_s
     @page.type_of_appointment_standard.set true

--- a/spec/features/guider_edits_an_appointment_spec.rb
+++ b/spec/features/guider_edits_an_appointment_spec.rb
@@ -160,7 +160,7 @@ RSpec.feature 'Guider edits an appointment' do
     start_at_time = @appointment.start_at.to_s(:govuk_time)
     end_at_time = @appointment.end_at.to_s(:govuk_time)
 
-    expect(@page.guider.text).to eq(@appointment.guider.name)
+    expect(@page.guider.text).to start_with(@appointment.guider.name)
     expect(@page.date_time.text).to eq("#{start_date}, #{start_at_time} - #{end_at_time}")
     expect(@page.created_date.text).to eq(@appointment.created_at.in_time_zone('London').to_s(:govuk_date_short))
     expect(@page.first_name.value).to eq(@appointment.first_name)

--- a/spec/features/resource_manager_reschedules_an_appointment_spec.rb
+++ b/spec/features/resource_manager_reschedules_an_appointment_spec.rb
@@ -37,6 +37,17 @@ RSpec.feature 'Resource manager reschedules an appointment', js: true do
     end
   end
 
+  scenario 'TPAS resource manager creates an appointment from external availability' do
+    given_the_user_is_a_resource_manager(organisation: :tpas) do
+      travel_to '2022-06-20 13:00' do
+        and_there_are_many_tpas_slots_and_one_external_slot
+        when_they_choose_the_external_slot
+        and_they_place_a_booking
+        then_the_resulting_appointment_is_correctly_allocated_to_cas
+      end
+    end
+  end
+
   scenario 'CAS resource manager creates an appointment' do
     given_the_user_is_a_resource_manager(organisation: :cas) do
       travel_to '2022-06-20 13:00' do
@@ -46,6 +57,20 @@ RSpec.feature 'Resource manager reschedules an appointment', js: true do
         then_the_resulting_appointment_is_correctly_allocated_to_cas
       end
     end
+  end
+
+  def and_there_are_many_tpas_slots_and_one_external_slot
+    start_at = Time.zone.parse('2022-06-24 09:00')
+
+    create(:bookable_slot, :cas, start_at: start_at)
+    # create many TPAS slots to increase the chance of random selection
+    create_list(:bookable_slot, 10, start_at: start_at)
+  end
+
+  def when_they_choose_the_external_slot
+    @page = Pages::NewAppointment.new.tap(&:load)
+    @page.wait_until_slots_visible
+    @page.choose_slot('09:00')
   end
 
   def when_they_choose_their_slot

--- a/spec/features/resource_manager_reschedules_an_appointment_spec.rb
+++ b/spec/features/resource_manager_reschedules_an_appointment_spec.rb
@@ -26,6 +26,80 @@ RSpec.feature 'Resource manager reschedules an appointment', js: true do
     end
   end
 
+  scenario 'TPAS resource manager creates an appointment from internal availability' do
+    given_the_user_is_a_resource_manager(organisation: :tpas) do
+      travel_to '2022-06-20 13:00' do
+        and_there_are_matching_available_slots_across_multiple_organisations
+        when_they_choose_an_internal_slot
+        and_they_place_a_booking
+        then_the_resulting_appointment_is_correctly_allocated
+      end
+    end
+  end
+
+  scenario 'CAS resource manager creates an appointment' do
+    given_the_user_is_a_resource_manager(organisation: :cas) do
+      travel_to '2022-06-20 13:00' do
+        and_there_are_matching_available_slots_across_multiple_organisations
+        when_they_choose_their_slot
+        and_they_place_a_booking
+        then_the_resulting_appointment_is_correctly_allocated_to_cas
+      end
+    end
+  end
+
+  def when_they_choose_their_slot
+    @page = Pages::NewAppointment.new.tap(&:load)
+    expect(@page).to have_no_internal_availability
+
+    @page.wait_until_slots_visible
+    @page.choose_slot('09:00')
+  end
+
+  def then_the_resulting_appointment_is_correctly_allocated_to_cas
+    @page.confirm_appointment.click
+
+    @page = Pages::EditAppointment.new
+    expect(@page).to be_displayed
+
+    expect(@page.guider).to have_text('CAS')
+  end
+
+  def when_they_choose_an_internal_slot
+    @page = Pages::NewAppointment.new.tap(&:load)
+    @page.internal_availability.set true
+    @page.wait_until_slots_visible
+    @page.choose_slot('09:00')
+  end
+
+  def and_they_place_a_booking
+    @page.date_of_birth_day.set '23'
+    @page.date_of_birth_month.set '10'
+    @page.date_of_birth_year.set '1950'
+    @page.first_name.set 'Some'
+    @page.last_name.set 'Person'
+    @page.email.set 'email@example.org'
+    @page.phone.set '0208 252 4729'
+    @page.mobile.set '07715 930 459'
+    @page.memorable_word.set 'lozenge'
+    @page.gdpr_consent_yes.set true
+    @page.type_of_appointment_standard.set true
+    @page.where_you_heard.select 'Other'
+    @page.preview_appointment.click
+
+    @page = Pages::PreviewAppointment.new
+    expect(@page).to be_displayed
+  end
+
+  def then_the_resulting_appointment_is_correctly_allocated
+    @page.confirm_appointment.click
+
+    @page = Pages::EditAppointment.new
+    expect(@page).to be_displayed
+
+    expect(@page.guider).to have_text('TPAS')
+  end
+
   def and_there_are_matching_available_slots_across_multiple_organisations
     start_at = Time.zone.parse('2022-06-24 09:00')
 

--- a/spec/support/chrome.rb
+++ b/spec/support/chrome.rb
@@ -2,6 +2,9 @@ require 'capybara'
 require 'selenium/webdriver'
 require 'webdrivers/chromedriver'
 
+# Pinned for this https://github.com/titusfortner/webdrivers/issues/237
+Webdrivers::Chromedriver.required_version = '106.0.5249.21'
+
 Capybara.register_driver :chrome_headless do |app|
   browser_options = ::Selenium::WebDriver::Chrome::Options.new.tap do |opts|
     opts.args << '--window-size=2500,2500'


### PR DESCRIPTION
When the TPAS agent checks the internal availability, this preference
must persist all the way through to allocation of the slot.