### PR TITLE
Access the `event-data` nested hashes better

### DIFF
--- a/app/controllers/mail_gun/drops_controller.rb
+++ b/app/controllers/mail_gun/drops_controller.rb
@@ -14,15 +14,15 @@ module MailGun
     def drop_params # rubocop:disable AbcSize, MethodLength
       event_data = params['event-data']
 
-      description = event_data['delivery-status'][:description].presence ||
-                    event_data['delivery-status'][:message].presence
+      description = event_data.dig('delivery-status', :description).presence ||
+                    event_data.dig('delivery-status', :message).presence
 
       {
         event: event_data[:event],
         description: description,
-        message_type: event_data['user-variables'][:message_type],
-        environment: event_data['user-variables'][:environment],
-        appointment_id: event_data['user-variables'][:appointment_id],
+        message_type: event_data.dig('user-variables', :message_type),
+        environment: event_data.dig('user-variables', :environment),
+        appointment_id: event_data.dig('user-variables', :appointment_id),
         timestamp: params[:signature][:timestamp],
         token: params[:signature][:token],
         signature: params[:signature][:signature]

--- a/spec/requests/mailgun_drop_notification_spec.rb
+++ b/spec/requests/mailgun_drop_notification_spec.rb
@@ -10,6 +10,13 @@ RSpec.describe 'POST /mail_gun/drops' do
     end
   end
 
+  scenario 'an invalid message type payload responds OK' do
+    with_a_configured_token('deadbeef') do
+      when_mail_gun_posts_an_ignored_drop_notification
+      and_the_service_responds_ok
+    end
+  end
+
   def with_a_configured_token(token)
     existing = ENV['MAILGUN_API_TOKEN']
 
@@ -40,6 +47,29 @@ RSpec.describe 'POST /mail_gun/drops' do
           "message_type": 'booking_created',
           "environment": 'production',
           "appointment_id": @appointment.to_param
+        }
+      }
+    }
+
+    post mail_gun_drops_path, params: payload, as: :json
+  end
+
+  def when_mail_gun_posts_an_ignored_drop_notification
+    payload = {
+      "signature": {
+        "token": 'secret',
+        "timestamp": '1474638633',
+        "signature": 'abf02bef01e803bea52213cb092a31dc2174f63bcc2382ba25732f4c84e084c1'
+      },
+      "event-data": {
+        "event": 'dropped',
+        "delivery-status": {
+          "message": '',
+          "description": 'the reasoning'
+        },
+        "user-variables": {
+          "message_type": 'resource_manager_email_dropped',
+          "environment": 'production'
         }
       }
     }


### PR DESCRIPTION
There are cases where these nested values are not present in the payload from mailgun. In these cases currently an error is raised but instead we can try and parse the payload and allow the `DropForm` validation to exclude the message when necessary attributes are missing.