### PR TITLE
Widen search range to 6 months

### DIFF
--- a/app/models/appointment_search.rb
+++ b/app/models/appointment_search.rb
@@ -65,7 +65,7 @@ class AppointmentSearch
 
   def within_date_range(results)
     @start_at = 3.months.ago.beginning_of_day unless @start_at
-    @end_at   = 1.month.from_now.end_of_day unless @end_at
+    @end_at   = 3.months.from_now.end_of_day unless @end_at
 
     results.where('start_at between ? and ?', @start_at, @end_at)
   end

--- a/app/views/appointments/search.html.erb
+++ b/app/views/appointments/search.html.erb
@@ -15,7 +15,7 @@
         :date_range,
         class: 't-date-range appointment-search__date-range form-control',
         use_label: false,
-        placeholder: '3 months ago to 1 month from now',
+        placeholder: '3 months ago to 3 months from now',
         readonly: true,
         data: {
           module: 'date-range-picker',


### PR DESCRIPTION
This was requested by Pension Ops staff as it better matches the regular
window of bookings they operate under.