### PR TITLE
Ensure booking window validation is respected

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -554,8 +554,8 @@ class Appointment < ApplicationRecord
   def valid_within_booking_window
     return unless start_at && start_at_changed?
 
-    too_late = start_at > BusinessDays.from_now(40)
-    errors.add(:start_at, 'must be less than 40 business days from now') if too_late
+    too_late = start_at > BookableSlot.end_of_window_for(schedule_type)
+    errors.add(:start_at, 'must not exceed the booking window') if too_late
   end
 
   def data_subject_date_of_birth_valid

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -2,6 +2,30 @@ require 'rails_helper'
 
 # rubocop:disable Metrics/BlockLength
 RSpec.describe Appointment, type: :model do
+  describe 'Booking an appointment within the schedule type window' do
+    context 'when the appointment is PSG/DD' do
+      it 'validates the end of the window correctly' do
+        @appointment = build(:appointment, :due_diligence)
+        expect(@appointment).to be_valid
+
+        @appointment.start_at = BusinessDays.from_now(61).beginning_of_day
+        expect(@appointment).to be_invalid
+        expect(@appointment.errors[:start_at]).to be_present
+      end
+    end
+
+    context 'when the appointment is PW' do
+      it 'validates the end of the window correctly' do
+        @appointment = build(:appointment)
+        expect(@appointment).to be_valid
+
+        @appointment.start_at = BusinessDays.from_now(41).beginning_of_day
+        expect(@appointment).to be_invalid
+        expect(@appointment.errors[:start_at]).to be_present
+      end
+    end
+  end
+
   describe 'booking window alteration bug fix' do
     context 'when an appointment was booked before the booking window reduction' do
       it 'can be updated correctly' do


### PR DESCRIPTION
This wasn't taking into account the differences between the end of the booking window for PSG and PW respectively.