### PR TITLE
Allow consent email changes to trigger new email

### DIFF
--- a/app/lib/notifier.rb
+++ b/app/lib/notifier.rb
@@ -75,7 +75,7 @@ class Notifier
   end
 
   def requires_email_consent_form?
-    appointment.previous_changes.slice('email_consent_form_required').present? &&
+    appointment.previous_changes.slice('email_consent_form_required', 'email_consent').present? &&
       appointment.email_consent_form_required?
   end
 

--- a/spec/lib/notifier_spec.rb
+++ b/spec/lib/notifier_spec.rb
@@ -93,6 +93,14 @@ RSpec.describe Notifier, '#call' do
 
       subject.call
     end
+
+    it 'enqueues the consent form email job when the consent email changes' do
+      appointment.update(email_consent: 'smurfette@example.com', email_consent_form_required: true)
+
+      expect(EmailThirdPartyConsentFormJob).to receive(:perform_later).with(appointment)
+
+      subject.call
+    end
   end
 
   context 'when a BSL appointment is completed' do

--- a/spec/support/chrome.rb
+++ b/spec/support/chrome.rb
@@ -2,6 +2,9 @@ require 'capybara'
 require 'selenium/webdriver'
 require 'webdrivers/chromedriver'
 
+# Pinned for this https://github.com/titusfortner/webdrivers/issues/237
+Webdrivers::Chromedriver.required_version = '106.0.5249.21'
+
 Capybara.register_driver :chrome_headless do |app|
   browser_options = ::Selenium::WebDriver::Chrome::Options.new.tap do |opts|
     opts.args << '--window-size=2500,2500'


### PR DESCRIPTION
We noticed changes to the consent email wouldn't trigger new consent form
emails to be sent.