### PR TITLE
Convert payload to mailgun webhook JSON

### DIFF
--- a/app/controllers/mail_gun/drops_controller.rb
+++ b/app/controllers/mail_gun/drops_controller.rb
@@ -14,9 +14,12 @@ module MailGun
     def drop_params # rubocop:disable AbcSize, MethodLength
       event_data = params['event-data']
 
+      description = event_data['delivery-status'][:description].presence ||
+                    event_data['delivery-status'][:message].presence
+
       {
         event: event_data[:event],
-        description: event_data['delivery-status'][:description],
+        description: description,
         message_type: event_data['user-variables'][:message_type],
         environment: event_data['user-variables'][:environment],
         appointment_id: event_data['user-variables'][:appointment_id],

--- a/app/controllers/mail_gun/drops_controller.rb
+++ b/app/controllers/mail_gun/drops_controller.rb
@@ -11,17 +11,19 @@ module MailGun
 
     private
 
-    def drop_params
-      params.permit(
-        :event,
-        :description,
-        :appointment_id,
-        :message_type,
-        :environment,
-        :timestamp,
-        :token,
-        :signature
-      )
+    def drop_params # rubocop:disable AbcSize, MethodLength
+      event_data = params['event-data']
+
+      {
+        event: event_data[:event],
+        description: event_data['delivery-status'][:description],
+        message_type: event_data['user-variables'][:message_type],
+        environment: event_data['user-variables'][:environment],
+        appointment_id: event_data['user-variables'][:appointment_id],
+        timestamp: params[:signature][:timestamp],
+        token: params[:signature][:token],
+        signature: params[:signature][:signature]
+      }
     end
   end
 end

--- a/spec/requests/mailgun_drop_notification_spec.rb
+++ b/spec/requests/mailgun_drop_notification_spec.rb
@@ -24,16 +24,26 @@ RSpec.describe 'POST /mail_gun/drops' do
   end
 
   def when_mail_gun_posts_a_drop_notification
-    post mail_gun_drops_path, params: {
-      'event'          => 'dropped',
-      'description'    => 'the reasoning',
-      'environment'    => 'production',
-      'message_type'   => 'booking_created',
-      'appointment_id' => @appointment.to_param,
-      'timestamp'      => '1474638633',
-      'token'          => 'secret',
-      'signature'      => 'abf02bef01e803bea52213cb092a31dc2174f63bcc2382ba25732f4c84e084c1'
+    payload = {
+      "signature": {
+        "token": 'secret',
+        "timestamp": '1474638633',
+        "signature": 'abf02bef01e803bea52213cb092a31dc2174f63bcc2382ba25732f4c84e084c1'
+      },
+      "event-data": {
+        "event": 'dropped',
+        "delivery-status": {
+          "description": 'the reasoning'
+        },
+        "user-variables": {
+          "message_type": 'booking_created',
+          "environment": 'production',
+          "appointment_id": @appointment.to_param
+        }
+      }
     }
+
+    post mail_gun_drops_path, params: payload, as: :json
   end
 
   def then_an_activity_is_created

--- a/spec/requests/mailgun_drop_notification_spec.rb
+++ b/spec/requests/mailgun_drop_notification_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe 'POST /mail_gun/drops' do
       "event-data": {
         "event": 'dropped',
         "delivery-status": {
+          "message": '',
           "description": 'the reasoning'
         },
         "user-variables": {


### PR DESCRIPTION
Upgraded to new webhook format (JSON) as legacy webhooks (regular form payload) have been discontinued