### PR TITLE
Use `TSRANGE` types for optimisations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   global:
   - PATH=$PWD/bin:$PATH
 before_script:
+- psql -U postgres -c "create extension btree_gist;"
 - "[ -d .downloads ] || mkdir .downloads"
 - "(cd .downloads; [ -d prince-9.0r5-linux-amd64-static ] || curl -s https://www.princexml.com/download/prince-9.0r5-linux-amd64-static.tar.gz | tar xzf -)"
 - echo $PWD | ./.downloads/prince-9.0r5-linux-amd64-static/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: focal
 language: ruby
 addons:
   chrome: stable
+  postgresql: 16
 services:
 - redis-server
 - postgresql
@@ -15,9 +16,16 @@ cache:
   - tmp/cache/assets/sprockets
 env:
   global:
+  - PGUSER=postgres
+  - PGPORT=5432
+  - PGHOST=localhost
   - PATH=$PWD/bin:$PATH
+before_install:
+ - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/*/main/pg_hba.conf
+ - sudo service postgresql restart
 before_script:
-- psql -U postgres -c "create extension btree_gist;"
+- psql -U postgres -c 'create database telephone_appointment_planner_test;'
+- psql -U postgres -d telephone_appointment_planner_test -c 'create extension btree_gist;'
 - "[ -d .downloads ] || mkdir .downloads"
 - "(cd .downloads; [ -d prince-9.0r5-linux-amd64-static ] || curl -s https://www.princexml.com/download/prince-9.0r5-linux-amd64-static.tar.gz | tar xzf -)"
 - echo $PWD | ./.downloads/prince-9.0r5-linux-amd64-static/install.sh
@@ -28,7 +36,7 @@ before_script:
 - "export PATH=$PWD/bin/chromedriver/linux-${CHROMEDRIVER}/chromedriver-linux64:$PATH"
 - gem install bundler
 - bundle exec rails assets:precompile RAILS_ENV=test
-- bundle exec rails db:create db:migrate RAILS_ENV=test
+- bundle exec rails db:migrate RAILS_ENV=test
 notifications:
   slack:
     secure: izFI8CV1BAc5Sk08/q84YijolWAY2Zm3JA4RPyilwjzfrro5v2lOM9rEX32W1fgPDu7hWq1bmqYcgxhVI+ecu2RFkI0iQklgNSe256HN7AKqRtSgtVx+3L6w8B9tBCJJ9wfj0lur/8x6oh8UwH8jExJmqtJbL3rxIq+O9N0/nJdf4jXR9vPHfFtprZwExQQTDQccqXkfyE+BqYRsFjoa/jL0utZlLt5kn8ErQPW/lDiSFvOA9OKk5o2ihQrndxkhAhZX6GbKp2aBP3xkom37aQZRyXsKIMXCz16+0IGOsTrW32j3lwLjsesb308Bp01e4q4ssp3a+2k5Hs2CKs0++b9Bb4GLpEl6Q63TGewUqK9/TXjvp7IWx5SOTQbktB5YLL6WmfR+j7MfD52VrEIHahEgJUwQQ+2+EG9MP0O8Qbs4Gek1FgGtpN7+rUS9WpOUIiGEjN7+uGd+PHTgSL7gf0kqrhtQcDHkP8KfI7KOrB1O0gO4DmdHNfJ184MXKEFlh7ULKtX08i8iB5GMVGQqsCuI7lfgR/P+u/SlIbPVu/aRoXpzo4e18UVpjBl9fR5mk6vroXqiR/5v4sHByFp5wn/QwvGszXjZcgmqTtZ7tyGGoq1IS6QdPr1Y0D/mBZT/O4N7QzG7fugPXwKOIfiktPooGt6CSVca5SHa13OkBrk=

--- a/db/migrate/20241215181148_add_ts_range_indices_for_appointments_holidays_bookable_slots.rb
+++ b/db/migrate/20241215181148_add_ts_range_indices_for_appointments_holidays_bookable_slots.rb
@@ -1,0 +1,27 @@
+class AddTsRangeIndicesForAppointmentsHolidaysBookableSlots < ActiveRecord::Migration[6.1]
+  def up
+    execute <<-SQL
+      DROP INDEX IF EXISTS index_bookable_slots_tsrange_start_at_end_at;
+      DROP INDEX IF EXISTS index_appointments_tsrange_start_at_end_at;
+      DROP INDEX IF EXISTS index_holidays_tsrange_start_at_end_at;
+      DROP INDEX IF EXISTS index_appointments_guider_start_schedule_status;
+      DROP INDEX IF EXISTS index_holidays_userid_tsrange;
+
+      CREATE INDEX index_bookable_slots_tsrange_start_at_end_at ON bookable_slots USING gist (tsrange(start_at, end_at));
+      CREATE INDEX index_appointments_tsrange_start_at_end_at ON appointments USING gist (tsrange(start_at, end_at));
+      CREATE INDEX index_holidays_tsrange_start_at_end_at ON holidays USING gist (tsrange(start_at, end_at));
+      CREATE INDEX index_appointments_guider_start_schedule_status on appointments USING btree (guider_id, start_at) WHERE schedule_type::text = 'pension_wise'::text AND (status <> ALL ('{6,7,8,9}'::integer[]));
+      CREATE INDEX index_holidays_userid_tsrange on holidays USING gist (user_id, tsrange(start_at, end_at));
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      DROP INDEX IF EXISTS index_bookable_slots_tsrange_start_at_end_at;
+      DROP INDEX IF EXISTS index_appointments_tsrange_start_at_end_at;
+      DROP INDEX IF EXISTS index_holidays_tsrange_start_at_end_at;
+      DROP INDEX IF EXISTS index_appointments_guider_start_schedule_status;
+      DROP INDEX IF EXISTS index_holidays_userid_tsrange;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_12_15_171846) do
+ActiveRecord::Schema.define(version: 2024_12_15_181148) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pg_stat_statements"
+  enable_extension "btree_gist"
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
 
@@ -125,14 +125,14 @@ ActiveRecord::Schema.define(version: 2024_12_15_171846) do
     t.string "cancelled_via", default: "", null: false
     t.string "rescheduling_route", default: "", null: false
     t.string "other_reason", default: "", null: false
+    t.index "tsrange(start_at, end_at)", name: "index_appointments_tsrange_start_at_end_at", using: :gist
+    t.index ["guider_id", "start_at"], name: "index_appointments_guider_start_schedule_status", where: "(((schedule_type)::text = 'pension_wise'::text) AND (status <> ALL ('{6,7,8,9}'::integer[])))"
     t.index ["guider_id", "start_at"], name: "unique_slot_guider_in_appointment", unique: true, where: "((status <> ALL (ARRAY[5, 6, 7, 8, 9])) AND (start_at > '2024-01-01 00:00:00'::timestamp without time zone))"
     t.index ["guider_id"], name: "index_appointments_guider_schedule_status", where: "(((schedule_type)::text = 'pension_wise'::text) AND (status <> ALL ('{6,7,8,9}'::integer[])))"
     t.index ["guider_id"], name: "index_appointments_on_guider_id"
     t.index ["schedule_type"], name: "index_appointments_on_schedule_type"
     t.index ["start_at", "end_at", "guider_id"], name: "index_appointments_on_start_at_and_end_at_and_guider_id"
-    t.index ["start_at", "end_at"], name: "index_appointments_on_start_at_and_end_at"
     t.index ["start_at"], name: "index_appointments_on_start_at"
-    t.index ["status"], name: "index_appointments_on_status"
   end
 
   create_table "audits", id: :serial, force: :cascade do |t|
@@ -164,6 +164,7 @@ ActiveRecord::Schema.define(version: 2024_12_15_171846) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "schedule_type", default: "pension_wise", null: false
+    t.index "tsrange(start_at, end_at)", name: "index_bookable_slots_tsrange_start_at_end_at", using: :gist
     t.index ["guider_id"], name: "index_bookable_slots_on_guider_id"
     t.index ["schedule_type"], name: "index_bookable_slots_on_schedule_type"
     t.index ["start_at", "end_at"], name: "index_bookable_slots_on_start_at_and_end_at"
@@ -199,6 +200,8 @@ ActiveRecord::Schema.define(version: 2024_12_15_171846) do
     t.datetime "updated_at", null: false
     t.boolean "bank_holiday", null: false
     t.boolean "all_day", default: false, null: false
+    t.index "tsrange(start_at, end_at)", name: "index_holidays_tsrange_start_at_end_at", using: :gist
+    t.index "user_id, tsrange(start_at, end_at)", name: "index_holidays_userid_tsrange", using: :gist
     t.index ["start_at", "end_at"], name: "index_holidays_on_start_at_and_end_at"
     t.index ["user_id"], name: "index_holidays_on_user_id"
   end


### PR DESCRIPTION
`OVERLAPS` barely ever makes use of indices. Conversion to the native `TSRANGE` and comparisons of such are hugely more performant.