### PR TITLE
Switch adapters to counter webmock errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ source 'https://rubygems.org' do
   gem 'capitalize-names', require: 'capitalize_names'
   gem 'faraday'
   gem 'faraday-conductivity'
+  gem 'faraday-http'
   gem 'faraday_middleware'
   gem 'font-awesome-rails'
   gem 'foreman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,8 @@ GEM
     daemons (1.3.1)
     database_rewinder (0.9.1)
     diff-lcs (1.3)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     em-http-request (1.1.7)
       addressable (>= 2.3.4)
       cookiejar (!= 0.3.1)
@@ -177,6 +179,9 @@ GEM
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
+    faraday-http (1.1.0)
+      faraday (~> 1.0)
+      http (>= 4.0, < 6)
     faraday-httpclient (1.0.1)
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
@@ -188,6 +193,9 @@ GEM
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     ffi (1.15.4)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
     foreman (0.87.1)
@@ -208,6 +216,16 @@ GEM
       rails (>= 3.2.0)
     hashdiff (1.0.1)
     hashie (5.0.0)
+    http (4.4.1)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      http-parser (~> 1.2.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
+    http-parser (1.2.3)
+      ffi-compiler (>= 1.0, < 2.0)
     http_parser.rb (0.6.0)
     httpclient (2.8.3)
     i18n (1.10.0)
@@ -474,6 +492,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     unicode-display_width (1.5.0)
     vcr (6.1.0)
     warden (1.2.9)
@@ -520,6 +541,7 @@ DEPENDENCIES
   faker!
   faraday!
   faraday-conductivity!
+  faraday-http!
   faraday_middleware!
   font-awesome-rails!
   foreman!

--- a/app/lib/summary_document_api.rb
+++ b/app/lib/summary_document_api.rb
@@ -29,7 +29,7 @@ class SummaryDocumentApi
       faraday.response :raise_error
       faraday.response :json
       faraday.use :instrumentation
-      faraday.adapter Faraday.default_adapter
+      faraday.adapter :http
       faraday.authorization :Bearer, bearer_token if bearer_token
       faraday.headers[:accept] = 'application/json'
     end

--- a/app/lib/summary_document_api.rb
+++ b/app/lib/summary_document_api.rb
@@ -39,18 +39,13 @@ class SummaryDocumentApi
     {
       url: api_uri,
       request: {
-        timeout: read_timeout,
-        open_timeout: open_timeout
+        timeout: timeout
       }
     }
   end
 
-  def open_timeout
+  def timeout
     ENV.fetch('SUMMARY_DOCUMENT_API_OPEN_TIMEOUT', 2).to_i
-  end
-
-  def read_timeout
-    ENV.fetch('SUMMARY_DOCUMENT_API_READ_TIMEOUT', 2).to_i
   end
 
   def api_uri

--- a/app/lib/web_hook.rb
+++ b/app/lib/web_hook.rb
@@ -27,8 +27,7 @@ class WebHook
     {
       url: hook_uri,
       request: {
-        timeout:      Integer(ENV.fetch('WEB_HOOK_TIMEOUT', 2)),
-        open_timeout: Integer(ENV.fetch('WEB_HOOK_OPEN_TIMEOUT', 2))
+        timeout: Integer(ENV.fetch('WEB_HOOK_TIMEOUT', 2))
       }
     }
   end

--- a/app/lib/web_hook.rb
+++ b/app/lib/web_hook.rb
@@ -19,7 +19,7 @@ class WebHook
       faraday.request  :json
       faraday.response :raise_error
       faraday.use      :instrumentation
-      faraday.adapter  Faraday.default_adapter
+      faraday.adapter  :http
     end
   end
 


### PR DESCRIPTION
The standard Net::HTTP adapter causes 'too many open files' during tests and the webmock configuration to counter this also doesn't work as expected. We can just switch to a more reliable adapter instead.