### PR TITLE
Send a separate email for potential duplicates

### DIFF
--- a/app/controllers/api/v1/appointments_controller.rb
+++ b/app/controllers/api/v1/appointments_controller.rb
@@ -22,6 +22,7 @@ module Api
 
       def send_notifications(appointment)
         AdjustmentNotificationsJob.perform_later(appointment) if appointment.adjustments?
+        AppointmentMailer.potential_duplicates(appointment).deliver_later if appointment.potential_duplicates?
         CustomerUpdateJob.perform_later(appointment, CustomerUpdateActivity::CONFIRMED_MESSAGE)
         AppointmentCreatedNotificationsJob.perform_later(appointment)
         PushCasebookAppointmentJob.perform_later(appointment)

--- a/app/controllers/api/v1/nudge_appointments_controller.rb
+++ b/app/controllers/api/v1/nudge_appointments_controller.rb
@@ -16,6 +16,7 @@ module Api
 
       def send_notifications(appointment)
         AdjustmentNotificationsJob.perform_later(appointment) if appointment.adjustments?
+        AppointmentMailer.potential_duplicates(appointment).deliver_later if appointment.potential_duplicates?
         NudgeSmsAppointmentConfirmationJob.perform_later(appointment) if appointment.sms_confirmation?
         CustomerUpdateJob.perform_later(appointment, CustomerUpdateActivity::CONFIRMED_MESSAGE)
         AppointmentCreatedNotificationsJob.perform_later(appointment)

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -118,6 +118,7 @@ class AppointmentsController < ApplicationController
 
   def send_notifications(appointment)
     AdjustmentNotificationsJob.perform_later(appointment) if appointment.adjustments?
+    AppointmentMailer.potential_duplicates(appointment).deliver_later if appointment.potential_duplicates?
     PushCasebookAppointmentJob.perform_later(appointment)
     CustomerUpdateJob.perform_later(appointment, CustomerUpdateActivity::CONFIRMED_MESSAGE)
     PrintedConfirmationJob.perform_later(appointment)

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,11 +1,12 @@
 class ApplicationJob < ActiveJob::Base
   CAS_RECIPIENTS = Array('CAS_PWBooking@cas.org.uk').freeze
+  OPS_SUPERVISOR = 'supervisors@maps.org.uk'.freeze
 
   protected
 
   def recipients_for(appointment)
     if appointment.tpas_guider?
-      Array('supervisors@maps.org.uk')
+      Array(OPS_SUPERVISOR)
     elsif appointment.cas_guider?
       CAS_RECIPIENTS
     else

--- a/app/mailers/appointment_mailer.rb
+++ b/app/mailers/appointment_mailer.rb
@@ -35,6 +35,12 @@ class AppointmentMailer < ApplicationMailer
     mail to: recipient, subject: @appointment.subject('Appointment Created')
   end
 
+  def potential_duplicates(appointment)
+    mailgun_headers('potential_duplicates', appointment.id)
+    @appointment = decorate(appointment)
+    mail to: ApplicationJob::OPS_SUPERVISOR, subject: @appointment.subject('Potential Duplicates')
+  end
+
   def adjustment(appointment, recipient)
     return unless appointment.adjustments?
 

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -241,7 +241,6 @@ class Appointment < ApplicationRecord
   def adjustments?
     return true if accessibility_requirements? || third_party_booking?
     return false if tpas_guider?
-    return true if potential_duplicates? && pension_wise?
 
     !dc_pot_confirmed? && pension_wise?
   end

--- a/app/views/appointment_mailer/potential_duplicates.html.erb
+++ b/app/views/appointment_mailer/potential_duplicates.html.erb
@@ -1,0 +1,15 @@
+<h1 style="color: #0F19A0 !important;font-family: Calibri, Arial, sans-serif;margin: 15px 0;font-weight: 700;font-size: 20px;line-height: 1.111111111;padding: 15px 0;">
+  The appointment has been identified as a potential duplicate booking
+</h1>
+
+<%= p do %>
+  Reference number:
+  <br>
+  <strong class="emphasize">
+    <%= @appointment.id %>
+  </strong>
+<% end %>
+
+<%= p do %>
+  <%= link_to 'View the appointment', edit_appointment_url(@appointment) %>
+<% end %>

--- a/app/views/appointment_mailer/potential_duplicates.text.erb
+++ b/app/views/appointment_mailer/potential_duplicates.text.erb
@@ -1,0 +1,5 @@
+The appointment has been identified as a potential duplicate booking
+
+Reference number: <%= @appointment.id %>
+
+View the appointment: <%= edit_appointment_url(@appointment) %>

--- a/spec/lib/notifier_spec.rb
+++ b/spec/lib/notifier_spec.rb
@@ -13,7 +13,19 @@ RSpec.describe Notifier, '#call' do
     allow(AppointmentMailer).to receive(:confirmation) { mailer }
     allow(AppointmentMailer).to receive(:missed) { mailer }
     allow(AppointmentMailer).to receive(:updated) { mailer }
+    allow(AppointmentMailer).to receive(:potential_duplicates) { mailer }
     allow(mailer).to receive(:deliver_now)
+    allow(mailer).to receive(:deliver_later)
+  end
+
+  context 'when the appointment has potential duplicates' do
+    it 'sends the correct email notification' do
+      allow(appointment).to receive(:potential_duplicates?).and_return(true)
+      expect(AppointmentMailer).to receive(:potential_duplicates).and_return(mailer)
+      expect(mailer).to receive(:deliver_later)
+
+      subject.call
+    end
   end
 
   context 'when an appointment is otherwise altered' do

--- a/spec/mailers/appointment_mailer_spec.rb
+++ b/spec/mailers/appointment_mailer_spec.rb
@@ -14,6 +14,24 @@ RSpec.describe AppointmentMailer, type: :mailer do
     )
   end
 
+  describe 'Potential duplicates notification' do
+    let(:appointment) { build_stubbed(:appointment) }
+
+    subject(:mail) { described_class.potential_duplicates(appointment) }
+
+    it 'determines the correct subject' do
+      expect(subject.subject).to eq('Pension Wise Potential Duplicates')
+    end
+
+    it 'is delivered to the ops supervisor mailbox' do
+      expect(subject.to).to eq(['supervisors@maps.org.uk'])
+    end
+
+    it 'contains the duplicates details' do
+      expect(subject.body.encoded).to include('identified as a potential duplicate')
+    end
+  end
+
   describe 'Due diligence appointment confirmation' do
     let(:appointment) { build_stubbed(:appointment, :due_diligence) }
 

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -21,19 +21,6 @@ RSpec.describe Appointment, type: :model do
   end
 
   describe '#adjustments?' do
-    context 'when the appointment is Pension Wise' do
-      context 'when the guider is not Pension Ops' do
-        context 'when the adjustment is potential duplicates' do
-          it 'is true' do
-            appointment = build_stubbed(:appointment_for_casebook_creation, organisation: :cas)
-            allow(appointment).to receive(:potential_duplicates?).and_return(true)
-
-            expect(appointment).to be_adjustments
-          end
-        end
-      end
-    end
-
     context 'when the customer is DC unsure' do
       context 'when the appointment is Pension Wise' do
         context 'when the guider is Pension Ops/TPAS' do


### PR DESCRIPTION
This changes how these notifications were delivered. They're no longer part of the broader adjustments notifications and now are a separate email notification that occurs at any given time during the appointment lifecycle and are only ever received by the ops mailbox alias.