### PR TITLE
Add change log page

### DIFF
--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -1,0 +1,5 @@
+class ReleasesController < ApplicationController
+  def index
+    @releases = Release.order(released_on: :desc).page(params[:page])
+  end
+end

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -1,0 +1,2 @@
+class Release < ApplicationRecord
+end

--- a/app/views/releases/index.html.erb
+++ b/app/views/releases/index.html.erb
@@ -1,0 +1,30 @@
+<% content_for(:page_title, t('service.title', page_title: 'Changes')) %>
+<%= breadcrumb( { title: 'Changes' } ) %>
+
+<h1>Changes</h1>
+
+<nav aria-label="Pagination">
+  <%= paginate @releases %>
+</nav>
+
+<table class="table table-striped table-bordered table-hover">
+  <caption><span class="sr-only">List of changes</span></caption>
+  <thead>
+    <tr>
+      <th>Change</th>
+      <th>Released</th>
+    </tr>
+  </thead>
+  <tbody class="list">
+    <% @releases.each do |release| %>
+      <tr>
+        <td><%= release.summary %></td>
+        <td><%= release.released_on.to_s(:govuk_date) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<nav aria-label="Pagination">
+  <%= paginate @releases %>
+</nav>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -41,6 +41,10 @@
   </li>
 <% end %>
 
+<li>
+  <%= active_link_to 'Changes', releases_path %>
+</li>
+
 <li class="dropdown quick-search" data-module="quick-search">
   <a href="#" class="dropdown-toggle js-quick-search-button" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
     <span class="sr-only">Quick Search</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,6 +97,8 @@ Rails.application.routes.draw do
     get 'create', on: :collection, action: :create
   end
 
+  resources :releases, only: :index
+
   mount Sidekiq::Web, at: '/sidekiq', constraints: AuthenticatedUser.new
 end
 # rubocop:enable Metrics/BlockLength

--- a/db/migrate/20241125195323_create_releases.rb
+++ b/db/migrate/20241125195323_create_releases.rb
@@ -1,0 +1,10 @@
+class CreateReleases < ActiveRecord::Migration[6.1]
+  def change
+    create_table :releases do |t|
+      t.text :summary
+      t.date :released_on
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_10_23_134101) do
+ActiveRecord::Schema.define(version: 2024_11_25_195323) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -198,6 +198,13 @@ ActiveRecord::Schema.define(version: 2024_10_23_134101) do
     t.boolean "all_day", default: false, null: false
     t.index ["start_at", "end_at"], name: "index_holidays_on_start_at_and_end_at"
     t.index ["user_id"], name: "index_holidays_on_user_id"
+  end
+
+  create_table "releases", force: :cascade do |t|
+    t.text "summary"
+    t.date "released_on"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "reporting_summaries", force: :cascade do |t|


### PR DESCRIPTION
Adds a date ordered list of released changes with plain text summaries. This is very basic for now and entries will be made from the console.