### PR TITLE
Add Welsh language appointments flag

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -227,6 +227,7 @@ class AppointmentsController < ApplicationController
       small_pots
       nudged
       internal_availability
+      welsh
     ]
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -49,6 +49,7 @@ class Appointment < ApplicationRecord
     referrer
     small_pots
     country_code
+    welsh
   ].freeze
 
   enum status: { pending: 0, complete: 1, no_show: 2, incomplete: 3, ineligible_age: 4,
@@ -361,6 +362,12 @@ class Appointment < ApplicationRecord
     phone.start_with?('07') || mobile.start_with?('07')
   end
 
+  def owned_by_my_organisation?(myself)
+    return true unless guider
+
+    myself.organisation_content_id == guider.organisation_content_id
+  end
+
   def cancel!
     without_auditing do
       transaction do
@@ -449,10 +456,6 @@ class Appointment < ApplicationRecord
   end
 
   private
-
-  def owned_by_my_organisation?(myself)
-    myself.organisation_content_id == guider.organisation_content_id
-  end
 
   def track_initial_status
     status_transitions << StatusTransition.new(status:)

--- a/app/views/appointments/_personal_details_form.html.erb
+++ b/app/views/appointments/_personal_details_form.html.erb
@@ -86,6 +86,7 @@
     <%= f.check_box :accessibility_requirements, class: 't-accessibility-requirements', label: 'Do you require an adjustment to access our service?' %>
 
     <% unless @appointment.due_diligence? %>
+      <%= f.check_box :welsh, class: 't-welsh', label: 'Welsh language appointment?', disabled: !@appointment.owned_by_my_organisation?(current_user) %>
     <%= f.check_box :third_party_booking, class: 't-third-party-booked', label: 'Third party appointment?', data: { target: 'consent' } %>
     <div class="col-md-offset-1" id="consent">
       <p><strong>This appointment will be delivered to a third party on behalf of the data subject:</strong></p>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -5,6 +5,10 @@
 ) %>
 
 <h4>
+  <% if @appointment.welsh? %>
+    <span class="label label-default t-welsh-appointment">Welsh Language Appointment</span></span>
+  <% end %>
+
   <% if @appointment.nudged? %>
     <span class="label label-default t-nudged">Nudged</span></span>
   <% end %>

--- a/app/views/appointments/preview.html.erb
+++ b/app/views/appointments/preview.html.erb
@@ -21,6 +21,7 @@
   <%= f.hidden_field :end_at %>
   <%= f.hidden_field :guider_id %>
   <%= f.hidden_field :third_party_booking %>
+  <%= f.hidden_field :welsh %>
 
   <%= f.hidden_field :first_name %>
   <%= f.hidden_field :last_name %>
@@ -201,6 +202,12 @@
             <% if @appointment.due_diligence? %>
             <tr>
               <td class="active"><b>PSG appointment?</b></td>
+              <td>Yes</td>
+            </tr>
+            <% end %>
+            <% if @appointment.welsh? %>
+            <tr>
+              <td class="active"><b>Welsh language appointment?</b></td>
               <td>Yes</td>
             </tr>
             <% end %>

--- a/db/migrate/20240326090221_add_welsh_to_appointments.rb
+++ b/db/migrate/20240326090221_add_welsh_to_appointments.rb
@@ -1,0 +1,5 @@
+class AddWelshToAppointments < ActiveRecord::Migration[6.1]
+  def change
+    add_column :appointments, :welsh, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_13_111659) do
+ActiveRecord::Schema.define(version: 2024_03_26_090221) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -119,6 +119,7 @@ ActiveRecord::Schema.define(version: 2024_02_13_111659) do
     t.string "nudge_confirmation", default: "", null: false
     t.string "nudge_eligibility_reason", default: "", null: false
     t.string "country_code", default: "GB", null: false
+    t.boolean "welsh", default: false, null: false
     t.index ["guider_id", "start_at"], name: "unique_slot_guider_in_appointment", unique: true, where: "((status <> ALL (ARRAY[5, 6, 7, 8])) AND (start_at > '2022-07-02 00:00:00'::timestamp without time zone))"
     t.index ["guider_id"], name: "index_appointments_on_guider_id"
     t.index ["schedule_type"], name: "index_appointments_on_schedule_type"

--- a/spec/features/agent_manages_appointments_spec.rb
+++ b/spec/features/agent_manages_appointments_spec.rb
@@ -514,6 +514,7 @@ RSpec.feature 'Agent manages appointments' do
     @page.end_at.set day.change(hour: 10, min: 40).to_s
     @page.type_of_appointment_standard.set true
     @page.where_you_heard.select 'Other'
+    @page.welsh.set true
     @page.address_line_one.set(options[:address_line_one]) if options[:address_line_one]
     @page.town.set(options[:town]) if options[:town]
     @page.postcode.set(options[:postcode]) if options[:postcode]
@@ -549,6 +550,7 @@ RSpec.feature 'Agent manages appointments' do
     expect(@page.preview).to have_content 'Smarter signposted referral? Yes' if options[:smarter_signposted]
     expect(@page.preview).to have_content 'Small pots appointment? Yes' if options[:small_pots]
     expect(@page.preview).to have_content 'Stronger Nudge appointment? Yes' if options[:stronger_nudge]
+    expect(@page.preview).to have_content 'Welsh language appointment? Yes'
   end
 
   def and_they_fill_in_their_appointment_details_without_an_email
@@ -586,6 +588,7 @@ RSpec.feature 'Agent manages appointments' do
     expect(appointment).to_not be_bsl_video
     expect(appointment).to be_small_pots if options[:small_pots]
     expect(appointment).to be_nudged if options[:stronger_nudge]
+    expect(appointment).to be_welsh
   end
 
   def and_the_customer_gets_an_email_confirmation

--- a/spec/features/agent_searches_for_appointments_spec.rb
+++ b/spec/features/agent_searches_for_appointments_spec.rb
@@ -180,7 +180,7 @@ RSpec.feature 'Agent searches for appointments' do
   end
 
   def then_they_can_see_all_appointments
-    expected = @appointments.map { |a| "##{a.id}" }
+    expected = @appointments.map { |a| "##{a.id}" }.sort
     actual = @page.results.map(&:id).map(&:text).sort
     expect(actual).to eq expected
   end

--- a/spec/features/booking_due_diligence_appointments_spec.rb
+++ b/spec/features/booking_due_diligence_appointments_spec.rb
@@ -140,6 +140,7 @@ RSpec.feature 'Booking due diligence appointments', js: true do
   end
 
   def and_they_are_presented_with_the_correct_fields
+    expect(@page).to have_no_welsh
     expect(@page).to have_no_third_party_booked
     expect(@page).to have_no_smarter_signposted
     expect(@page).to have_no_type_of_appointment_standard

--- a/spec/support/pages/new_appointment.rb
+++ b/spec/support/pages/new_appointment.rb
@@ -17,6 +17,7 @@ module Pages
     element :memorable_word,                        '.t-memorable-word'
     element :accessibility_requirements,            '.t-accessibility-requirements'
 
+    element :welsh,                                 '.t-welsh'
     element :third_party_booked,                    '.t-third-party-booked'
     element :data_subject_name,                     '.t-data-subject-name'
     element :data_subject_date_of_birth_day,        '.t-data-subject-date-of-birth-day'


### PR DESCRIPTION
This is managed by anyone for their own organisation but is disabled when viewing another organisation's appointment(s). Does not trigger changed notifications.