### PR TITLE
Do not search across guider name

### DIFF
--- a/app/models/appointment_search.rb
+++ b/app/models/appointment_search.rb
@@ -82,7 +82,7 @@ class AppointmentSearch
     if REFERENCE_REGEX === @query
       scope.where(id: @query)
     else
-      scope.where(ilike(%w[appointments.first_name appointments.last_name users.name]))
+      scope.where(ilike(%w[appointments.first_name appointments.last_name]))
     end
   end
 end

--- a/app/views/appointments/search.html.erb
+++ b/app/views/appointments/search.html.erb
@@ -6,7 +6,7 @@
 <%= form_for @search, method: 'GET', url: { action: :search }, html: { class: 'appointment-search form-inline' } do |f| %>
   <div class="form-group">
     <%= f.label :q, 'Search term' %>
-    <%= f.text_field :q, use_label: false, class: 't-q appointment-search__term form-control', placeholder: 'Reference, name or guider' %>
+    <%= f.text_field :q, use_label: false, class: 't-q appointment-search__term form-control', placeholder: 'Reference or name' %>
   </div>
   <div class="form-group">
     <%= f.label :date_range, 'Date range' %>

--- a/spec/models/appointment_search_spec.rb
+++ b/spec/models/appointment_search_spec.rb
@@ -100,15 +100,6 @@ RSpec.describe AppointmentSearch, type: :model do
       results = results(nil, date_range_start, date_range_end)
       expect(results).to eq [appointment]
     end
-
-    it 'returns results for guider name' do
-      guider = create(:guider, name: 'Kate Bush')
-      appointment = @appointments.first
-      appointment.guider = guider
-      appointment.save!
-      results = results('kate bush', nil, nil)
-      expect(results).to eq [appointment]
-    end
   end
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Removes guider name as a criteria when searching for appointments as it causes false-positives in the results and has been requested by Pensions Ops.