### PR TITLE
Remove PSG reallocation validation

### DIFF
--- a/app/assets/javascripts/modules/calendars/allocations.es6
+++ b/app/assets/javascripts/modules/calendars/allocations.es6
@@ -210,16 +210,6 @@
     }
 
     handleEventChange(event, revertFunc) {
-      if (event.pensionWise === true) {
-        let res = this.$el.fullCalendar('getResourceById', event.resourceId);
-
-        if (res.dueDiligence === true) {
-          alert('This appointment cannot be allocated to a PSG schedule');
-          revertFunc();
-          return;
-        }
-      }
-
       event.hasChanged = true;
 
       this.eventChanges.push({

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -1,4 +1,10 @@
 module UserHelper
+  def psg_banner(guider)
+    return unless guider.due_diligence?
+
+    content_tag(:small, ' (PSG)')
+  end
+
   def can_process?(current_user, appointment)
     !current_user.tpas? && !appointment.processed_at?
   end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -150,7 +150,6 @@ class Appointment < ApplicationRecord
   validate :validate_mobile_digits, if: :tp_agent?
   validate :validate_secondary_status
   validate :validate_lloyds_signposted_guider_allocated, if: :lloyds_signposted?, on: :create
-  validate :validate_guider_schedule_type, on: :update, if: :pension_wise?
   validate :validate_pending_overlaps, if: :due_diligence?, on: :create
   validate :validate_signposting
   validate :validate_small_pots, if: :small_pots?
@@ -670,10 +669,6 @@ class Appointment < ApplicationRecord
 
   def validate_lloyds_signposted_guider_allocated
     errors.add(:guider, 'The guider is not from an LBGPTL schedule') unless cita?
-  end
-
-  def validate_guider_schedule_type
-    errors.add(:guider, 'Cannot be reallocated to a non Pension Wise guider') if guider&.due_diligence?
   end
 
   def validate_pending_overlaps # rubocop:disable Metrics/MethodLength

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,5 +1,4 @@
 class UserSerializer < ActiveModel::Serializer
   attribute :id
   attribute :name, key: :title
-  attribute :due_diligence?, key: :dueDiligence
 end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -37,7 +37,7 @@
                 <span class="sr-only">Select <%= guider.name %></span>
               </label>
             </td>
-            <td><span class="glyphicon glyphicon-user" aria-hidden="true"></span> <span class="name"><%= guider.name %></span></td>
+            <td><span class="glyphicon glyphicon-user" aria-hidden="true"></span> <span class="name"><%= guider.name %><%= psg_banner(guider) %></span></td>
             <td>
               <% guider.groups.each do |group| %>
                 <span class="label label-info <%= dom_id(group) %> t-group"><%= group.name %></span>

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -335,17 +335,6 @@ RSpec.describe Appointment, type: :model do
       end
     end
 
-    context 'when the appointment is for Pension Wise' do
-      it 'cannot be moved to a `due_diligence` enrolled guider' do
-        pension_wise_appointment = create(:appointment)
-        due_diligence_guider     = create(:guider, :due_diligence)
-
-        pension_wise_appointment.guider = due_diligence_guider
-
-        expect(pension_wise_appointment).to be_invalid
-      end
-    end
-
     context 'when due diligence' do
       subject { build(:appointment, :due_diligence) }
 


### PR DESCRIPTION
This will be redundant once the guiders are legitimate guiders and not the 'fake' PSG scheduled guiders.