### PR TITLE
Include casebook case reference in activity feed

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,7 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Exclude:
     - 'spec/helpers/*'
+    - 'spec/lib/casebook/api_spec.rb'
 
 Style/ExpandPathArguments:
   Exclude:

--- a/app/lib/casebook/api.rb
+++ b/app/lib/casebook/api.rb
@@ -10,7 +10,7 @@ module Casebook
       payload = Presenters::Create.new(appointment).to_h
 
       response = token.post('/api/v1/appointments', params: payload)
-      response.parsed['data']['id']
+      Response.new(response.parsed)
     rescue OAuth2::Error => e
       raise ApiError.new(e.response.status, e)
     end
@@ -27,7 +27,7 @@ module Casebook
       payload = Presenters::Reschedule.new(appointment).to_h
 
       response = token.post("/api/v1/appointments/#{appointment.casebook_appointment_id}/reschedule", params: payload)
-      response.parsed['data']['id']
+      Response.new(response.parsed)
     rescue OAuth2::Error => e
       raise ApiError.new(e.response.status, e)
     end

--- a/app/lib/casebook/push.rb
+++ b/app/lib/casebook/push.rb
@@ -6,9 +6,9 @@ module Casebook
     end
 
     def call
-      casebook_identifier = api.create(appointment)
+      casebook_response = api.create(appointment)
 
-      appointment.process_casebook!(casebook_identifier)
+      appointment.process_casebook!(casebook_response)
     end
 
     private

--- a/app/lib/casebook/reschedule.rb
+++ b/app/lib/casebook/reschedule.rb
@@ -6,9 +6,9 @@ module Casebook
     end
 
     def call
-      casebook_identifier = api.reschedule(appointment)
+      casebook_response = api.reschedule(appointment)
 
-      appointment.process_casebook!(casebook_identifier)
+      appointment.process_casebook!(casebook_response)
     end
 
     private

--- a/app/lib/casebook/response.rb
+++ b/app/lib/casebook/response.rb
@@ -1,0 +1,15 @@
+module Casebook
+  class Response
+    def initialize(response)
+      @response = response
+    end
+
+    def appointment_id
+      @response['data']['id']
+    end
+
+    def case_reference_number
+      @response['data']['attributes']['case-reference-number']
+    end
+  end
+end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -218,12 +218,12 @@ class Appointment < ApplicationRecord
     schedule_type == User::PENSION_WISE_SCHEDULE_TYPE
   end
 
-  def process_casebook!(casebook_identifier)
+  def process_casebook!(casebook_response)
     without_auditing do
       transaction do
-        update!(processed_at: Time.zone.now, casebook_appointment_id: casebook_identifier)
+        update!(processed_at: Time.zone.now, casebook_appointment_id: casebook_response.appointment_id)
 
-        CasebookProcessedActivity.create!(appointment: self)
+        CasebookProcessedActivity.create!(appointment: self, message: casebook_response.case_reference_number)
       end
     end
   end

--- a/app/views/activities/_casebook_processed_activity.html.erb
+++ b/app/views/activities/_casebook_processed_activity.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:activity_message, flush: true) do %>
   <span class="glyphicon glyphicon-book" aria-hidden="true"></span>
-  The appointment was successfully published to casebook
+  The appointment was successfully published to casebook <% if casebook_processed_activity.message? %><strong><%= casebook_processed_activity.message %></strong><% end %>
 <% end %>
 <%= render 'activities/activity', activity: casebook_processed_activity, details: details, hide: hide %>

--- a/spec/lib/casebook/api_spec.rb
+++ b/spec/lib/casebook/api_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Casebook::Api do # rubocop:disable Metrics/BlockLength
+RSpec.describe Casebook::Api do
   let(:client) { double }
   let(:token) { double }
 
@@ -33,9 +33,19 @@ RSpec.describe Casebook::Api do # rubocop:disable Metrics/BlockLength
             }
           }
         }
-      ).and_return(double(parsed: { 'data' => { 'id' => '123456' } }))
+      ).and_return(
+        double(parsed: {
+                 'data' => {
+                   'id' => '123456',
+                   'attributes' => { 'case-reference-number' => 'CA-1010101' }
+                 }
+               })
+      )
 
-      expect(subject.create(appointment)).to eq('123456')
+      response = subject.create(appointment)
+
+      expect(response.appointment_id).to eq('123456')
+      expect(response.case_reference_number).to eq('CA-1010101')
     end
   end
 
@@ -82,9 +92,19 @@ RSpec.describe Casebook::Api do # rubocop:disable Metrics/BlockLength
             }
           }
         }
-      ).and_return(double(parsed: { 'data' => { 'id' => '123456' } }))
+      ).and_return(
+        double(parsed: {
+                 'data' => {
+                   'id' => '123456',
+                   'attributes' => { 'case-reference-number' => 'CA-1010101' }
+                 }
+               })
+      )
 
-      expect(subject.reschedule(appointment)).to eq('123456')
+      response = subject.reschedule(appointment)
+
+      expect(response.appointment_id).to eq('123456')
+      expect(response.case_reference_number).to eq('CA-1010101')
     end
   end
 end

--- a/spec/lib/casebook/push_spec.rb
+++ b/spec/lib/casebook/push_spec.rb
@@ -4,9 +4,10 @@ RSpec.describe Casebook::Push, '#call' do
   it 'calls the casebook API and processes the response' do
     casebook_api = instance_double(Casebook::Api)
     appointment  = instance_double(Appointment)
+    response     = instance_double(Casebook::Response)
 
-    expect(casebook_api).to receive(:create).with(appointment).and_return('123456')
-    expect(appointment).to receive(:process_casebook!).with('123456').and_return(true)
+    expect(casebook_api).to receive(:create).with(appointment).and_return(response)
+    expect(appointment).to receive(:process_casebook!).with(response).and_return(true)
 
     described_class.new(appointment, api: casebook_api).call
   end

--- a/spec/lib/casebook/reschedule_spec.rb
+++ b/spec/lib/casebook/reschedule_spec.rb
@@ -4,9 +4,10 @@ RSpec.describe Casebook::Reschedule, '#call' do
   it 'calls the casebook API and processes the response' do
     casebook_api = instance_double(Casebook::Api)
     appointment  = instance_double(Appointment)
+    response     = instance_double(Casebook::Response)
 
-    expect(casebook_api).to receive(:reschedule).with(appointment).and_return('123456')
-    expect(appointment).to receive(:process_casebook!).with('123456').and_return(true)
+    expect(casebook_api).to receive(:reschedule).with(appointment).and_return(response)
+    expect(appointment).to receive(:process_casebook!).with(response).and_return(true)
 
     described_class.new(appointment, api: casebook_api).call
   end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -167,8 +167,9 @@ RSpec.describe Appointment, type: :model do
   describe '#process_casebook!' do
     it 'processes the appointment and logs an activity' do
       appointment = create(:appointment)
+      casebook_response = instance_double(Casebook::Response, appointment_id: 123, case_reference_number: 'CA-123')
 
-      appointment.process_casebook!('123')
+      appointment.process_casebook!(casebook_response)
 
       expect(appointment).to be_processed_at
       expect(appointment.casebook_appointment_id).to eq(123)


### PR DESCRIPTION
This was requested by CITA as it helps them find the matching appointment in casebook without using DOB and other criteria from the underlying appointment.