### PR TITLE
Infer rescheduling reason when missing

### DIFF
--- a/app/lib/casebook/presenters/reschedule.rb
+++ b/app/lib/casebook/presenters/reschedule.rb
@@ -3,8 +3,14 @@ module Casebook
     class Reschedule < Create
       def to_h
         super.tap do |h|
-          h[:data][:attributes][:reschedule_status] = appointment.rescheduling_reason
+          h[:data][:attributes][:reschedule_status] = rescheduling_reason
         end
+      end
+
+      private
+
+      def rescheduling_reason
+        appointment.rescheduling_reason.presence || Appointment::OFFICE_RESCHEDULED
       end
     end
   end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -11,7 +11,10 @@ class Appointment < ApplicationRecord
 
   DEFAULT_COUNTRY_CODE = 'GB'.freeze
 
-  RESCHEDULING_REASONS = %w[client_rescheduled office_rescheduled].freeze
+  RESCHEDULING_REASONS = [
+    CLIENT_RESCHEDULED = 'client_rescheduled'.freeze,
+    OFFICE_RESCHEDULED = 'office_rescheduled'.freeze
+  ].freeze
   RESCHEDULING_ROUTES  = %w[phone email_or_crm].freeze
 
   CANCELLED_STATUSES = %i[

--- a/spec/lib/casebook/presenters/reschedule_spec.rb
+++ b/spec/lib/casebook/presenters/reschedule_spec.rb
@@ -19,4 +19,12 @@ RSpec.describe Casebook::Presenters::Reschedule, '#to_h' do
       reschedule_status: 'office_rescheduled'
     )
   end
+
+  context 'when the guider was reallocated' do
+    let(:appointment) { build_stubbed(:appointment, :casebook_guider) }
+
+    it 'infers the correct `reschedule_status`' do
+      expect(subject[:reschedule_status]).to eq('office_rescheduled')
+    end
+  end
 end


### PR DESCRIPTION
When a guider is reallocated and the appointment was pushed to casebook, we will automatically send a reschedule call to the casebook API. However, we don't provide the mandatory `reschedule_status`. We can safely infer this as `office_rescheduled`.