### PR TITLE
Send alerts after 24 hours without summarising

### DIFF
--- a/app/jobs/summary_document_check_job.rb
+++ b/app/jobs/summary_document_check_job.rb
@@ -1,0 +1,9 @@
+class SummaryDocumentCheckJob < ApplicationJob
+  queue_as :default
+
+  def perform(appointment)
+    return if appointment.summarised? || !appointment.complete?
+
+    AppointmentMailer.guider_summary_document_missing(appointment).deliver_now
+  end
+end

--- a/app/lib/notifier.rb
+++ b/app/lib/notifier.rb
@@ -51,6 +51,8 @@ class Notifier
   end
 
   def notify_guiders
+    SummaryDocumentCheckJob.set(wait: 24.hours).perform_later(appointment) if appointment_complete?
+
     guiders_to_notify.each do |guider_id|
       PusherAppointmentChangedJob.perform_later(guider_id, appointment)
     end

--- a/app/mailers/appointment_mailer.rb
+++ b/app/mailers/appointment_mailer.rb
@@ -5,6 +5,12 @@ class AppointmentMailer < ApplicationMailer
 
   default subject: -> { @appointment.subject }, from: -> { @appointment.from }
 
+  def guider_summary_document_missing(appointment)
+    mailgun_headers('guider_summary_document_missing', appointment.id)
+    @appointment = decorate(appointment)
+    mail to: appointment.guider.email, subject: @appointment.subject('No Summary Document Generated')
+  end
+
   def resource_manager_email_dropped(appointment, recipient)
     mailgun_headers('resource_manager_email_dropped', appointment.id)
     @appointment = decorate(appointment)

--- a/app/views/appointment_mailer/guider_summary_document_missing.html.erb
+++ b/app/views/appointment_mailer/guider_summary_document_missing.html.erb
@@ -1,0 +1,31 @@
+<h1 style="color: #0F19A0 !important;font-family: Calibri, Arial, sans-serif;margin: 15px 0;font-weight: 700;font-size: 20px;line-height: 1.111111111;padding: 15px 0;">
+  A summary document has not been generated for this appointment via Telephone Appointment Planner (TAP)
+</h1>
+
+<%= p do %>
+  Reference number:
+  <br>
+  <strong class="emphasize">
+    <%= @appointment.id %>
+  </strong>
+<% end %>
+
+<%= p do %>
+  Date:
+  <br>
+  <strong class="emphasize">
+    <%= @appointment.start_at.to_date.to_s(:govuk_date) %>
+  </strong>
+<% end %>
+
+<%= p do %>
+  Time:
+  <br>
+  <strong class="emphasize">
+    <%= "#{@appointment.start_at.to_time.to_s(:govuk_time)} (#{@appointment.timezone})" %>
+  </strong>
+<% end %>
+
+<%= p do %>
+  <%= link_to 'View the appointment', edit_appointment_url(@appointment) %>
+<% end %>

--- a/app/views/appointment_mailer/guider_summary_document_missing.text.erb
+++ b/app/views/appointment_mailer/guider_summary_document_missing.text.erb
@@ -1,0 +1,7 @@
+A summary document has not been generated for this appointment via Telephone Appointment Planner (TAP)
+
+Reference number: <%= @appointment.id %>
+Date: <%= @appointment.start_at.to_date.to_s(:govuk_date) %>
+Time: <%= "#{@appointment.start_at.to_time.to_s(:govuk_time)} (#{@appointment.timezone})" %>
+
+<%= edit_appointment_url(@appointment) %>

--- a/spec/jobs/summary_document_check_job_spec.rb
+++ b/spec/jobs/summary_document_check_job_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe SummaryDocumentCheckJob, '#perform' do
+  context 'when the appointment was summarised already' do
+    it 'does not send the notification' do
+      appointment = create(:appointment, :digital_summarised)
+
+      expect(AppointmentMailer).not_to receive(:guider_summary_document_missing).with(appointment)
+
+      described_class.perform_now(appointment)
+    end
+  end
+
+  context 'when the appointment was not summarised already' do
+    it 'does not send the notification' do
+      appointment = create(:appointment, status: :complete)
+
+      mailer = double(deliver_now: true)
+
+      expect(AppointmentMailer).to receive(:guider_summary_document_missing).with(appointment).and_return(mailer)
+
+      described_class.perform_now(appointment)
+    end
+  end
+end

--- a/spec/mailers/appointment_mailer_spec.rb
+++ b/spec/mailers/appointment_mailer_spec.rb
@@ -88,6 +88,30 @@ RSpec.describe AppointmentMailer, type: :mailer do
     end
   end
 
+  describe 'Guider summary document missing' do
+    let(:mailgun_headers) { JSON.parse(subject['X-Mailgun-Variables'].value) }
+    let(:appointment) { build_stubbed(:appointment) }
+    let(:body) { subject.body.encoded }
+
+    subject { described_class.guider_summary_document_missing(appointment) }
+
+    it 'renders the headers' do
+      expect(subject.to).to eq(['some-name@example.org'])
+      expect(subject.subject).to eq('Pension Wise No Summary Document Generated')
+    end
+
+    it 'renders the mailgun specific headers' do
+      expect(mailgun_headers).to include(
+        'message_type'   => 'guider_summary_document_missing',
+        'appointment_id' => appointment.id
+      )
+    end
+
+    it 'includes the body specifics' do
+      expect(body).to match(/A summary document has not been generated/)
+    end
+  end
+
   describe 'Resource Manager Email Failure' do
     let(:mailgun_headers) { JSON.parse(subject['X-Mailgun-Variables'].value) }
     let(:appointment) { build_stubbed(:appointment) }

--- a/spec/mailers/previews/appointment_mailer_preview.rb
+++ b/spec/mailers/previews/appointment_mailer_preview.rb
@@ -1,5 +1,11 @@
 # Preview all emails at http://localhost:3000/rails/mailers/appointment_mailer
 class AppointmentMailerPreview < ActionMailer::Preview
+  def guider_summary_document_missing
+    appointment = random_appointment
+
+    AppointmentMailer.guider_summary_document_missing(appointment)
+  end
+
   def resource_manager_email_dropped
     appointment = random_appointment
 
@@ -90,7 +96,7 @@ class AppointmentMailerPreview < ActionMailer::Preview
   private
 
   def random_appointment
-    Appointment.all.sample(1).first || FactoryBot.create(:appointment)
+    Appointment.limit(200).sample(1).first || FactoryBot.create(:appointment)
   end
 
   def random_due_diligence_appointment


### PR DESCRIPTION
When the appointment is completed, a check is scheduled or 24hrs that will notify the guider when the appointment was not yet summarised.