### PR TITLE
Don't send printed confirmation of reallocation

### DIFF
--- a/app/lib/notifier.rb
+++ b/app/lib/notifier.rb
@@ -30,7 +30,7 @@ class Notifier
   def notify_casebook
     if appointment_cancelled?
       CancelCasebookAppointmentJob.perform_later(appointment)
-    elsif appointment_rescheduled?
+    elsif appointment_reallocated?
       RescheduleCasebookAppointmentJob.perform_later(appointment)
     end
   end
@@ -38,7 +38,7 @@ class Notifier
   def notify_resource_managers
     if appointment_cancelled?
       AppointmentCancelledNotificationsJob.perform_later(appointment)
-    elsif appointment_rescheduled?
+    elsif appointment_reallocated?
       AppointmentRescheduledNotificationsJob.perform_later(appointment)
     elsif requires_adjustment_notification?
       AdjustmentNotificationsJob.perform_later(appointment)
@@ -128,8 +128,12 @@ class Notifier
       appointment.no_show?
   end
 
-  def appointment_rescheduled?
+  def appointment_reallocated?
     appointment.previous_changes.slice('guider_id', 'start_at').present?
+  end
+
+  def appointment_rescheduled?
+    appointment.previous_changes.slice('start_at').present?
   end
 
   attr_reader :appointment, :modifying_agent

--- a/spec/lib/notifier_spec.rb
+++ b/spec/lib/notifier_spec.rb
@@ -138,12 +138,22 @@ RSpec.describe Notifier, '#call' do
     end
 
     context 'with a postal address' do
-      it 'enqueues a printed confirmation' do
-        appointment.update_attribute(:start_at, Time.zone.parse('2022-07-27 13:00'))
+      context 'when the appointment is rescheduled by date/time' do
+        it 'enqueues a printed confirmation' do
+          appointment.update_attribute(:start_at, Time.zone.parse('2022-07-27 13:00'))
 
-        expect(PrintedConfirmationJob).to receive(:perform_later).with(appointment)
+          expect(PrintedConfirmationJob).to receive(:perform_later).with(appointment)
 
-        subject.call
+          subject.call
+        end
+      end
+
+      context 'when the appointment is only reallocated' do
+        it 'does not enqueue a printed confirmation' do
+          expect(PrintedConfirmationJob).to_not receive(:perform_later).with(appointment)
+
+          subject.call
+        end
       end
     end
 


### PR DESCRIPTION
This shouldn't occur as the customer only needs to be informed when the appointment date/time changes, not when this remains the same but the guider has changed eg reallocation.