### PR TITLE
Retry on network timeouts

### DIFF
--- a/app/jobs/casebook_job.rb
+++ b/app/jobs/casebook_job.rb
@@ -3,5 +3,7 @@ class CasebookJob < ApplicationJob
     Bugsnag.notify(error)
   end
 
+  retry_on Faraday::TimeoutError, wait: :exponentially_longer
+
   queue_as :default
 end


### PR DESCRIPTION
We had a couple instances of these due to Casebook suffering ephemeral network issues. With this mitigation the jobs will retry a few times on an exponential backoff until successful, otherwise an error will be logged as usual.