### PR TITLE
Expand booking and slot generation window

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -490,8 +490,8 @@ class Appointment < ApplicationRecord
   def valid_within_booking_window
     return unless start_at
 
-    too_late = start_at > BusinessDays.from_now(45)
-    errors.add(:start_at, 'must be less than 45 business days from now') if too_late
+    too_late = start_at > BusinessDays.from_now(55)
+    errors.add(:start_at, 'must be less than 55 business days from now') if too_late
   end
 
   def data_subject_date_of_birth_valid

--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -79,7 +79,7 @@ class BookableSlot < ApplicationRecord
     if day
       [Time.zone.parse(day).beginning_of_day, Time.zone.parse(day).end_of_day]
     else
-      [next_valid_start_date(nil, schedule_type), BusinessDays.from_now(40).end_of_day]
+      [next_valid_start_date(nil, schedule_type), BusinessDays.from_now(55).end_of_day]
     end
   end
 
@@ -209,6 +209,6 @@ class BookableSlot < ApplicationRecord
   end
 
   def self.generation_range
-    Time.zone.now.to_date..8.weeks.from_now.to_date
+    Time.zone.now.to_date..BusinessDays.from_now(55).to_date
   end
 end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -720,8 +720,8 @@ RSpec.describe Appointment, type: :model do
       end
     end
 
-    it 'cannot be booked further ahead than forty five working days' do
-      subject.start_at = BusinessDays.from_now(46)
+    it 'cannot be booked further ahead than fifty five working days' do
+      subject.start_at = BusinessDays.from_now(56)
       subject.validate
       expect(subject.errors[:start_at]).to_not be_empty
     end

--- a/spec/requests/bookable_slots_api_spec.rb
+++ b/spec/requests/bookable_slots_api_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe 'GET /api/v1/bookable_slots' do
     JSON.parse(response.body).tap do |json|
       expect(json['2017-01-16']).to eq(%w(2017-01-16T12:00:00.000Z 2017-01-16T15:00:00.000Z))
 
-      expect(json.keys).to eq(%w(2017-01-13 2017-01-16 2017-02-19))
+      expect(json.keys).to eq(%w(2017-01-13 2017-01-16 2017-02-19 2017-03-05))
     end
   end
 


### PR DESCRIPTION
Increases these two in lockstep to ensure there is Pension Wise availability during this particularly busy period.