### PR TITLE
Email consent should be an email field

### DIFF
--- a/app/views/appointments/_personal_details_form.html.erb
+++ b/app/views/appointments/_personal_details_form.html.erb
@@ -134,7 +134,7 @@
 
       <%= f.check_box :email_consent_form_required, class: 't-email-consent-form-required', data: { target: 'email-consent' } %>
       <div class="col-md-offset-1" id="email-consent">
-        <%= f.text_field :email_consent, autocomplete: 'off', class: 't-email-consent', label: 'Consent email', placeholder: 'A consent form is sent to this email' %>
+        <%= f.email_field :email_consent, autocomplete: 'off', class: 't-email-consent', label: 'Consent email', placeholder: 'A consent form is sent to this email' %>
       </div>
 
       <%= f.check_box :printed_consent_form_required, class: 't-printed-consent-form-required', data: { target: 'printed-consent' } %>


### PR DESCRIPTION
This stops some dud entries being given and uses the right keyboard on mobile devices.