### PR TITLE
Log an activity when SMS reminder fails

### DIFF
--- a/app/models/sms_reminder_failure_activity.rb
+++ b/app/models/sms_reminder_failure_activity.rb
@@ -1,0 +1,10 @@
+class SmsReminderFailureActivity < Activity
+  def self.from(appointment)
+    create!(
+      owner: appointment.guider,
+      appointment:,
+      message: "could not deliver an SMS reminder to '#{appointment.canonical_sms_number}'. " \
+        'The number is incorrect or invalid.'
+    )
+  end
+end

--- a/app/views/activities/_sms_reminder_failure_activity.html.erb
+++ b/app/views/activities/_sms_reminder_failure_activity.html.erb
@@ -1,0 +1,5 @@
+<% content_for(:activity_message, flush: true) do %>
+  <span class="glyphicon glyphicon-phone" aria-hidden="true"></span>
+  <strong>The system</strong> <%= sms_reminder_failure_activity.message %>
+<% end %>
+<%= render 'activities/activity', activity: sms_reminder_failure_activity, details: details, hide: hide %>

--- a/spec/jobs/sms_appointment_reminder_job_spec.rb
+++ b/spec/jobs/sms_appointment_reminder_job_spec.rb
@@ -38,6 +38,18 @@ RSpec.describe SmsAppointmentReminderJob, '#perform' do
   context 'for Pension Wise' do
     let(:appointment) { create(:appointment, created_at: 1.day.ago) }
 
+    context 'when Notify cannot send the SMS to the given number' do
+      it 'creates an SMS failure activity' do
+        allow(client).to receive(:send_sms)
+          .and_raise(Notifications::Client::BadRequestError.new(double(code: 400, body: 'meh')))
+
+        described_class.new.perform(appointment)
+
+        expect(appointment.activities.find_by(type: 'SmsReminderFailureActivity')).to be
+        expect(appointment.activities.find_by(type: 'SmsReminderActivity')).to be_nil
+      end
+    end
+
     context 'for non-BSL appointments' do
       it 'sends an SMS with the standard template' do
         travel_to(Time.zone.parse('2018-07-03 12:00')) do


### PR DESCRIPTION
If notify cannot deliver the SMS we create an activity and assign the guider as the owner.