### PR TITLE
Don't trigger booking window validations needless

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -547,7 +547,7 @@ class Appointment < ApplicationRecord
   end
 
   def valid_within_booking_window
-    return unless start_at
+    return unless start_at && start_at_changed?
 
     too_late = start_at > BusinessDays.from_now(40)
     errors.add(:start_at, 'must be less than 40 business days from now') if too_late

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -2,6 +2,19 @@ require 'rails_helper'
 
 # rubocop:disable Metrics/BlockLength
 RSpec.describe Appointment, type: :model do
+  describe 'booking window alteration bug fix' do
+    context 'when an appointment was booked before the booking window reduction' do
+      it 'can be updated correctly' do
+        @appointment = create(:appointment)
+
+        travel_to BusinessDays.before_now(50) do
+          @appointment.status = :complete
+          @appointment.save!
+        end
+      end
+    end
+  end
+
   describe '#summarised?' do
     context 'when it has an summary activity' do
       it 'is true' do


### PR DESCRIPTION
This should only be triggered when the `start_at` for the appointment was altered. This happens during creation and when the appointment is rescheduled. The prior behaviour was blocking online cancellations for appointments that were booked before the booking window reduction and were occuring past the now-valid booking window.