### PR TITLE
Guard against Casebook reschedule attempts

### DIFF
--- a/app/jobs/reschedule_casebook_appointment_job.rb
+++ b/app/jobs/reschedule_casebook_appointment_job.rb
@@ -1,6 +1,6 @@
 class RescheduleCasebookAppointmentJob < CasebookJob
   def perform(appointment)
-    return unless appointment.casebook_pushable_guider?
+    return unless appointment.casebook_pushable_guider? && appointment.casebook_appointment_id?
 
     Casebook::Reschedule.new(appointment).call
   end


### PR DESCRIPTION
In the case of appointments that were not originally pushed to Casebook, we mustn't attempt to 'reschedule' them via Casebook as it will cause a 404 error response since the TAP appointment does not hold the Casebook appointment ID.