### PR TITLE
Simplify appointment duration copy

### DIFF
--- a/app/views/appointments/preview.html.erb
+++ b/app/views/appointments/preview.html.erb
@@ -79,7 +79,7 @@
             </tr>
             <tr>
               <td class="active"><b>Appointment date</b></td>
-              <td><%= "#{@appointment.start_at.to_date.to_s(:govuk_date)} #{@appointment.start_at.to_time.to_s(:govuk_time)}" %><br>(will last around 45 to 60 minutes)</td>
+              <td><%= "#{@appointment.start_at.to_date.to_s(:govuk_date)} #{@appointment.start_at.to_time.to_s(:govuk_time)}" %><br>(will last around 60 minutes)</td>
             </tr>
           </tbody>
         </table>

--- a/app/views/shared/email/_appointment_details.html.erb
+++ b/app/views/shared/email/_appointment_details.html.erb
@@ -18,7 +18,7 @@
   Appointment lasts:
   <br>
   <strong class="emphasize">
-    45 to 60 minutes
+    Around 60 minutes
   </strong>
 <% end %>
 

--- a/app/views/shared/email/_appointment_details.text.erb
+++ b/app/views/shared/email/_appointment_details.text.erb
@@ -5,7 +5,7 @@ Time:
 <%= "#{@appointment.start_at.to_time.to_s(:govuk_time)} (#{@appointment.timezone})" %>
 
 Appointment lasts:
-45 to 60 minutes
+Around 60 minutes
 
 <% unless @appointment.bsl_video? %>
 Your phone number:

--- a/spec/features/agent_manages_appointments_spec.rb
+++ b/spec/features/agent_manages_appointments_spec.rb
@@ -542,7 +542,7 @@ RSpec.feature 'Agent manages appointments' do
     expect(@page).to be_displayed
 
     expect(@page.preview).to have_content "#{day.to_date.to_s(:govuk_date)} 9:30am"
-    expect(@page.preview).to have_content '(will last around 45 to 60 minutes)'
+    expect(@page.preview).to have_content '(will last around 60 minutes)'
 
     expect(@page.preview).to have_content '23 October 1950'
     expect(@page.preview).to have_content 'Some Person'

--- a/spec/mailers/appointment_mailer_spec.rb
+++ b/spec/mailers/appointment_mailer_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe AppointmentMailer, type: :mailer do
       end
 
       it 'includes the duration' do
-        expect(body).to include('45 to 60 minutes')
+        expect(body).to include('Around 60 minutes')
       end
 
       it 'includes the contact number' do
@@ -355,7 +355,7 @@ RSpec.describe AppointmentMailer, type: :mailer do
       end
 
       it 'includes the duration' do
-        expect(body).to include('45 to 60 minutes')
+        expect(body).to include('Around 60 minutes')
       end
 
       it 'includes the contact number' do
@@ -429,7 +429,7 @@ RSpec.describe AppointmentMailer, type: :mailer do
       end
 
       it 'includes the duration' do
-        expect(body).to include('45 to 60 minutes')
+        expect(body).to include('Around 60 minutes')
       end
 
       it 'includes the contact number' do


### PR DESCRIPTION
Remove the ambiguity around appointment durations.