### PR TITLE
Create a failure activity for postal letters

### DIFF
--- a/app/controllers/print_confirmations_controller.rb
+++ b/app/controllers/print_confirmations_controller.rb
@@ -1,0 +1,9 @@
+class PrintConfirmationsController < ApplicationController
+  def create
+    @appointment = Appointment.for_organisation(current_user).find(params[:appointment_id])
+    @appointment.resend_print_confirmation
+
+    redirect_back success: 'The appointment confirmation letter was resent to the customer.',
+                  fallback_location: root_path
+  end
+end

--- a/app/jobs/printed_confirmation_job.rb
+++ b/app/jobs/printed_confirmation_job.rb
@@ -9,13 +9,17 @@ class PrintedConfirmationJob < NotifyJobBase
 
     client = Notifications::Client.new(api_key(appointment.schedule_type))
 
-    client.send_letter(
-      template_id: template_id(appointment),
-      reference: appointment.to_param,
-      personalisation: personalisation
-    )
+    begin
+      client.send_letter(
+        template_id: template_id(appointment),
+        reference: appointment.to_param,
+        personalisation: personalisation
+      )
 
-    PrintedConfirmationActivity.from(appointment)
+      PrintedConfirmationActivity.from(appointment)
+    rescue Notifications::Client::BadRequestError
+      PrintedConfirmationFailedActivity.from(appointment)
+    end
   end
 
   private

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,5 +1,9 @@
 class Activity < ApplicationRecord
-  HIGH_PRIORITY_ACTIVITY_CLASS_NAMES = %w(DropActivity DroppedSummaryDocumentActivity).freeze
+  HIGH_PRIORITY_ACTIVITY_CLASS_NAMES = %w(
+    DropActivity
+    DroppedSummaryDocumentActivity
+    PrintedConfirmationFailedActivity
+  ).freeze
 
   belongs_to :appointment
   belongs_to :user, optional: true

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -176,6 +176,10 @@ class Appointment < ApplicationRecord
     CustomerUpdateJob.perform_later(self, CustomerUpdateActivity::CONFIRMED_MESSAGE)
   end
 
+  def resend_print_confirmation
+    PrintedConfirmationJob.perform_later(self)
+  end
+
   def internal_availability?
     internal_availability.present? && internal_availability == '1'
   end

--- a/app/models/printed_confirmation_failed_activity.rb
+++ b/app/models/printed_confirmation_failed_activity.rb
@@ -1,0 +1,9 @@
+class PrintedConfirmationFailedActivity < Activity
+  def self.from(appointment)
+    create!(
+      appointment_id: appointment.id,
+      message: appointment.rescheduled_at? ? 'rescheduled' : 'confirmation',
+      owner: appointment.agent
+    )
+  end
+end

--- a/app/views/activities/_printed_confirmation_failed_activity.html.erb
+++ b/app/views/activities/_printed_confirmation_failed_activity.html.erb
@@ -1,0 +1,5 @@
+<% content_for(:activity_message, flush: true) do %>
+  <span class="glyphicon glyphicon-print" aria-hidden="true"></span>
+  <strong>The system</strong> attempted to send a <%= printed_confirmation_failed_activity.message %> letter but it failed
+<% end %>
+<%= render 'activities/activity', activity: printed_confirmation_failed_activity, details: details, hide: hide %>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -86,9 +86,15 @@
       <span>Rebook</span>
     <% end %>
     <% if current_user.tp? || current_user.tpas_agent? %>
-      <%= link_to appointment_email_confirmation_path(@appointment), title: 'Resend', class: 'btn btn-info t-resend-email-confirmation', method: :post, data: { confirm: 'Resend the appointment confirmation email?' } do %>
+      <%= link_to appointment_email_confirmation_path(@appointment), title: 'Resend appointment confirmation email', class: 'btn btn-info t-resend-email-confirmation', method: :post, data: { confirm: 'Resend the appointment confirmation email?' } do %>
         <span class="glyphicon glyphicon-envelope" aria-hidden="true"></span>
         <span>Resend</span>
+      <% end %>
+      <% if @appointment.print_confirmation? %>
+        <%= link_to appointment_print_confirmation_path(@appointment), title: 'Resend appointment confirmation letter', class: 'btn btn-info t-resend-print-confirmation', method: :post, data: { confirm: 'Resend the appointment confirmation letter?' } do %>
+          <span class="glyphicon glyphicon-print" aria-hidden="true"></span>
+          <span>Resend</span>
+        <% end %>
       <% end %>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
     resource :consent, only: :show
     resource :process, only: :create
     resource :email_confirmation, only: :create
+    resource :print_confirmation, only: :create
 
     resources :changes, only: :index
     resources :duplicates, only: :index

--- a/spec/features/agent_manages_appointments_spec.rb
+++ b/spec/features/agent_manages_appointments_spec.rb
@@ -5,6 +5,15 @@ RSpec.feature 'Agent manages appointments' do
 
   let(:day) { BusinessDays.from_now(5) }
 
+  scenario 'Resending a printed confirmation letter', js: true do
+    given_the_user_is_a_resource_manager(organisation: :tpas) do
+      and_an_appointment_with_an_address_exists
+      when_they_edit_the_appointment
+      and_they_resend_the_printed_confirmation
+      then_the_printed_confirmation_is_sent
+    end
+  end
+
   scenario 'TP agent booking a stronger nudge appointment' do
     given_the_user_is_an_agent(organisation: :tp) do
       and_there_is_a_guider_with_available_slots
@@ -75,6 +84,20 @@ RSpec.feature 'Agent manages appointments' do
       when_they_accept_the_appointment_preview
       then_the_appointment_is_small_pots
     end
+  end
+
+  def and_an_appointment_with_an_address_exists
+    @appointment = create(:appointment, :with_address)
+  end
+
+  def and_they_resend_the_printed_confirmation
+    accept_confirm do
+      @page.resend_print_confirmation.click
+    end
+  end
+
+  def then_the_printed_confirmation_is_sent
+    expect(@page.flash_of_success).to have_text('letter was resent')
   end
 
   def then_they_see_the_stronger_nudge_checkbox

--- a/spec/jobs/printed_confirmation_job_spec.rb
+++ b/spec/jobs/printed_confirmation_job_spec.rb
@@ -71,6 +71,18 @@ RSpec.describe PrintedConfirmationJob, '#perform' do
         described_class.new.perform(appointment)
       end
     end
+
+    context 'when the confirmation fails to deliver' do
+      it 'creates a failure activity to be actioned' do
+        response_double = double(code: 400, body: 'bad times')
+
+        allow(client).to receive(:send_letter).and_raise(Notifications::Client::BadRequestError, response_double)
+
+        described_class.new.perform(appointment)
+
+        expect(appointment.activities.first).to be_an(PrintedConfirmationFailedActivity)
+      end
+    end
   end
 
   before do

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -28,6 +28,7 @@ module Pages
     element :rebook, '.t-rebook'
     element :process, '.t-process'
     element :resend_email_confirmation, '.t-resend-email-confirmation'
+    element :resend_print_confirmation, '.t-resend-print-confirmation'
     element :reschedule, '.t-reschedule'
     element :reissue_summary, '.t-reissue-summary'
 


### PR DESCRIPTION
When these fail due to errant address elements, the appointment record is not updated. This means the owning agent/guider has no knowledge or opportunity to correct the issues. This change ensures they can at least see that GOVUK notify determined that the address was invalid.