### PR TITLE
Ensure Casebook cancellation occurs correctly

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -396,10 +396,10 @@ class Appointment < ApplicationRecord
     without_auditing do
       transaction do
         update!(status: :cancelled_by_customer_sms)
-
-        CancelCasebookAppointmentJob.perform_later(self)
         SmsCancellationActivity.from(self)
       end
+
+      CancelCasebookAppointmentJob.perform_later(self)
     end
   end
 


### PR DESCRIPTION
When the job executes in the context of the transaction there is a timing issue meaning the cancellation status will not yet be persisted, causing the casebook cancellation job to short-circuit due to the `Appointment#cancelled?` evaluating false.