### PR TITLE
Log inbound SMS replies

### DIFF
--- a/app/forms/sms_cancellation.rb
+++ b/app/forms/sms_cancellation.rb
@@ -14,9 +14,19 @@ class SmsCancellation
     else
       SmsCancellationFailureJob.perform_later(source_number, schedule_type)
     end
+
+    log_message if appointment
   end
 
   private
+
+  def log_message
+    SmsMessageActivity.create!(
+      message:,
+      owner: appointment.guider,
+      appointment:
+    )
+  end
 
   def send_notifications
     PusherAppointmentChangedJob.perform_later(

--- a/app/models/sms_message_activity.rb
+++ b/app/models/sms_message_activity.rb
@@ -1,0 +1,2 @@
+class SmsMessageActivity < Activity
+end

--- a/app/views/activities/_sms_message_activity.html.erb
+++ b/app/views/activities/_sms_message_activity.html.erb
@@ -1,0 +1,5 @@
+<% content_for(:activity_message, flush: true) do %>
+  <span class="glyphicon glyphicon-phone" aria-hidden="true"></span>
+  <strong>The customer</strong> replied via SMS <em><%= sms_message_activity.message %></em>
+<% end %>
+<%= render 'activities/activity', activity: sms_message_activity, details: details, hide: hide %>

--- a/spec/requests/sms_cancellation_callback_spec.rb
+++ b/spec/requests/sms_cancellation_callback_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'POST /sms_cancellations', type: :request do
     when_the_client_requests_cancellation_by_sms
     then_the_service_responds_no_content
     and_the_appointment_is_cancelled
+    and_a_sms_message_activity_is_created
     and_a_cancellation_activity_is_created
     and_the_customer_is_sent_a_confirmation_sms
     and_the_guider_is_notified
@@ -46,8 +47,12 @@ RSpec.describe 'POST /sms_cancellations', type: :request do
     expect(@appointment).to be_cancelled_by_customer_sms
   end
 
+  def and_a_sms_message_activity_is_created
+    expect(@appointment.activities.first).to be_an(SmsMessageActivity)
+  end
+
   def and_a_cancellation_activity_is_created
-    expect(@appointment.activities.first).to be_an(SmsCancellationActivity)
+    expect(@appointment.activities.second).to be_an(SmsCancellationActivity)
   end
 
   def and_the_customer_is_sent_a_confirmation_sms


### PR DESCRIPTION
Logs inbound SMS replies from customers on the appointments they're
associated with. They'll appear in the activity feed in realtime.