### PR TITLE
Be more permissive with mobile numbers

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -6,6 +6,9 @@ class Appointment < ApplicationRecord
 
   attr_accessor :current_user, :internal_availability, :ad_hoc_start_at
 
+  MOBILE_REGEX = /^(07|\+447|00447)/
+  MOBILE_REGEX_POSIX = '^(07|\+447|00447)'.freeze
+
   DEFAULT_COUNTRY_CODE = 'GB'.freeze
 
   RESCHEDULING_REASONS = %w[client_rescheduled office_rescheduled].freeze
@@ -132,7 +135,7 @@ class Appointment < ApplicationRecord
 
   scope :cancelled, -> { where(status: CANCELLED_STATUSES) }
   scope :not_cancelled, -> { where.not(status: CANCELLED_STATUSES) }
-  scope :with_mobile_number, -> { where("mobile like '07%' or phone like '07%'") }
+  scope :with_mobile_number, -> { where("mobile ~ '#{MOBILE_REGEX_POSIX}' or phone ~ '#{MOBILE_REGEX_POSIX}'") }
   scope :not_booked_today, -> { where.not(created_at: Time.current.beginning_of_day..Time.current.end_of_day) }
   scope :for_pension_wise, -> { where(schedule_type: User::PENSION_WISE_SCHEDULE_TYPE) }
   scope :for_due_diligence, -> { where(schedule_type: User::DUE_DILIGENCE_SCHEDULE_TYPE) }
@@ -395,7 +398,7 @@ class Appointment < ApplicationRecord
   end
 
   def mobile?
-    phone.start_with?('07') || mobile.start_with?('07')
+    MOBILE_REGEX === phone || MOBILE_REGEX === mobile
   end
 
   def owned_by_my_organisation?(myself)

--- a/spec/features/sms_appointment_reminder_spec.rb
+++ b/spec/features/sms_appointment_reminder_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'SMS appointment reminders' do
+RSpec.feature 'SMS appointment reminders' do # rubocop:disable Metrics/BlockLength
   scenario 'Executing the SMS appointment reminders job' do
     travel_to '2017-11-28 08:00 UTC' do
       given_appointments_due_sms_reminders_exist
@@ -19,6 +19,8 @@ RSpec.feature 'SMS appointment reminders' do
     @no_uk_mobile = create(:appointment, mobile: '0121 123 4567', start_at: 2.days.from_now, agent: @agent)
     # in the window with a mobile number
     @mobile = create(:appointment, start_at: 2.days.from_now, agent: @agent)
+    @other_mobile = create(:appointment, mobile: '', phone: '+447715930459', start_at: 2.days.from_now, agent: @agent)
+    @another_mobile = create(:appointment, mobile: '00447715930459', start_at: 2.days.from_now, agent: @agent)
   end
 
   def when_the_task_is_executed
@@ -28,7 +30,10 @@ RSpec.feature 'SMS appointment reminders' do
   end
 
   def then_the_required_jobs_are_scheduled
-    expect(@job_class).to have_received(:perform_later).at_most(:once)
-    expect(@job_class).to have_received(:perform_later).with(@mobile)
+    expect(@job_class).to have_received(:perform_later).exactly(3).times
+
+    [@mobile, @other_mobile, @another_mobile].each do |appointment|
+      expect(@job_class).to have_received(:perform_later).with(appointment)
+    end
   end
 end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -147,13 +147,19 @@ RSpec.describe Appointment, type: :model do
   end
 
   describe '#mobile?' do
-    context 'when the appointment has mobileish number' do
-      it 'is true' do
-        appointment = build_stubbed(:appointment, phone: '07715930485', mobile: '')
-        expect(appointment).to be_mobile
+    %w[
+      07715930459
+      +447715930459
+      00447715930459
+    ].each do |valid_number|
+      context "when the mobile or phone #{valid_number} is mobileish" do
+        it 'is true' do
+          appointment = build_stubbed(:appointment, phone: valid_number, mobile: '')
+          expect(appointment).to be_mobile
 
-        appointment = build_stubbed(:appointment, phone: '', mobile: '0771675849')
-        expect(appointment).to be_mobile
+          appointment = build_stubbed(:appointment, phone: '', mobile: valid_number)
+          expect(appointment).to be_mobile
+        end
       end
     end
 


### PR DESCRIPTION
Allows other mobileish numbers through for SMS messaging. When the phone or mobile begins with any of 07, +447 or 00447 then it is included in SMS confirmations, reminders and other comms.