### PR TITLE
Allow cancellation reasons to be expanded

### DIFF
--- a/app/controllers/api/v1/cancels_controller.rb
+++ b/app/controllers/api/v1/cancels_controller.rb
@@ -19,7 +19,7 @@ module Api
       end
 
       def cancellation_params
-        params.permit(:appointment_id, :date_of_birth, :secondary_status)
+        params.permit(:appointment_id, :date_of_birth, :secondary_status, :other_reason)
       end
     end
   end

--- a/app/forms/api/v1/appointment_cancellation.rb
+++ b/app/forms/api/v1/appointment_cancellation.rb
@@ -3,12 +3,12 @@ module Api
     class AppointmentCancellation
       include ActiveModel::Model
 
-      attr_accessor :appointment_id, :date_of_birth, :secondary_status
+      attr_accessor :appointment_id, :date_of_birth, :secondary_status, :other_reason
 
       def cancel
         return false unless appointment
 
-        appointment.self_serve_cancel!(secondary_status)
+        appointment.self_serve_cancel!(secondary_status, other_reason)
       end
 
       def model

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -414,10 +414,12 @@ class Appointment < ApplicationRecord
     end
   end
 
-  def self_serve_cancel!(secondary_status)
+  def self_serve_cancel!(secondary_status, other_reason)
+    other_reason = '' unless secondary_status == '40' # Other
+
     without_auditing do
       transaction do
-        update!(status: :cancelled_by_customer_online, secondary_status:)
+        update!(status: :cancelled_by_customer_online, secondary_status:, other_reason:)
         CustomerOnlineCancellationActivity.from(self)
       end
 

--- a/db/migrate/20241023134101_add_other_reason_to_appointments.rb
+++ b/db/migrate/20241023134101_add_other_reason_to_appointments.rb
@@ -1,0 +1,5 @@
+class AddOtherReasonToAppointments < ActiveRecord::Migration[6.1]
+  def change
+    add_column :appointments, :other_reason, :string, null: false, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_10_04_103932) do
+ActiveRecord::Schema.define(version: 2024_10_23_134101) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -124,6 +124,7 @@ ActiveRecord::Schema.define(version: 2024_10_04_103932) do
     t.string "rescheduling_reason", default: "", null: false
     t.string "cancelled_via", default: "", null: false
     t.string "rescheduling_route", default: "", null: false
+    t.string "other_reason", default: "", null: false
     t.index ["guider_id", "start_at"], name: "unique_slot_guider_in_appointment", unique: true, where: "((status <> ALL (ARRAY[5, 6, 7, 8, 9])) AND (start_at > '2024-01-01 00:00:00'::timestamp without time zone))"
     t.index ["guider_id"], name: "index_appointments_on_guider_id"
     t.index ["schedule_type"], name: "index_appointments_on_schedule_type"

--- a/spec/forms/api/v1/appointment_cancellation_spec.rb
+++ b/spec/forms/api/v1/appointment_cancellation_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Api::V1::AppointmentCancellation, '#cancel' do # rubocop:disable 
           described_class.new(
             appointment_id: @appointment.id,
             date_of_birth: @appointment.date_of_birth,
-            secondary_status: '32'
+            secondary_status: '32',
+            other_reason: ''
           ).cancel
         ).to be_truthy
       end
@@ -20,7 +21,8 @@ RSpec.describe Api::V1::AppointmentCancellation, '#cancel' do # rubocop:disable 
           described_class.new(
             appointment_id: @appointment.id,
             date_of_birth: @appointment.date_of_birth,
-            secondary_status: '32'
+            secondary_status: '32',
+            other_reason: ''
           ).cancel
         ).to be_falsey
       end
@@ -35,7 +37,8 @@ RSpec.describe Api::V1::AppointmentCancellation, '#cancel' do # rubocop:disable 
         described_class.new(
           appointment_id: @appointment.id,
           date_of_birth: @appointment.date_of_birth,
-          secondary_status: '32'
+          secondary_status: '32',
+          other_reason: ''
         ).cancel
       ).to be_falsey
     end
@@ -49,7 +52,8 @@ RSpec.describe Api::V1::AppointmentCancellation, '#cancel' do # rubocop:disable 
         described_class.new(
           appointment_id: @appointment.id,
           date_of_birth: @appointment.date_of_birth,
-          secondary_status: '32'
+          secondary_status: '32',
+          other_reason: ''
         ).cancel
       ).to be_truthy
     end
@@ -63,7 +67,8 @@ RSpec.describe Api::V1::AppointmentCancellation, '#cancel' do # rubocop:disable 
         described_class.new(
           appointment_id: @appointment.id,
           date_of_birth: @appointment.date_of_birth,
-          secondary_status: '32'
+          secondary_status: '32',
+          other_reason: ''
         ).cancel
       ).to be_falsey
     end

--- a/spec/requests/cancellations_api_spec.rb
+++ b/spec/requests/cancellations_api_spec.rb
@@ -31,13 +31,13 @@ RSpec.describe 'POST /api/v1/appointments/{id}/cancel' do # rubocop:disable Metr
   end
 
   def when_the_client_posts_a_valid_request_for_a_missing_appointment
-    @payload = { 'date_of_birth' => '1970-01-01', 'secondary_status' => '32' }
+    @payload = { 'date_of_birth' => '1970-01-01', 'secondary_status' => '32', 'other_reason' => '' }
 
     post api_v1_appointment_cancel_path(appointment_id: '999', params: @payload, as: :json)
   end
 
   def when_the_client_posts_a_valid_cancellation_request
-    @payload = { 'date_of_birth' => '1970-01-01', 'secondary_status' => '32' }
+    @payload = { 'date_of_birth' => '1970-01-01', 'secondary_status' => '32', 'other_reason' => '' }
 
     post api_v1_appointment_cancel_path(@appointment, params: @payload, as: :json)
   end


### PR DESCRIPTION
The customer can now specify a further free-text reason when they follow the cancellation self-serve journey and specify 'other' as their reason.