### PR TITLE
Only validate when the status changes

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -162,7 +162,7 @@ class Appointment < ApplicationRecord
   validate :validate_signposting
   validate :validate_small_pots, if: :small_pots?
   validate :validate_tp_agent_statuses
-  validate :validate_tpas_agent_statuses
+  validate :validate_tpas_agent_statuses, if: :status_changed?, on: :update
 
   before_validation :format_name, on: :create
   before_create :track_initial_status

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -410,6 +410,8 @@ RSpec.describe Appointment, type: :model do
             it 'only permits particular statuses' do
               subject.current_user = build_stubbed(:resource_manager, :tpas)
 
+              expect(subject).to be_valid
+
               subject.status = :ineligible_age
               expect(subject).to be_valid
 


### PR DESCRIPTION
This resolves an issue occuring currently for TPAS agents when
attempting to alter an existing appointment belonging to an outside
organisation.