### PR TITLE
Broaden summary document button visibility

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -297,9 +297,7 @@ class Appointment < ApplicationRecord
     start_at >= BookableSlot.next_valid_start_date
   end
 
-  def can_create_summary?(agent = nil)
-    return false if agent&.tpas_agent? && !guider.tpas?
-
+  def can_create_summary?
     complete? || ineligible_age? || ineligible_pension_type?
   end
 

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -55,7 +55,7 @@
         <span>Process</span>
       <% end %>
     <% end %>
-    <% if @appointment.can_create_summary?(current_user) %>
+    <% if @appointment.can_create_summary? %>
       <%= link_to SummaryDocumentLink.generate(@appointment), title: 'Create summary', class: 'btn btn-info', target: '_blank', data: summary_prompt_data(@appointment) do %>
         <span class="glyphicon glyphicon-print" aria-hidden="true"></span>
         <span>Create Summary</span>

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -1065,27 +1065,6 @@ RSpec.describe Appointment, type: :model do
         it 'is true' do
           expect(result).to be true
         end
-
-        context 'a TPAS agent' do
-          let(:agent) { build_stubbed(:resource_manager, :tpas) }
-          let(:result) { Appointment.new(status:, guider:).can_create_summary?(agent) }
-
-          context 'attempts to create a summary belonging to another organisation' do
-            let(:guider) { build(:guider, :cas) }
-
-            it 'is false' do
-              expect(result).to be false
-            end
-          end
-
-          context 'attempts to create a summary belonging to them' do
-            let(:guider) { build_stubbed(:guider, :tpas) }
-
-            it 'is true' do
-              expect(result).to be true
-            end
-          end
-        end
       end
     end
 


### PR DESCRIPTION
This change allows anyone to create summary documents within their organisation. Pension Ops can create across all organisations.