### PR TITLE
Limit the high-priority activities

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -26,6 +26,7 @@ class ActivitiesController < ApplicationController
     @activities = Activity
                   .high_priority_for(current_user)
                   .unresolved
+                  .where('created_at > ?', 1.month.ago)
                   .order('id DESC')
                   .limit(5)
 


### PR DESCRIPTION
This is in some cases querying across the whole table for particular individuals. These aren't considered timely after a month or so so limiting them this way is a quick fix.