### PR TITLE
Discard email failures for MailGun sandboxing

### DIFF
--- a/app/jobs/customer_update_job.rb
+++ b/app/jobs/customer_update_job.rb
@@ -16,13 +16,13 @@ class CustomerUpdateJob < ActiveJob::Base
   def send_email(appointment, message)
     case message
     when CustomerUpdateActivity::CANCELLED_MESSAGE
-      AppointmentMailer.cancelled(appointment).deliver
+      AppointmentMailer.cancelled(appointment).deliver_now
     when CustomerUpdateActivity::CONFIRMED_MESSAGE
-      AppointmentMailer.confirmation(appointment).deliver
+      AppointmentMailer.confirmation(appointment).deliver_now
     when CustomerUpdateActivity::MISSED_MESSAGE
-      AppointmentMailer.missed(appointment).deliver
+      AppointmentMailer.missed(appointment).deliver_now
     when CustomerUpdateActivity::UPDATED_MESSAGE
-      AppointmentMailer.updated(appointment).deliver
+      AppointmentMailer.updated(appointment).deliver_now
     end
   end
 end

--- a/app/mailers/appointment_mailer.rb
+++ b/app/mailers/appointment_mailer.rb
@@ -1,4 +1,8 @@
 class AppointmentMailer < ApplicationMailer
+  rescue_from Net::SMTPUnknownError do |exception|
+    Rails.logger.error(exception)
+  end
+
   default subject: -> { @appointment.subject }, from: -> { @appointment.from }
 
   def resource_manager_email_dropped(appointment, recipient)

--- a/spec/lib/notifier_spec.rb
+++ b/spec/lib/notifier_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Notifier, '#call' do
     allow(AppointmentMailer).to receive(:confirmation) { mailer }
     allow(AppointmentMailer).to receive(:missed) { mailer }
     allow(AppointmentMailer).to receive(:updated) { mailer }
-    allow(mailer).to receive(:deliver)
+    allow(mailer).to receive(:deliver_now)
   end
 
   context 'when an appointment is otherwise altered' do


### PR DESCRIPTION
These continually retry when the recipient is unlisted in MailGun's allow-list and we don't want them to queue indefinitely.