### PR TITLE
Improve searching

### DIFF
--- a/app/views/appointments/search.html.erb
+++ b/app/views/appointments/search.html.erb
@@ -15,7 +15,7 @@
         :date_range,
         class: 't-date-range appointment-search__date-range form-control',
         use_label: false,
-        placeholder: 'Appointment date range',
+        placeholder: '3 months ago to 1 month from now',
         readonly: true,
         data: {
           module: 'date-range-picker',

--- a/spec/features/resource_manager_reschedules_an_appointment_spec.rb
+++ b/spec/features/resource_manager_reschedules_an_appointment_spec.rb
@@ -181,12 +181,14 @@ RSpec.feature 'Resource manager reschedules an appointment', js: true do
 
   scenario 'Rebooking with ad-hoc allocation' do
     given_the_user_is_a_resource_manager do
-      and_there_is_a_cancelled_appointment
-      and_there_are_several_guiders
-      when_they_attempt_to_rebook_the_appointment
-      and_select_ad_hoc_allocation
-      and_rebook_the_appointment
-      then_the_appointment_is_rebooked
+      travel_to '2017-12-27 13:00 utc' do
+        and_there_is_a_cancelled_appointment
+        and_there_are_several_guiders
+        when_they_attempt_to_rebook_the_appointment
+        and_select_ad_hoc_allocation
+        and_rebook_the_appointment
+        then_the_appointment_is_rebooked
+      end
     end
   end
 


### PR DESCRIPTION
This is a performance nightmare as it currently stands. We can
short-circuit a lot of queries straight to a simple where clause when
the query is just an appointment reference. Also, we can bound the
result set when no date range is specified, so we're not performing text
scans across the whole dataset.