### PR TITLE
Broaden duplicates to non-pending too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 dist: focal
 language: ruby
+addons:
+  chrome: stable
 services:
 - redis-server
 - postgresql

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -246,20 +246,21 @@ class Appointment < ApplicationRecord
     mobile.presence || phone
   end
 
-  def potential_duplicates
-    self.class.where.not(id:)
-        .where(
-          first_name:,
-          last_name:,
-          date_of_birth:,
-          status: :pending
-        )
-        .order(:id)
-        .take(10)
+  def potential_duplicates(only_pending: true)
+    scope = self.class.where.not(id:)
+                .where(
+                  first_name:,
+                  last_name:,
+                  date_of_birth:
+                )
+
+    scope = scope.where(status: :pending) if only_pending
+
+    scope.order(:id).take(20)
   end
 
-  def potential_duplicates?
-    potential_duplicates.size.positive?
+  def potential_duplicates?(only_pending: true)
+    potential_duplicates(only_pending:).size.positive?
   end
 
   def imported?

--- a/app/presenters/appointment_search_result_presenter.rb
+++ b/app/presenters/appointment_search_result_presenter.rb
@@ -4,7 +4,7 @@ class AppointmentSearchResultPresenter < SimpleDelegator
   delegate :name, :organisation, to: :guider, prefix: true
 
   def status
-    super.titleize
+    super&.titleize
   end
 
   def created_at

--- a/app/presenters/duplicate_presenter.rb
+++ b/app/presenters/duplicate_presenter.rb
@@ -20,7 +20,7 @@ class DuplicatePresenter < SimpleDelegator
   end
 
   def status
-    super.humanize
+    super&.humanize
   end
 
   def email

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -38,9 +38,9 @@
   <% end %>
 </h4>
 
-<% if @appointment.potential_duplicates? %>
+<% if @appointment.potential_duplicates?(only_pending: false) %>
   <div class="alert alert-warning" role="alert">
-    <p>This appointment <strong><%= link_to 'may be duplicated', appointment_duplicates_path(@appointment) %></strong></p>
+    <p>The customer’s details <strong><%= link_to 'match other appointment records', appointment_duplicates_path(@appointment) %></strong></p>
   </div>
 <% end %>
 

--- a/app/views/duplicates/index.html.erb
+++ b/app/views/duplicates/index.html.erb
@@ -1,10 +1,10 @@
-<% content_for(:page_title, t('service.title', page_title: "Duplicates for Appointment ##{@appointment.id}")) %>
+<% content_for(:page_title, t('service.title', page_title: "Matching customer details for Appointment ##{@appointment.id}")) %>
 <%= breadcrumb(
   { title: 'Edit Appointment', path: edit_appointment_path(@appointment.id) },
-  { title: "Duplicates for Appointment ##{@appointment.id}" }
+  { title: "Matching customer details for Appointment ##{@appointment.id}" }
 ) %>
 
-<h1>Duplicates for Appointment #<%= @appointment.id %></h1>
+<h1>Matching customer details for Appointment #<%= @appointment.id %></h1>
 
 <table class="table table-striped table-bordered">
   <thead>
@@ -18,7 +18,7 @@
     </tr>
   </thead>
   <tbody>
-  <% @appointment.potential_duplicates.each do |duplicate| %>
+  <% @appointment.potential_duplicates(only_pending: false).each do |duplicate| %>
     <% @duplicate = DuplicatePresenter.new(duplicate) %>
     <tr class="t-duplicate">
       <td><%= @duplicate.id %></td>


### PR DESCRIPTION
This will keep the notifications to pending-only but broaden the display of the duplicates during appointment viewings.