### PR TITLE
Alter duplicate checks to match DoB

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -258,7 +258,8 @@ class Appointment < ApplicationRecord
         .where(
           first_name:,
           last_name:,
-          start_at: start_at.beginning_of_day..start_at.end_of_day
+          date_of_birth:,
+          status: :pending
         )
         .order(:id)
         .take(10)


### PR DESCRIPTION
Rather than attempting to match the appointment day, match on the DoB too.