### PR TITLE
Remove redundant paragraph spacing

### DIFF
--- a/app/views/consents/create.html.erb
+++ b/app/views/consents/create.html.erb
@@ -18,13 +18,10 @@ Wales and Citizens Advice Scotland.
 <p>
 During a Pension Wise guidance appointment, questions will be asked about your
 personal and family affairs, financial arrangements and plans and general state
-of health to inform the options we run through.
-</p>
-
-<p>
-Your personal data will be securely stored by Pension Wise and our delivery
-partners to monitor quality of service and respond to queries and complaints.
-The call will be recorded and stored securely for a period of 6 years.
+of health to inform the options we run through. Your personal data will be
+securely stored by Pension Wise and our delivery partners to monitor quality of
+service and respond to queries and complaints. The call will be recorded and
+stored securely for a period of 6 years.
 </p>
 
 <p>


### PR DESCRIPTION
This brings the form down to a single page.