### PR TITLE
Refresh allocations calendar when changed

### DIFF
--- a/app/assets/javascripts/modules/calendars/allocations.es6
+++ b/app/assets/javascripts/modules/calendars/allocations.es6
@@ -44,6 +44,11 @@
     }
 
     handlePushEvent() {
+      if (this.$actionPanel.is(':visible')) {
+        alert('The calendar events have changed and the calendar will be refreshed.');
+        this.$actionPanel.find('.js-action-panel-undo-all').click();
+      }
+
       this.$el.fullCalendar('removeEvents');
       this.$el.fullCalendar('refetchEvents');
     }

--- a/app/assets/javascripts/modules/calendars/allocations.es6
+++ b/app/assets/javascripts/modules/calendars/allocations.es6
@@ -1,4 +1,4 @@
-/* global CompanyCalendar */
+/* global CompanyCalendar, Pusher */
 {
   'use strict';
 
@@ -36,6 +36,34 @@
 
       this.setCalendarToCorrectHeight();
       this.setupUndo();
+    }
+
+    viewRender(view) {
+      const channel = Pusher.instance.subscribe('telephone_appointment_planner');
+      channel.bind(`${view.start.format('YYYY-MM-DD')}-${this.config.userOrganisationId}`, this.handlePushEvent.bind(this));
+    }
+
+    handlePushEvent() {
+      this.$el.fullCalendar('removeEvents');
+      this.$el.fullCalendar('refetchEvents');
+    }
+
+    select(start, end, jsEvent, view, resource) {
+      let title = prompt(`Name of holiday period for ${resource.title}?`);
+
+      if (title) {
+        this.$holidayForm.find('.js-user-id').val(resource.id);
+        this.$holidayForm.find('.js-title').val(title);
+        this.$holidayForm.find('.js-start-at').val(start.format());
+        this.$holidayForm.find('.js-end-at').val(end.format());
+        this.$holidayForm.submit();
+      }
+
+      this.$el.fullCalendar('unselect');
+    }
+
+    selectOverlap(event) {
+      return (event.source.eventType != 'holiday');
     }
 
     bindEvents() {

--- a/app/assets/javascripts/modules/calendars/allocations.es6
+++ b/app/assets/javascripts/modules/calendars/allocations.es6
@@ -43,10 +43,12 @@
       channel.bind(`${view.start.format('YYYY-MM-DD')}-${this.config.userOrganisationId}`, this.handlePushEvent.bind(this));
     }
 
-    handlePushEvent() {
-      if (this.$actionPanel.is(':visible')) {
-        alert('The calendar events have changed and the calendar will be refreshed.');
-        this.$actionPanel.find('.js-action-panel-undo-all').click();
+    handlePushEvent(data) {
+      if (this.config.userUid != data.ownerId) {
+        if (this.$actionPanel.is(':visible')) {
+          alert('The calendar events have changed and the calendar will be refreshed.');
+          this.$actionPanel.find('.js-action-panel-undo-all').click();
+        }
       }
 
       this.$el.fullCalendar('removeEvents');

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -7,7 +7,7 @@ class AppointmentsController < ApplicationController
   end
 
   def batch_update
-    BatchAppointmentUpdate.new(params[:changes]).call
+    BatchAppointmentUpdate.new(params[:changes], current_user).call
     head :ok
   end
 

--- a/app/jobs/pusher_appointment_calendar_alterations_job.rb
+++ b/app/jobs/pusher_appointment_calendar_alterations_job.rb
@@ -1,0 +1,18 @@
+class PusherAppointmentCalendarAlterationsJob < ApplicationJob
+  queue_as :default
+
+  def perform(appointment)
+    trigger_notification("#{appointment.start_at.to_date}-#{appointment.guider.organisation_content_id}")
+
+    return unless (@changes = appointment.previous_changes['start_at'])
+    return unless @changes.first
+
+    trigger_notification("#{@changes.first.to_date}-#{appointment.guider.organisation_content_id}")
+  end
+
+  private
+
+  def trigger_notification(key)
+    Pusher.trigger('telephone_appointment_planner', key, refresh: true)
+  end
+end

--- a/app/jobs/pusher_appointment_calendar_alterations_job.rb
+++ b/app/jobs/pusher_appointment_calendar_alterations_job.rb
@@ -1,18 +1,29 @@
 class PusherAppointmentCalendarAlterationsJob < ApplicationJob
   queue_as :default
 
-  def perform(appointment)
-    trigger_notification("#{appointment.start_at.to_date}-#{appointment.guider.organisation_content_id}")
+  def perform(appointment, modifying_agent)
+    trigger_notification(
+      "#{appointment.start_at.to_date}-#{appointment.guider.organisation_content_id}",
+      modifying_agent
+    )
 
     return unless (@changes = appointment.previous_changes['start_at'])
     return unless @changes.first
 
-    trigger_notification("#{@changes.first.to_date}-#{appointment.guider.organisation_content_id}")
+    trigger_notification(
+      "#{@changes.first.to_date}-#{appointment.guider.organisation_content_id}",
+      modifying_agent
+    )
   end
 
   private
 
-  def trigger_notification(key)
-    Pusher.trigger('telephone_appointment_planner', key, refresh: true)
+  def trigger_notification(key, modifying_agent)
+    Pusher.trigger(
+      'telephone_appointment_planner',
+      key,
+      refresh: true,
+      ownerId: modifying_agent&.uid
+    )
   end
 end

--- a/app/lib/batch_appointment_update.rb
+++ b/app/lib/batch_appointment_update.rb
@@ -1,13 +1,14 @@
 class BatchAppointmentUpdate
-  def initialize(changes)
+  def initialize(changes, current_user)
     @changes = JSON.parse(changes)
+    @current_user = current_user
   end
 
   def call
     changes.each do |change|
       appointment = update_appointment(change)
 
-      Notifier.new(appointment).call
+      Notifier.new(appointment, @current_user).call
     end
   end
 

--- a/app/lib/notifier.rb
+++ b/app/lib/notifier.rb
@@ -1,4 +1,4 @@
-class Notifier
+class Notifier # rubocop:disable Metrics/ClassLength
   NOTIFY_RESOURCE_MANAGER_ATTRIBUTES = %w[
     first_name
     last_name
@@ -20,9 +20,16 @@ class Notifier
     notify_customer
     notify_guiders
     notify_resource_managers
+    notify_calendar_alterations
   end
 
   private
+
+  def notify_calendar_alterations
+    return unless status_changed? || appointment_reallocated?
+
+    PusherAppointmentCalendarAlterationsJob.perform_later(appointment)
+  end
 
   def notify_resource_managers # rubocop:disable Metrics/AbcSize
     if appointment_cancelled?
@@ -80,8 +87,7 @@ class Notifier
   end
 
   def appointment_complete?
-    appointment.previous_changes.slice('status').present? &&
-      appointment.complete?
+    status_changed? && appointment.complete?
   end
 
   def requires_agent_changed_notification?
@@ -99,13 +105,11 @@ class Notifier
   end
 
   def appointment_cancelled?
-    appointment.previous_changes.slice('status').present? &&
-      appointment.cancelled?
+    status_changed? && appointment.cancelled?
   end
 
   def appointment_missed?
-    appointment.previous_changes.slice('status').present? &&
-      appointment.no_show?
+    status_changed? && appointment.no_show?
   end
 
   def appointment_reallocated?
@@ -119,6 +123,10 @@ class Notifier
   def requires_rescheduled_away_notification?
     appointment.previous_changes.slice('previous_guider_id').present? &&
       appointment.guider_organisation_differs?
+  end
+
+  def status_changed?
+    appointment.previous_changes.slice('status').present?
   end
 
   attr_reader :appointment, :modifying_agent

--- a/app/lib/notifier.rb
+++ b/app/lib/notifier.rb
@@ -28,7 +28,7 @@ class Notifier # rubocop:disable Metrics/ClassLength
   def notify_calendar_alterations
     return unless status_changed? || appointment_reallocated?
 
-    PusherAppointmentCalendarAlterationsJob.perform_later(appointment)
+    PusherAppointmentCalendarAlterationsJob.perform_later(appointment, modifying_agent)
   end
 
   def notify_resource_managers # rubocop:disable Metrics/AbcSize

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -19,6 +19,7 @@
   id="AllocationsCalendar"
   class="company-calendar js-calendar t-calendar"
   data-module="allocations-calendar"
+  data-config='{ "userOrganisationId": "<%= current_user.organisation_content_id %>"}'
   data-default-date="<%= Time.zone.now %>"
   data-filter-select-id="filter_guiders">
 </div>

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -19,7 +19,7 @@
   id="AllocationsCalendar"
   class="company-calendar js-calendar t-calendar"
   data-module="allocations-calendar"
-  data-config='{ "userOrganisationId": "<%= current_user.organisation_content_id %>"}'
+  data-config='{ "userOrganisationId": "<%= current_user.organisation_content_id %>", "userUid": "<%= current_user.uid %>" }'
   data-default-date="<%= Time.zone.now %>"
   data-filter-select-id="filter_guiders">
 </div>

--- a/spec/jobs/pusher_appointment_calendar_alterations_job_spec.rb
+++ b/spec/jobs/pusher_appointment_calendar_alterations_job_spec.rb
@@ -2,10 +2,11 @@ require 'rails_helper'
 
 RSpec.describe PusherAppointmentCalendarAlterationsJob, '#perform' do # rubocop:disable Metrics/BlockLength
   let(:appointment) { create(:appointment, start_at: Time.zone.parse('2024-05-15 13:00')) }
+  let(:modifying_agent) { create(:resource_manager) }
 
   before { allow(Pusher).to receive(:trigger) }
 
-  subject { described_class.new.perform(appointment) }
+  subject { described_class.new.perform(appointment, modifying_agent) }
 
   context 'when something other than `start_at` changed' do
     it 'triggers once for the current `start_at`' do
@@ -14,7 +15,8 @@ RSpec.describe PusherAppointmentCalendarAlterationsJob, '#perform' do # rubocop:
       expect(Pusher).to have_received(:trigger).with(
         'telephone_appointment_planner',
         '2024-05-15-14a48488-a42f-422d-969d-526e30922fe4',
-        refresh: true
+        refresh: true,
+        ownerId: modifying_agent.uid
       )
     end
   end
@@ -33,13 +35,15 @@ RSpec.describe PusherAppointmentCalendarAlterationsJob, '#perform' do # rubocop:
       expect(Pusher).to have_received(:trigger).with(
         'telephone_appointment_planner',
         '2024-05-15-14a48488-a42f-422d-969d-526e30922fe4',
-        refresh: true
+        refresh: true,
+        ownerId: modifying_agent.uid
       )
 
       expect(Pusher).to have_received(:trigger).with(
         'telephone_appointment_planner',
         '2024-05-16-14a48488-a42f-422d-969d-526e30922fe4',
-        refresh: true
+        refresh: true,
+        ownerId: modifying_agent.uid
       )
     end
   end

--- a/spec/jobs/pusher_appointment_calendar_alterations_job_spec.rb
+++ b/spec/jobs/pusher_appointment_calendar_alterations_job_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe PusherAppointmentCalendarAlterationsJob, '#perform' do # rubocop:disable Metrics/BlockLength
+  let(:appointment) { create(:appointment, start_at: Time.zone.parse('2024-05-15 13:00')) }
+
+  before { allow(Pusher).to receive(:trigger) }
+
+  subject { described_class.new.perform(appointment) }
+
+  context 'when something other than `start_at` changed' do
+    it 'triggers once for the current `start_at`' do
+      subject
+
+      expect(Pusher).to have_received(:trigger).with(
+        'telephone_appointment_planner',
+        '2024-05-15-14a48488-a42f-422d-969d-526e30922fe4',
+        refresh: true
+      )
+    end
+  end
+
+  context 'when the `start_at` changed' do
+    it 'triggers for the prior `start_at` as well' do
+      appointment.update!(
+        start_at: '2024-05-16 13:00',
+        end_at: '2024-05-16 14:10',
+        rescheduling_reason: Appointment::OFFICE_RESCHEDULED,
+        rescheduling_route: 'unplanned_absence'
+      )
+
+      subject
+
+      expect(Pusher).to have_received(:trigger).with(
+        'telephone_appointment_planner',
+        '2024-05-15-14a48488-a42f-422d-969d-526e30922fe4',
+        refresh: true
+      )
+
+      expect(Pusher).to have_received(:trigger).with(
+        'telephone_appointment_planner',
+        '2024-05-16-14a48488-a42f-422d-969d-526e30922fe4',
+        refresh: true
+      )
+    end
+  end
+end


### PR DESCRIPTION
When a change is made to an appointment to either its status, guider or start date/time, anybody viewing the allocations calendar will have their view refreshed in realtime to see the changes.