### PR TITLE
Only send duplicate notifications on pending

### DIFF
--- a/app/lib/notifier.rb
+++ b/app/lib/notifier.rb
@@ -75,7 +75,7 @@ class Notifier
   end
 
   def requires_potential_duplicates_notification?
-    appointment.potential_duplicates?
+    appointment.pending? && appointment.potential_duplicates?
   end
 
   def requires_adjustment_notification?

--- a/spec/lib/notifier_spec.rb
+++ b/spec/lib/notifier_spec.rb
@@ -19,12 +19,24 @@ RSpec.describe Notifier, '#call' do
   end
 
   context 'when the appointment has potential duplicates' do
-    it 'sends the correct email notification' do
-      allow(appointment).to receive(:potential_duplicates?).and_return(true)
-      expect(AppointmentMailer).to receive(:potential_duplicates).and_return(mailer)
-      expect(mailer).to receive(:deliver_later)
+    context 'when the appointment is pending' do
+      it 'sends the correct email notification' do
+        allow(appointment).to receive(:potential_duplicates?).and_return(true)
+        expect(AppointmentMailer).to receive(:potential_duplicates).and_return(mailer)
+        expect(mailer).to receive(:deliver_later)
 
-      subject.call
+        subject.call
+      end
+    end
+
+    context 'when the appointment is not pending' do
+      it 'does not send the notification' do
+        allow(appointment).to receive(:pending?).and_return(false)
+        allow(appointment).to receive(:potential_duplicates?).and_return(true)
+        expect(AppointmentMailer).not_to receive(:potential_duplicates)
+
+        subject.call
+      end
     end
   end
 


### PR DESCRIPTION
There were some cases where duplicate notifications were being sent and causing confusion. Eg when an appointment was cancelled by an agent it was still notifying the relevant resource managers that duplicates were present. This change ensures duplicate notifications are only triggered by pending appointments.