### PR TITLE
Remove guider's availability when SSO suspended

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ before_script:
 - nvm install 16
 - nvm use 16
 - npm install
-- npx @puppeteer/browsers install chromedriver@118.0.5993.70 --path $PWD/bin
-- export PATH=$PWD/bin/chromedriver/linux-118.0.5993.70/chromedriver-linux64:$PATH
+- npx @puppeteer/browsers install chromedriver@119.0.6045.105 --path $PWD/bin
+- export PATH=$PWD/bin/chromedriver/linux-119.0.6045.105/chromedriver-linux64:$PATH
 - gem install bundler
 - bundle exec rails assets:precompile RAILS_ENV=test
 - bundle exec rails db:create db:migrate RAILS_ENV=test

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -56,7 +56,7 @@ FactoryBot.define do
     end
 
     factory :pension_wise_api_user do
-      permissions { Array(User::PENSION_WISE_API_PERMISSION) }
+      permissions { [User::PENSION_WISE_API_PERMISSION, User::USER_UPDATE_PERMISSION] }
     end
   end
 end

--- a/spec/requests/sso_push_for_disabling_guider_permissions_spec.rb
+++ b/spec/requests/sso_push_for_disabling_guider_permissions_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe 'PUT /auth/gds/api/users/:id' do
+  scenario 'Signon pushing an existing, newly disabled user' do
+    given_the_user_is_a_pension_wise_api_user do
+      given_the_guider_exists
+      and_the_guider_has_future_availability
+      when_signon_pushes_their_disabled_account
+      then_their_future_availability_is_nerfed
+    end
+  end
+
+  def given_the_guider_exists
+    @guider = create(:guider)
+  end
+
+  def and_the_guider_has_future_availability
+    create(:bookable_slot, guider: @guider, start_at: 1.day.from_now)
+  end
+
+  def when_signon_pushes_their_disabled_account
+    put "/auth/gds/api/users/#{@guider.uid}", params: {
+      'user' => {
+        'uid' => @guider.uid,
+        'name' => 'Daisy Lovell',
+        'email' => 'daisy@example.com',
+        'permissions' => [],
+        'organisation_slug' => 'cita',
+        'organisation_content_id' => @guider.organisation_content_id,
+        'disabled' => true
+      }
+    }, as: :json
+  end
+
+  def then_their_future_availability_is_nerfed
+    @guider.reload
+
+    expect(@guider.bookable_slots).to be_empty
+    # ensure guider is inactive so no future schedules are generated
+    expect(@guider).not_to be_active
+  end
+end


### PR DESCRIPTION
When a guider is suspended or has the 'guider' permission removed in signon, there are some cases where their availability continues and errant appointments are created with their slots. This change ensures that when a guider is suspended, or has their 'guider' permission removed, a blank schedule is created from the current day which has the effect of removing their future availability.

When they are reinstated, their resource manager can create new availability schedules as they see fit.