### PR TITLE
Don't scope resource managers to `active`

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,7 +50,6 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
     colleagues
       .where('permissions @> ?', %(["#{RESOURCE_MANAGER_PERMISSION}"]))
       .enabled
-      .active
       .unexcluded
   end
 


### PR DESCRIPTION
This scope is used to determine which resource managers to notify, wherever it's used. `active` doesn't make sense for resource managers since unless they have the `guider` permission, they won't appear in a screen where this flag could be toggled. I think it was included historically just to maintain parity with how guiders are retrieved, but this doesn't make sense.