### PR TITLE
Money Helper address change

### DIFF
--- a/app/views/consents/create.html.erb
+++ b/app/views/consents/create.html.erb
@@ -68,10 +68,11 @@ accordance with the Data Protection Act 2018.
 </p>
 
 <p>
-Please return the completed form to Pension Wise Money and Pensions Service,
-120 Holborn, London EC1N 2TD. Or you can email a scanned copy to:
-contact.pensionwise@moneyhelper.org.uk. If your appointment will be delivered
-face to face then you can bring the form to the appointment.
+Please return the completed form to Money and Pensions Service, Pension Wise
+(MoneyHelper), Borough Hall, 138 Cauldwell Street, Bedford, MK42 9AP. Or you
+can email a scanned copy to: contact.pensionwise@moneyhelper.org.uk. If your
+appointment will be delivered face to face then you can bring the form to the
+appointment.
 </p>
 
 <p>

--- a/app/views/shared/email/_money_helper.html.erb
+++ b/app/views/shared/email/_money_helper.html.erb
@@ -22,7 +22,7 @@
   MoneyHelper collects and stores personal data for the purpose of delivering
   pensions guidance. Full details of our privacy policy, including information on
   your rights in relation to the data we hold can be found at
-  <a href="https://www.moneyhelper.org.uk/privacy">moneyhelper.org.uk/privacy</a>. <% if @appointment.pension_wise? %>Alternatively, please write to Pension Wise, P.O. Box 10404, LE65 9EH.<% end %>
+  <a href="https://www.moneyhelper.org.uk/privacy">moneyhelper.org.uk/privacy</a>. <% if @appointment.pension_wise? %>Alternatively, please write to Money and Pensions Service, Pension Wise (MoneyHelper), Borough Hall, 138 Cauldwell Street, Bedford, MK42 9AP.<% end %>
 <% end %>
 
 <%= p do %>

--- a/app/views/shared/email/_money_helper.text.erb
+++ b/app/views/shared/email/_money_helper.text.erb
@@ -15,7 +15,7 @@ you’ll need to see a regulated financial adviser or seek legal advice.
 MoneyHelper collects and stores personal data for the purpose of delivering
 pensions guidance. Full details of our privacy policy, including information on
 your rights in relation to the data we hold can be found at
-https://www.moneyhelper.org.uk/privacy. <% if @appointment.pension_wise? %>Alternatively, please write to Pension Wise, P.O. Box 10404, LE65 9EH.<% end %>
+https://www.moneyhelper.org.uk/privacy. <% if @appointment.pension_wise? %>Alternatively, please write to Money and Pensions Service, Pension Wise (MoneyHelper), Borough Hall, 138 Cauldwell Street, Bedford, MK42 9AP.<% end %>
 
 Find out more about when and how to get professional advice in our guide ‘Do
 you need a financial adviser’:


### PR DESCRIPTION
Changes the office address to the new Bedford location in both the customer emails and the PDF third-party consent form.