### PR TITLE
Hide week view from booking calendar

### DIFF
--- a/app/assets/javascripts/modules/calendars/appointment-availability.es6
+++ b/app/assets/javascripts/modules/calendars/appointment-availability.es6
@@ -8,14 +8,14 @@
         showAll = !!$('.js-internal-availability').prop('checked');
 
       this.config = {
-        defaultView: 'agendaWeek',
+        defaultView: 'agendaThreeDay',
         columnFormat: 'ddd D/M',
         slotDuration: '00:30:00',
         eventBorderColor: '#000',
         events: this.getEventsUrl(lloydsSignposted, el),
         defaultDate: moment(el.data('default-date')),
         header: {
-          'right': 'agendaDay agendaThreeDay agendaWeek today jumpToDate prev,next'
+          'right': 'agendaDay agendaThreeDay today jumpToDate prev,next'
         },
         views: {
           agendaThreeDay: {

--- a/spec/features/agent_manages_appointments_spec.rb
+++ b/spec/features/agent_manages_appointments_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature 'Agent manages appointments' do
         and_slots_exist_for_general_availability
         and_slots_exist_for_due_diligence_availability
         when_they_attempt_to_book_an_appointment
-        then_they_see_only_general_availability
+        then_they_see_only_general_availability(navigate_next: false)
         and_they_do_not_see_small_pots
       end
     end
@@ -112,7 +112,8 @@ RSpec.feature 'Agent manages appointments' do
     expect(@page).to have_no_small_pots
   end
 
-  def then_they_see_only_general_availability
+  def then_they_see_only_general_availability(navigate_next: true)
+    @page.next_period.click if navigate_next
     @page.wait_until_calendar_events_visible
 
     expect(@page).to have_calendar_events(count: 1)

--- a/spec/features/agent_rebooks_appointments_spec.rb
+++ b/spec/features/agent_rebooks_appointments_spec.rb
@@ -51,6 +51,7 @@ RSpec.feature 'Agent rebooks appointments' do
   def then_they_see_only_their_availability
     @page = Pages::NewAppointment.new
     expect(@page).to be_displayed
+    @page.next_period.click
 
     @page.wait_until_slots_visible
     expect(@page).to have_slots(count: 1)
@@ -84,6 +85,7 @@ RSpec.feature 'Agent rebooks appointments' do
     @page = Pages::NewAppointment.new
     expect(@page).to be_displayed
 
+    @page.next_period.click
     @page.wait_until_slots_visible
     expect(@page).to have_slots(count: 1)
     expect(@page.slots.first).to have_text('11:00 1 guider')

--- a/spec/features/booking_due_diligence_appointments_spec.rb
+++ b/spec/features/booking_due_diligence_appointments_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Booking due diligence appointments', js: true do
         then_they_see_only_due_diligence_availability
         when_they_attempt_to_book_with_invalid_fields
         then_they_see_validation_messages
-        then_they_see_only_due_diligence_availability
+        then_they_see_only_due_diligence_availability(navigate_next: false)
       end
     end
   end
@@ -173,7 +173,8 @@ RSpec.feature 'Booking due diligence appointments', js: true do
     create(:bookable_slot, :due_diligence, start_at: Time.zone.parse('2021-04-08 14:30'))
   end
 
-  def then_they_see_only_due_diligence_availability
+  def then_they_see_only_due_diligence_availability(navigate_next: true)
+    @page.next_period.click if navigate_next
     @page.wait_until_calendar_events_visible
 
     # they're deduplicated properly given one is PW and one is DD

--- a/spec/features/resource_manager_reschedules_an_appointment_spec.rb
+++ b/spec/features/resource_manager_reschedules_an_appointment_spec.rb
@@ -69,6 +69,8 @@ RSpec.feature 'Resource manager reschedules an appointment', js: true do
 
   def when_they_choose_the_external_slot
     @page = Pages::NewAppointment.new.tap(&:load)
+    @page.next_period.click
+
     @page.wait_until_slots_visible
     @page.choose_slot('09:00')
   end
@@ -77,6 +79,7 @@ RSpec.feature 'Resource manager reschedules an appointment', js: true do
     @page = Pages::NewAppointment.new.tap(&:load)
     expect(@page).to have_no_internal_availability
 
+    @page.next_period.click
     @page.wait_until_slots_visible
     @page.choose_slot('09:00')
   end
@@ -93,6 +96,7 @@ RSpec.feature 'Resource manager reschedules an appointment', js: true do
   def when_they_choose_an_internal_slot
     @page = Pages::NewAppointment.new.tap(&:load)
     @page.internal_availability.set true
+    @page.next_period.click
     @page.wait_until_slots_visible
     @page.choose_slot('09:00')
   end
@@ -141,6 +145,7 @@ RSpec.feature 'Resource manager reschedules an appointment', js: true do
   end
 
   def and_they_choose_the_one_available_slot
+    @page.next_period.click
     @page.wait_until_slots_visible
 
     expect(@page).to have_slots(count: 1)
@@ -169,6 +174,7 @@ RSpec.feature 'Resource manager reschedules an appointment', js: true do
   end
 
   def then_they_see_only_cas_slots
+    @page.next_period.click
     @page.wait_until_slots_visible
 
     expect(@page).to have_slots(count: 1)

--- a/spec/support/pages/new_appointment.rb
+++ b/spec/support/pages/new_appointment.rb
@@ -2,6 +2,7 @@ module Pages
   class NewAppointment < Base
     set_url '/appointments/new{?query*}'
 
+    element :next_period, '.fc-next-button'
     elements :slots, '.fc-time-grid-event'
 
     element :first_name,                            '.t-first-name'

--- a/spec/support/pages/reschedule_appointment.rb
+++ b/spec/support/pages/reschedule_appointment.rb
@@ -14,6 +14,7 @@ module Pages
     element :reschedule, '.t-reschedule'
     elements :slots, '.fc-time-grid-event'
     elements :calendar_events, '.fc-event'
+    element :next_period, '.fc-next-button'
 
     def ad_hoc_start_at(value)
       execute_script("$('.t-ad-hoc-start-at').val('#{value}')")


### PR DESCRIPTION
Temporarily hide this expensive view while we work on a solution to
timeout and slow request issues.