### PR TITLE
Do not trigger notifications on 'reschedule'

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -20,6 +20,7 @@ class Appointment < ApplicationRecord
   NON_NOTIFY_COLUMNS = %w(
     agent_id
     guider_id
+    rescheduled_at
     notes
     status
     secondary_status

--- a/spec/lib/notifier_spec.rb
+++ b/spec/lib/notifier_spec.rb
@@ -226,4 +226,14 @@ RSpec.describe Notifier, '#call' do
       )
     end
   end
+
+  context 'when the `rescheduled_at` column is touched' do
+    it 'does not send a customer email' do
+      expect(CustomerUpdateJob).to_not receive(:perform_later)
+
+      appointment.touch(:rescheduled_at)
+
+      subject.call
+    end
+  end
 end


### PR DESCRIPTION
This event should not trigger customer notifications. Adding the column to the non-notify list satisfies this.