### PR TITLE
Show potential duplicates on preview page

### DIFF
--- a/app/presenters/duplicate_presenter.rb
+++ b/app/presenters/duplicate_presenter.rb
@@ -27,6 +27,14 @@ class DuplicatePresenter < SimpleDelegator
     provider&.email
   end
 
+  def schedule_type
+    if pension_wise?
+      'Pension Wise'
+    else
+      'PSG'
+    end
+  end
+
   private
 
   def provider

--- a/app/presenters/duplicate_presenter.rb
+++ b/app/presenters/duplicate_presenter.rb
@@ -29,7 +29,7 @@ class DuplicatePresenter < SimpleDelegator
 
   def schedule_type
     if pension_wise?
-      'Pension Wise'
+      'PW'
     else
       'PSG'
     end

--- a/app/views/appointments/preview.html.erb
+++ b/app/views/appointments/preview.html.erb
@@ -71,7 +71,7 @@
           <div class="alert alert-warning t-duplicates" role="alert">
             <h4>This customer may have pending phone appointments:</h4>
             <ul>
-            <% @appointment.potential_duplicates(only_pending: false).each do |duplicate| %>
+            <% @appointment.potential_duplicates.each do |duplicate| %>
               <% @duplicate = DuplicatePresenter.new(duplicate) %>
               <li>
                 <p>Reference: <%= @duplicate.id %> <small>(<%= @duplicate.schedule_type %>)</small></p>

--- a/app/views/appointments/preview.html.erb
+++ b/app/views/appointments/preview.html.erb
@@ -67,6 +67,21 @@
   <div class="t-preview appointment-preview">
     <div class="row">
       <div class="col-md-8">
+        <% if @appointment.potential_duplicates? %>
+          <div class="alert alert-warning t-duplicates" role="alert">
+            <h4>This customer may have pending Pension Wise phone appointments:</h4>
+            <ul>
+            <% @appointment.potential_duplicates(only_pending: false).each do |duplicate| %>
+              <% @duplicate = DuplicatePresenter.new(duplicate) %>
+              <li>
+                <p>Reference: <%= @duplicate.id %></p>
+                <p>Appointment date/time: <%= @duplicate.start %></p>
+              </li>
+            <% end %>
+            </ul>
+          </div>
+        <% end %>
+
         <p class="alert alert-warning">
           This appointment has not yet been created.<br>Please check the details below and then click <b>Confirm appointment</b>.
         </p>

--- a/app/views/appointments/preview.html.erb
+++ b/app/views/appointments/preview.html.erb
@@ -76,6 +76,7 @@
               <li>
                 <p>Reference: <%= @duplicate.id %></p>
                 <p>Appointment date/time: <%= @duplicate.start %></p>
+                <p>Type: <%= @duplicate.schedule_type %></p>
               </li>
             <% end %>
             </ul>

--- a/app/views/appointments/preview.html.erb
+++ b/app/views/appointments/preview.html.erb
@@ -69,14 +69,13 @@
       <div class="col-md-8">
         <% if @appointment.potential_duplicates? %>
           <div class="alert alert-warning t-duplicates" role="alert">
-            <h4>This customer may have pending Pension Wise phone appointments:</h4>
+            <h4>This customer may have pending phone appointments:</h4>
             <ul>
             <% @appointment.potential_duplicates(only_pending: false).each do |duplicate| %>
               <% @duplicate = DuplicatePresenter.new(duplicate) %>
               <li>
-                <p>Reference: <%= @duplicate.id %></p>
+                <p>Reference: <%= @duplicate.id %> <small>(<%= @duplicate.schedule_type %>)</small></p>
                 <p>Appointment date/time: <%= @duplicate.start %></p>
-                <p>Type: <%= @duplicate.schedule_type %></p>
               </li>
             <% end %>
             </ul>

--- a/app/views/duplicates/index.html.erb
+++ b/app/views/duplicates/index.html.erb
@@ -21,7 +21,7 @@
   <% @appointment.potential_duplicates(only_pending: false).each do |duplicate| %>
     <% @duplicate = DuplicatePresenter.new(duplicate) %>
     <tr class="t-duplicate">
-      <td><%= @duplicate.id %></td>
+      <td><%= @duplicate.id %> <small>(<%= @duplicate.schedule_type %>)</small></td>
       <td><%= @duplicate.organisation_name %> <small><%= @duplicate.email %></small></td>
       <td><%= @duplicate.start %></td>
       <td><%= @duplicate.status %></td>

--- a/spec/support/pages/preview_appointment.rb
+++ b/spec/support/pages/preview_appointment.rb
@@ -2,6 +2,7 @@ module Pages
   class PreviewAppointment < Base
     set_url '/appointments/preview'
 
+    element :duplicates,          '.t-duplicates'
     element :confirm_appointment, '.t-confirm-appointment'
     element :edit_appointment,    '.t-edit-appointment'
     element :preview,             '.t-preview'


### PR DESCRIPTION
When the agent is previewing an appointment we now display any duplicates matching the usual logic of first and last name, DoB and the pending status.