### PR TITLE
Ensure allocation respects booking window

### DIFF
--- a/app/forms/api/v1/appointment.rb
+++ b/app/forms/api/v1/appointment.rb
@@ -33,7 +33,7 @@ module Api
       end
 
       def create
-        model.allocate
+        model.allocate(agent: agent)
         model.save
       end
 

--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -47,8 +47,10 @@ class BookableSlot < ApplicationRecord
   end
 
   def self.find_available_slot(start_at, agent, schedule_type = User::PENSION_WISE_SCHEDULE_TYPE, scoped = true, external: false) # rubocop:disable Layout/LineLength
-    scope = bookable.where(start_at: start_at)
-    scope = scope.for_organisation(agent, scoped: scoped, external: external) if agent
+    scope = bookable
+    scope = scope.limit_by_organisation(start_at.beginning_of_day, start_at.end_of_day) if agent&.pension_wise_api?
+    scope = scope.where(start_at: start_at)
+    scope = scope.for_organisation(agent, scoped: scoped, external: external) if agent && !agent.pension_wise_api?
     scope = for_schedule_type(schedule_type: schedule_type, scope: scope)
 
     scope.limit(1).order('RANDOM()').first

--- a/spec/models/bookable_slot_spec.rb
+++ b/spec/models/bookable_slot_spec.rb
@@ -52,6 +52,22 @@ RSpec.describe BookableSlot, type: :model do
 
       expect(@allocated).to eq(@expected)
     end
+
+    context 'when a customer books via the website' do
+      it 'honours the TPAS/ops booking window' do
+        travel_to '2023-10-02 13:00' do
+          agent = double(pension_wise_api?: true)
+
+          # falls outside the starting window
+          slot = create(:bookable_slot, start_at: Time.zone.parse('2023-10-04 13:00'))
+          expect(BookableSlot.find_available_slot(slot.start_at, agent)).to be_nil
+
+          # falls inside the starting window
+          slot = create(:bookable_slot, start_at: Time.zone.parse('2023-10-14 13:00'))
+          expect(BookableSlot.find_available_slot(slot.start_at, agent)).to eq(slot)
+        end
+      end
+    end
   end
 
   describe '#next_valid_start_date' do


### PR DESCRIPTION
Prior to this change the allocation of slots was not respecting the variable booking window per provider. For example, in the case of TPAS/ops, they could have 10 slots for the given `start_at` and this would outweigh the slot that would usually be allocated by a single instance of matching date/time despite being outside of their regular booking window.