### PR TITLE
Block all Saturdays throughout 2025 for CAS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,7 @@ end
 group :test do
   gem 'chronic'
   gem 'database_rewinder'
+  gem 'rspec-retry'
   gem 'scss_lint', require: false
   gem 'selenium-webdriver'
   gem 'vcr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,6 +455,8 @@ GEM
       rspec-expectations (~> 3.9)
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
     rspec-support (3.9.2)
     rubocop (1.56.3)
       base64 (~> 0.1.1)
@@ -619,6 +621,7 @@ DEPENDENCIES
   rails-assets-qTip2!
   rails-assets-zloirock--core-js (= 2.5.1)!
   rspec-rails
+  rspec-retry
   rubocop
   rubocop-rails
   sassc-rails

--- a/lib/tasks/holidays.rake
+++ b/lib/tasks/holidays.rake
@@ -3,4 +3,22 @@ namespace :holidays do
   task exclude: :environment do
     BankHolidayExcluder.new.call
   end
+
+  task block_cas_guiders_saturdays: :environment do
+    all_saturdays = (Date.parse('2025-01-01 00:00')..Date.parse('2025-12-31 23:59')).select(&:saturday?)
+    cas_guiders   = User.where(organisation_content_id: Provider::CAS.id).guiders
+
+    all_saturdays.each do |saturday|
+      cas_guiders.each do |guider|
+        Holiday.find_or_create_by!(
+          user_id: guider.id,
+          all_day: true,
+          bank_holiday: false,
+          title: 'ALL - Saturday Exclusion',
+          start_at: saturday.beginning_of_day,
+          end_at: saturday.end_of_day
+        )
+      end
+    end
+  end
 end

--- a/spec/features/resource_manager_modifies_appointments_spec.rb
+++ b/spec/features/resource_manager_modifies_appointments_spec.rb
@@ -103,7 +103,7 @@ RSpec.feature 'Resource manager modifies appointments' do
     end
   end
 
-  scenario 'Creating a holiday for one guider', js: true do
+  scenario 'Creating a holiday for one guider', js: true, retry: 3 do
     given_the_user_is_a_resource_manager do
       travel_to BusinessDays.from_now(1) do
         and_there_is_a_guider


### PR DESCRIPTION
CAS have requested that all guiders have an allocated holiday entry for every Saturday throughout 2025.