### PR TITLE
Strip non-numeric characters for mobile payloads

### DIFF
--- a/app/lib/casebook/presenters/create.rb
+++ b/app/lib/casebook/presenters/create.rb
@@ -12,7 +12,7 @@ module Casebook
               first_name: appointment.first_name,
               last_name: appointment.last_name,
               date_of_birth: appointment.date_of_birth.to_s,
-              mobile_phone: appointment.canonical_sms_number,
+              mobile_phone: appointment.canonical_sms_number.gsub(/\D/, ''),
               email: appointment.email,
               starts_at: starts_at.iso8601,
               ends_at: ends_at.iso8601,

--- a/spec/lib/casebook/api_spec.rb
+++ b/spec/lib/casebook/api_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Casebook::Api do # rubocop:disable Metrics/BlockLength
               first_name: 'Daisy',
               last_name: 'George',
               location_id: 26_089,
-              mobile_phone: '07715 930 444',
+              mobile_phone: '07715930444',
               notes: "Pension Wise online booking ##{appointment.id}.",
               starts_at: '2024-02-22T13:00:00Z',
               user_id: 90_939
@@ -74,7 +74,7 @@ RSpec.describe Casebook::Api do # rubocop:disable Metrics/BlockLength
               first_name: 'Daisy',
               last_name: 'George',
               location_id: 26_089,
-              mobile_phone: '07715 930 444',
+              mobile_phone: '07715930444',
               notes: "Pension Wise online booking ##{appointment.id}.",
               starts_at: '2024-02-22T13:00:00Z',
               user_id: 90_939,

--- a/spec/lib/casebook/presenters/create_spec.rb
+++ b/spec/lib/casebook/presenters/create_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Casebook::Presenters::Create, '#to_h' do # rubocop:disable Metric
       first_name: appointment.first_name,
       last_name: appointment.last_name,
       date_of_birth: '1945-01-01',
-      mobile_phone: '07715 930 444',
+      mobile_phone: '07715930444',
       email: 'someone@example.com',
       notes: "Pension Wise online booking ##{appointment.id}.",
       user_id: appointment.guider.casebook_guider_id,

--- a/spec/lib/casebook/presenters/reschedule_spec.rb
+++ b/spec/lib/casebook/presenters/reschedule_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Casebook::Presenters::Reschedule, '#to_h' do
       first_name: appointment.first_name,
       last_name: appointment.last_name,
       date_of_birth: '1945-01-01',
-      mobile_phone: '07715 930 444',
+      mobile_phone: '07715930444',
       email: 'someone@example.com',
       notes: "Pension Wise online booking ##{appointment.id}.",
       user_id: appointment.guider.casebook_guider_id,


### PR DESCRIPTION
This helps match casebook's expectations.