### PR TITLE
Ensure customer update email sent correctly

### DIFF
--- a/spec/jobs/customer_update_job_spec.rb
+++ b/spec/jobs/customer_update_job_spec.rb
@@ -23,4 +23,18 @@ RSpec.describe CustomerUpdateJob, '#perform' do
       expect(appointment.activities.first).to be_a(DropActivity)
     end
   end
+
+  context 'when the appointment is not pending' do
+    context 'when an appointment updated attempt is made' do
+      it 'does not send the notification or log an activity' do
+        appointment = create(:appointment, status: :cancelled_by_customer_sms)
+
+        expect(AppointmentMailer).to_not receive(:updated)
+
+        described_class.new.perform(appointment, CustomerUpdateActivity::UPDATED_MESSAGE)
+
+        expect(CustomerUpdateActivity.count).to be_zero
+      end
+    end
+  end
 end


### PR DESCRIPTION
There was an edge case where the appointment could be in a non-pending status and the customer would still receive an email informing them their appointment was updated, when an agent or other individual changed the underlying appointment. This change ensures we guard against this eventually by always checking whether the appointment is still in the pending phase.