### PR TITLE
Alerts for bt internet were removed 

### DIFF
--- a/app/forms/drop_form.rb
+++ b/app/forms/drop_form.rb
@@ -45,19 +45,12 @@ class DropForm
 
       EmailDropNotificationsJob.perform_later(appointment)
 
-      log_btinternet_drops
     else
       logger.info(errors.full_messages)
     end
   end
 
   private
-
-  def log_btinternet_drops
-    return unless description.include? 'btinternet'
-
-    Rails.logger.info "Mail drop for @btinternet #{appointment_id}"
-  end
 
   def appointment
     Appointment.find(appointment_id)

--- a/spec/forms/drop_form_spec.rb
+++ b/spec/forms/drop_form_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe DropForm, '#create_activity' do
     end
 
     context 'when everything is validated' do
-      it 'creates the drop activity and enqueues the notifications job' do
+      it 'creates the drop activity and enqueues the notifications zob' do
         expect(DropActivity).to receive(:from).with(
           params['event'],
           params['description'],
@@ -82,20 +82,6 @@ RSpec.describe DropForm, '#create_activity' do
         expect(EmailDropNotificationsJob).to receive(:perform_later).with(appointment)
 
         subject.create_activity
-      end
-
-      context 'when the description contains a btinternet email' do
-        before do
-          params['description'] = 'myemail@btinternet.com'
-        end
-
-        it 'logs out the maildrop for logentries' do
-          allow(Rails.logger).to receive(:info)
-
-          subject.create_activity
-
-          expect(Rails.logger).to have_received(:info).with("Mail drop for @btinternet #{appointment.to_param}")
-        end
       end
     end
   end


### PR DESCRIPTION
These notifications are not longer an issue since the sender domains were added to their allow list