### PR TITLE
Non-ops resource managers can rebook external

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -78,7 +78,8 @@ class AppointmentsController < ApplicationController
     @appointment.allocate(
       via_slot: calendar_scheduling?,
       agent: current_user,
-      scoped: !@appointment.internal_availability?
+      scoped: !@appointment.internal_availability?,
+      rebooking: rebooking?
     )
 
     if @appointment.valid?
@@ -93,7 +94,8 @@ class AppointmentsController < ApplicationController
     @appointment.allocate(
       via_slot: calendar_scheduling?,
       agent: current_user,
-      scoped: !@appointment.internal_availability?
+      scoped: !@appointment.internal_availability?,
+      rebooking: rebooking?
     )
     @appointment.copy_attachments!
 
@@ -273,5 +275,10 @@ class AppointmentsController < ApplicationController
   def creating?
     params[:edit_appointment].nil?
   end
+
+  def rebooking?
+    params[:copy_from].present? || @appointment&.rebooked_from_id.present?
+  end
+  helper_method :rebooking?
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/controllers/bookable_slots_controller.rb
+++ b/app/controllers/bookable_slots_controller.rb
@@ -31,7 +31,8 @@ class BookableSlotsController < ApplicationController
       Time.zone.parse(params[:start]),
       Time.zone.parse(params[:end]),
       schedule_type:,
-      external: true
+      external: true,
+      rebooking: rebooking?
     )
   end
 
@@ -56,6 +57,10 @@ class BookableSlotsController < ApplicationController
 
   def rescheduling?
     params[:rescheduling] == 'true'
+  end
+
+  def rebooking?
+    params[:rebooking] == 'true'
   end
 
   def filtered_user

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,4 +10,12 @@ module ApplicationHelper
       .unresolved
       .count
   end
+
+  def available_slots_path(current_user, schedule_type, rescheduling, appointment_id, rebooking)
+    if rebooking && current_user.non_tpas_resource_manager?
+      external_bookable_slots_path(schedule_type:, rescheduling:, id: appointment_id, rebooking:)
+    else
+      available_bookable_slots_path(schedule_type:, rescheduling:, id: appointment_id)
+    end
+  end
 end

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -11,6 +11,14 @@ module UserHelper
     content_tag(:small, ' (Casebook)')
   end
 
+  def can_switch_availability?(current_user, appointment, rebooking, rescheduling)
+    return false unless appointment.pension_wise?
+    return true if current_user.tpas_agent? && !rescheduling
+    return true if current_user.non_tpas_resource_manager? && rebooking
+
+    false
+  end
+
   def can_process?(current_user, appointment)
     !current_user.tpas? && !appointment.processed_at?
   end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -293,9 +293,9 @@ class Appointment < ApplicationRecord
     status.start_with?('cancelled')
   end
 
-  def allocate(via_slot: true, agent: nil, scoped: false)
+  def allocate(via_slot: true, agent: nil, scoped: false, rebooking: false)
     if via_slot
-      allocate_slot(agent, scoped)
+      allocate_slot(agent, scoped, rebooking)
     else
       return unless start_at?
 
@@ -524,10 +524,12 @@ class Appointment < ApplicationRecord
     self.unique_reference_number = '' if status_changed?(from: 'complete') && due_diligence?
   end
 
-  def allocate_slot(agent, scoped)
+  def allocate_slot(agent, scoped, rebooking) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     args = agent&.tpas_agent? && pension_wise? && scoped ? { external: true } : {}
+    args = { external: scoped } if agent&.non_tpas_resource_manager? && pension_wise? && rebooking
 
     slot = BookableSlot.find_available_slot(start_at, agent, schedule_type, scoped:, **args)
+
     self.guider = nil
     return unless slot
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -101,6 +101,10 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
     tpas? && resource_manager?
   end
 
+  def non_tpas_resource_manager?
+    !tpas? && resource_manager?
+  end
+
   def lloyds_signposter?
     return true if tp_agent? || administrator?
 

--- a/app/views/appointments/_availability_calendar.html.erb
+++ b/app/views/appointments/_availability_calendar.html.erb
@@ -5,7 +5,7 @@
 
 <%= render 'shared/nojs' %>
 
-<% if current_user.tpas_agent? && !rescheduling && @appointment.pension_wise? %>
+<% if can_switch_availability?(current_user, @appointment, rebooking?, rescheduling) %>
   <%= form.check_box :internal_availability, label: 'Internal availability', class: 't-internal-availability js-internal-availability', data: { module: 'internal-availability' } %>
 <% end %>
 
@@ -17,10 +17,10 @@
   id="AppointmentAvailabilityCalendar"
   class="appointment-availability-calendar"
   data-module="appointment-availability-calendar"
-  data-available-slots-path="<%= available_bookable_slots_path(schedule_type: schedule_type, rescheduling: rescheduling, id: @appointment.id) %>"
+  data-available-slots-path="<%= available_slots_path(current_user, schedule_type, rescheduling, @appointment.id, rebooking?) %>"
   data-lloyds-slots-path="<%= lloyds_bookable_slots_path(rescheduling: rescheduling, id: @appointment.id) %>"
   data-internal-slots-path="<%= internal_bookable_slots_path(schedule_type: schedule_type, rescheduling: rescheduling, id: @appointment.id) %>"
-  data-external-slots-path="<%= external_bookable_slots_path(schedule_type: schedule_type, rescheduling: rescheduling, id: @appointment.id) %>"
+  data-external-slots-path="<%= external_bookable_slots_path(schedule_type: schedule_type, rescheduling: rescheduling, id: @appointment.id, rebooking: rebooking?) %>"
   data-default-date="<%= BookableSlot.next_valid_start_date(current_user) %>"
 ></div>
 <%= form.hidden_field :start_at, class: 't-start-at js-selected-start' %>

--- a/spec/features/agent_rebooks_appointments_spec.rb
+++ b/spec/features/agent_rebooks_appointments_spec.rb
@@ -8,8 +8,12 @@ RSpec.feature 'Agent rebooks appointments' do
         and_there_is_cross_organisational_availability
         and_an_existing_appointment_for_cas
         when_they_attempt_to_rebook_an_appointment
+        they_default_to_cas_external_availability
+        when_they_select_internal_availability
         then_they_see_only_their_availability
-        and_they_do_not_see_the_internal_availability_toggle
+        when_they_switch_back_to_external_availability
+        and_rebook_using_external_availability
+        then_the_booking_is_placed_externally
       end
     end
   end
@@ -52,7 +56,6 @@ RSpec.feature 'Agent rebooks appointments' do
   def then_they_see_only_their_availability
     @page = Pages::NewAppointment.new
     expect(@page).to be_displayed
-    @page.next_period.click
 
     @page.wait_until_slots_visible
     expect(@page).to have_slots(count: 1)
@@ -68,6 +71,7 @@ RSpec.feature 'Agent rebooks appointments' do
   def and_there_is_cross_organisational_availability
     create(:bookable_slot, start_at: Time.zone.parse('2022-06-24 09:00'))
     create(:bookable_slot, :cas, start_at: Time.zone.parse('2022-06-24 11:00'))
+    create(:bookable_slot, :cas, start_at: Time.zone.parse('2022-06-20 11:00'))
   end
 
   def and_an_existing_appointment_for_tpas
@@ -80,6 +84,39 @@ RSpec.feature 'Agent rebooks appointments' do
 
     @page.wait_until_slots_visible
     expect(@page).to have_slots(count: 2)
+  end
+
+  def they_default_to_cas_external_availability
+    @page = Pages::NewAppointment.new
+    expect(@page).to be_displayed
+
+    expect(@page).to have_no_slots
+
+    @page.next_period.click
+    @page.wait_until_slots_visible
+    expect(@page).to have_slots(count: 1)
+    expect(@page.slots.first).to have_text('09:00 1 guider')
+  end
+
+  def when_they_switch_back_to_external_availability
+    @page.internal_availability.uncheck
+    @page.wait_until_slots_visible
+  end
+
+  def and_rebook_using_external_availability
+    @page.choose_slot('09:00')
+    @page.preview_appointment.click
+
+    @page = Pages::PreviewAppointment.new
+    expect(@page).to be_displayed
+    @page.confirm_appointment.click
+  end
+
+  def then_the_booking_is_placed_externally
+    @rebooked = Appointment.last
+
+    expect(@rebooked.guider.organisation).to eq('TPAS')
+    expect(@rebooked.rebooked_from_id).to eq(@appointment.id)
   end
 
   def they_default_to_external_availability

--- a/spec/features/agent_rebooks_appointments_spec.rb
+++ b/spec/features/agent_rebooks_appointments_spec.rb
@@ -117,6 +117,8 @@ RSpec.feature 'Agent rebooks appointments' do
 
     expect(@rebooked.guider.organisation).to eq('TPAS')
     expect(@rebooked.rebooked_from_id).to eq(@appointment.id)
+
+    expect(@page).to have_text(/The appointment \#\d+ has been booked for/)
   end
 
   def they_default_to_external_availability


### PR DESCRIPTION
This change permits non-ops resource managers to rebook externally. When they see the rebooking calendar they're automatically offered external slots only. They have to choose internal explicitly to see their own slots.

This is currently in the proof-of-concept phases and may change.