### PR TITLE
Add cancellation via option

### DIFF
--- a/app/assets/javascripts/modules/secondary-status.es6
+++ b/app/assets/javascripts/modules/secondary-status.es6
@@ -7,6 +7,7 @@
       super.start(el);
 
       this.$secondaryStatus = $('.js-secondary-status');
+      this.$cancelledVia = $('.js-cancelled-via');
       this.$secondaryOptions = this.$el.data('options');
       this.$initialSecondaryStatus = this.$el.data('initial-secondary-status');
 
@@ -15,8 +16,10 @@
 
     bindEvents() {
       this.$el.on('change', this.renderSecondaryOptions.bind(this));
+      this.$secondaryStatus.on('change', this.toggleCancelledVia.bind(this));
 
       this.renderSecondaryOptions();
+      this.toggleCancelledVia();
     }
 
     renderSecondaryOptions() {
@@ -31,6 +34,17 @@
         for (let key in options) {
           this.$secondaryStatus.append(`<option value="${key}" ${key == this.$initialSecondaryStatus ? 'selected' : ''}>${options[key]}</option>`);
         }
+      }
+    }
+
+    toggleCancelledVia() {
+      let chosenSecondaryStatus = this.$secondaryStatus.val();
+
+      if (chosenSecondaryStatus == '15') { // Cancelled prior to appointment
+        this.$cancelledVia.show();
+      }
+      else {
+        this.$cancelledVia.hide();
       }
     }
   }

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -229,6 +229,7 @@ class AppointmentsController < ApplicationController
       nudged
       internal_availability
       welsh
+      cancelled_via
     ]
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -53,6 +53,7 @@ class Appointment < ApplicationRecord
     country_code
     welsh
     rescheduling_reason
+    cancelled_via
   ].freeze
 
   enum status: { pending: 0, complete: 1, no_show: 2, incomplete: 3, ineligible_age: 4,
@@ -147,6 +148,7 @@ class Appointment < ApplicationRecord
   validates :referrer, presence: true, if: :due_diligence?, on: :create
   validates :email, email: true, unless: :sms_confirmation?
   validates :email_consent, presence: true, email: true, if: :email_consent_form_required?
+  validates :cancelled_via, inclusion: %w[phone email], on: :update, if: :cancelled_prior_to_appointment?
 
   validate :validate_printed_consent_form_address
   validate :validate_consent_type
@@ -622,6 +624,10 @@ class Appointment < ApplicationRecord
     date = created_at || Time.zone.today
 
     accessibility_requirements? && date > ACCESSIBILITY_NOTES_CUTOFF
+  end
+
+  def cancelled_prior_to_appointment?
+    secondary_status == '15'
   end
 
   def validate_phone_digits

--- a/app/views/appointments/_personal_details_form.html.erb
+++ b/app/views/appointments/_personal_details_form.html.erb
@@ -209,6 +209,12 @@
         )
       %>
     <%= f.select(:secondary_status, [], {}, { class: 't-secondary-status js-secondary-status', data: { 'no-tracking' => true }}) %>
+
+    <div class="form-group js-cancelled-via" style="display: none">
+      <p><strong>Customer cancelled via</strong></p>
+      <%= f.radio_button :cancelled_via, 'phone', label: 'Phone', class: 't-cancelled-via-phone' %>
+      <%= f.radio_button :cancelled_via, 'email', label: 'Email or CRM', class: 't-cancelled-via-email-or-crm' %>
+    </div>
     <% end %>
 
   </div>

--- a/db/migrate/20240530142914_add_cancelled_via_to_appointments.rb
+++ b/db/migrate/20240530142914_add_cancelled_via_to_appointments.rb
@@ -1,0 +1,5 @@
+class AddCancelledViaToAppointments < ActiveRecord::Migration[6.1]
+  def change
+    add_column :appointments, :cancelled_via, :string, null: false, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_03_26_090221) do
+ActiveRecord::Schema.define(version: 2024_05_30_142914) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -89,12 +89,12 @@ ActiveRecord::Schema.define(version: 2024_03_26_090221) do
     t.datetime "batch_processed_at"
     t.datetime "rescheduled_at"
     t.string "gdpr_consent", default: "", null: false
-    t.boolean "accessibility_requirements", default: false, null: false
     t.string "pension_provider", default: "", null: false
+    t.boolean "accessibility_requirements", default: false, null: false
     t.datetime "processed_at"
-    t.boolean "smarter_signposted", default: false
-    t.boolean "bsl_video", default: false, null: false
     t.boolean "third_party_booking", default: false, null: false
+    t.integer "casebook_appointment_id"
+    t.boolean "smarter_signposted", default: false
     t.string "data_subject_name", default: "", null: false
     t.integer "data_subject_age"
     t.boolean "data_subject_consent_obtained", default: false, null: false
@@ -106,6 +106,7 @@ ActiveRecord::Schema.define(version: 2024_03_26_090221) do
     t.string "consent_town", default: "", null: false
     t.string "consent_county", default: "", null: false
     t.string "consent_postcode", default: "", null: false
+    t.boolean "bsl_video", default: false, null: false
     t.boolean "email_consent_form_required", default: false, null: false
     t.string "email_consent", default: "", null: false
     t.date "data_subject_date_of_birth"
@@ -115,13 +116,13 @@ ActiveRecord::Schema.define(version: 2024_03_26_090221) do
     t.string "unique_reference_number", default: "", null: false
     t.string "referrer", default: "", null: false
     t.boolean "small_pots", default: false, null: false
+    t.string "rescheduling_reason", default: "", null: false
     t.boolean "nudged", default: false, null: false
     t.string "nudge_confirmation", default: "", null: false
     t.string "nudge_eligibility_reason", default: "", null: false
     t.string "country_code", default: "GB", null: false
-    t.integer "casebook_appointment_id"
     t.boolean "welsh", default: false, null: false
-    t.string "rescheduling_reason", default: "", null: false
+    t.string "cancelled_via", default: "", null: false
     t.index ["guider_id", "start_at"], name: "unique_slot_guider_in_appointment", unique: true, where: "((status <> ALL (ARRAY[5, 6, 7, 8])) AND (start_at > '2022-07-02 00:00:00'::timestamp without time zone))"
     t.index ["guider_id"], name: "index_appointments_on_guider_id"
     t.index ["schedule_type"], name: "index_appointments_on_schedule_type"
@@ -245,10 +246,10 @@ ActiveRecord::Schema.define(version: 2024_03_26_090221) do
     t.jsonb "permissions", default: "[]"
     t.integer "position", default: 0, null: false
     t.boolean "active", default: true, null: false
-    t.string "schedule_type", default: "pension_wise", null: false
     t.integer "casebook_guider_id"
     t.integer "casebook_location_id"
-    t.index ["organisation_content_id"], name: "index_users_on_organisation_content_id"
+    t.string "schedule_type", default: "pension_wise", null: false
+    t.index ["organisation_content_id"], name: "users_organisation_content_id_idx"
     t.index ["permissions"], name: "index_users_on_permissions", using: :gin
     t.index ["schedule_type"], name: "index_users_on_schedule_type"
   end

--- a/spec/features/agent_manages_appointments_spec.rb
+++ b/spec/features/agent_manages_appointments_spec.rb
@@ -434,6 +434,8 @@ RSpec.feature 'Agent manages appointments' do
     @page.status.select('Cancelled By Customer')
     @page.wait_until_secondary_status_options_visible
     @page.secondary_status.select('Cancelled prior to appointment')
+    @page.wait_until_cancelled_via_phone_visible
+    @page.cancelled_via_phone.set(true)
     @page.submit.click
   end
 

--- a/spec/features/appointment_changes_spec.rb
+++ b/spec/features/appointment_changes_spec.rb
@@ -27,6 +27,8 @@ RSpec.feature 'Appointment audit trail' do
     @edit_page.status.select('Cancelled By Customer')
     @edit_page.wait_until_secondary_status_options_visible
     @edit_page.secondary_status.select('Cancelled prior to appointment')
+    @edit_page.wait_until_cancelled_via_phone_visible
+    @edit_page.cancelled_via_phone.set(true)
     @edit_page.submit.click
   end
 

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -547,6 +547,17 @@ RSpec.describe Appointment, type: :model do
     context 'when the status would require a secondary status' do
       before { subject.created_at = Time.current }
 
+      context 'when cancelled prior to appointment' do
+        it 'requires cancelled via' do
+          subject.status = :cancelled_by_customer
+          subject.secondary_status = '15' # Cancelled prior to appointment
+          expect(subject).to be_invalid
+
+          subject.cancelled_via = 'phone'
+          expect(subject).to be_valid
+        end
+      end
+
       context 'for secondary statuses without cut-off mandated' do
         it 'is invalid' do
           subject.status = :incomplete
@@ -571,6 +582,7 @@ RSpec.describe Appointment, type: :model do
 
             subject.status = :cancelled_by_customer
             subject.secondary_status = '15' # Cancelled prior to appointment
+            subject.cancelled_via = 'phone'
             expect(subject).to be_valid
 
             subject.secondary_status = '17' # Customer forgot

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -20,6 +20,8 @@ module Pages
     element :gdpr_consent_yes,                      '.t-gdpr-consent-yes'
     element :gdpr_consent_no,                       '.t-gdpr-consent-no'
     element :gdpr_consent_no_response,              '.t-gdpr-consent-no-response'
+    element :cancelled_via_phone,                   '.t-cancelled-via-phone'
+    element :cancelled_via_email,                   '.t-cancelled-via-email'
 
     element :status, '.t-status'
     element :secondary_status, '.t-secondary-status'


### PR DESCRIPTION
When the appointment is marked with the secondary status 'cancelled prior to appointment' we want to track the channel the customer used to cancel their appointment.