### PR TITLE
Configure SMS jobs to track failures

### DIFF
--- a/app/jobs/bsl_customer_exit_poll_job.rb
+++ b/app/jobs/bsl_customer_exit_poll_job.rb
@@ -3,6 +3,8 @@ class BslCustomerExitPollJob < NotifyJobBase
 
   queue_as :default
 
+  include SmsFailureRecordable
+
   def perform(appointment)
     send_sms(appointment) if appointment.mobile?
 

--- a/app/jobs/concerns/sms_failure_recordable.rb
+++ b/app/jobs/concerns/sms_failure_recordable.rb
@@ -1,0 +1,11 @@
+module SmsFailureRecordable
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from(Notifications::Client::BadRequestError) do
+      if (appointment = arguments[0])
+        SmsFailureActivity.from(appointment)
+      end
+    end
+  end
+end

--- a/app/jobs/concerns/sms_failure_recordable.rb
+++ b/app/jobs/concerns/sms_failure_recordable.rb
@@ -5,6 +5,8 @@ module SmsFailureRecordable
     rescue_from(Notifications::Client::BadRequestError) do
       if (appointment = arguments[0])
         SmsFailureActivity.from(appointment)
+
+        SmsFailureNotificationsJob.perform_later(appointment)
       end
     end
   end

--- a/app/jobs/sms_appointment_confirmation_job.rb
+++ b/app/jobs/sms_appointment_confirmation_job.rb
@@ -3,6 +3,8 @@ class SmsAppointmentConfirmationJob < NotifyJobBase
   DUE_DILIGENCE_TEMPLATE_ID = '58ef6845-25eb-4197-9cff-26457515d831'.freeze
   PENSION_WISE_TEMPLATE_ID = 'd9136496-a2f1-4262-86a6-d651c07dca87'.freeze
 
+  include SmsFailureRecordable
+
   def perform(appointment)
     return unless api_key(appointment.schedule_type)
 

--- a/app/jobs/sms_appointment_reminder_job.rb
+++ b/app/jobs/sms_appointment_reminder_job.rb
@@ -3,6 +3,8 @@ class SmsAppointmentReminderJob < NotifyJobBase
   BSL_TEMPLATE_ID      = '6bedd37b-c75c-44f5-bed3-3ec5eb5bb564'.freeze
   DUE_DILIGENCE_TEMPLATE_ID = 'c3157b23-c727-495e-b366-268536f848cc'.freeze
 
+  include SmsFailureRecordable
+
   def perform(appointment)
     return unless api_key(appointment.schedule_type)
 
@@ -11,7 +13,7 @@ class SmsAppointmentReminderJob < NotifyJobBase
 
   private
 
-  def send_sms_reminder(appointment) # rubocop:disable Metrics/MethodLength
+  def send_sms_reminder(appointment)
     client = Notifications::Client.new(api_key(appointment.schedule_type))
 
     client.send_sms(
@@ -22,10 +24,6 @@ class SmsAppointmentReminderJob < NotifyJobBase
         date: "#{appointment.start_at.to_s(:govuk_date_short)} (#{appointment.timezone})"
       }
     )
-  rescue Notifications::Client::BadRequestError
-    SmsFailureActivity.from(appointment)
-
-    false
   end
 
   def template_for(appointment)

--- a/app/jobs/sms_appointment_reminder_job.rb
+++ b/app/jobs/sms_appointment_reminder_job.rb
@@ -23,7 +23,7 @@ class SmsAppointmentReminderJob < NotifyJobBase
       }
     )
   rescue Notifications::Client::BadRequestError
-    SmsReminderFailureActivity.from(appointment)
+    SmsFailureActivity.from(appointment)
 
     false
   end

--- a/app/jobs/sms_cancellation_success_job.rb
+++ b/app/jobs/sms_cancellation_success_job.rb
@@ -3,6 +3,8 @@ class SmsCancellationSuccessJob < NotifyJobBase
   BSL_TEMPLATE_ID      = '43fb57ed-1abe-4115-81ca-10f5042e23ca'.freeze
   DUE_DILIGENCE_TEMPLATE_ID = 'cc05fe66-aeda-4153-9973-62a290f59e4b'.freeze
 
+  include SmsFailureRecordable
+
   def perform(appointment)
     return unless api_key(appointment.schedule_type)
 

--- a/app/jobs/sms_failure_notifications_job.rb
+++ b/app/jobs/sms_failure_notifications_job.rb
@@ -1,0 +1,9 @@
+class SmsFailureNotificationsJob < ApplicationJob
+  queue_as :default
+
+  def perform(appointment)
+    recipients_for(appointment).each do |recipient|
+      AppointmentMailer.resource_manager_sms_failure(appointment, recipient).deliver_later
+    end
+  end
+end

--- a/app/mailers/appointment_mailer.rb
+++ b/app/mailers/appointment_mailer.rb
@@ -11,6 +11,12 @@ class AppointmentMailer < ApplicationMailer
     mail to: appointment.guider.email, subject: @appointment.subject('No Summary Document Generated')
   end
 
+  def resource_manager_sms_failure(appointment, recipient)
+    mailgun_headers('resource_manager_sms_failure', appointment.id)
+    @appointment = decorate(appointment)
+    mail to: recipient, subject: @appointment.subject('SMS Failure')
+  end
+
   def resource_manager_email_dropped(appointment, recipient)
     mailgun_headers('resource_manager_email_dropped', appointment.id)
     @appointment = decorate(appointment)

--- a/app/models/sms_failure_activity.rb
+++ b/app/models/sms_failure_activity.rb
@@ -1,9 +1,9 @@
-class SmsReminderFailureActivity < Activity
+class SmsFailureActivity < Activity
   def self.from(appointment)
     create!(
       owner: appointment.guider,
       appointment:,
-      message: "could not deliver an SMS reminder to '#{appointment.canonical_sms_number}'. " \
+      message: "could not deliver an SMS to '#{appointment.canonical_sms_number}'. " \
         'The number is incorrect or invalid.'
     )
   end

--- a/app/views/activities/_sms_failure_activity.html.erb
+++ b/app/views/activities/_sms_failure_activity.html.erb
@@ -1,0 +1,5 @@
+<% content_for(:activity_message, flush: true) do %>
+  <span class="glyphicon glyphicon-phone" aria-hidden="true"></span>
+  <strong>The system</strong> <%= sms_failure_activity.message %>
+<% end %>
+<%= render 'activities/activity', activity: sms_failure_activity, details: details, hide: hide %>

--- a/app/views/activities/_sms_reminder_failure_activity.html.erb
+++ b/app/views/activities/_sms_reminder_failure_activity.html.erb
@@ -1,5 +1,0 @@
-<% content_for(:activity_message, flush: true) do %>
-  <span class="glyphicon glyphicon-phone" aria-hidden="true"></span>
-  <strong>The system</strong> <%= sms_reminder_failure_activity.message %>
-<% end %>
-<%= render 'activities/activity', activity: sms_reminder_failure_activity, details: details, hide: hide %>

--- a/app/views/appointment_mailer/resource_manager_sms_failure.html.erb
+++ b/app/views/appointment_mailer/resource_manager_sms_failure.html.erb
@@ -1,0 +1,15 @@
+<h1 style="color: #0F19A0 !important;font-family: Calibri, Arial, sans-serif;margin: 15px 0;font-weight: 700;font-size: 20px;line-height: 1.111111111;padding: 15px 0;">
+  An SMS to <%= @appointment.canonical_sms_number %> failed to deliver.
+</h1>
+
+<%= p do %>
+  Reference number:
+  <br>
+  <strong class="emphasize">
+    <%= @appointment.id %>
+  </strong>
+<% end %>
+
+<%= p do %>
+  <%= link_to 'View the appointment', edit_appointment_url(@appointment) %>
+<% end %>

--- a/app/views/appointment_mailer/resource_manager_sms_failure.text.erb
+++ b/app/views/appointment_mailer/resource_manager_sms_failure.text.erb
@@ -1,0 +1,6 @@
+The SMS to <%= @appointment.canonical_sms_number %> failed to deliver.
+
+Reference number:
+<%= @appointment.id %>
+
+<%= edit_appointment_url(@appointment) %>

--- a/db/migrate/20250202131803_rename_sms_reminder_failure_activities.rb
+++ b/db/migrate/20250202131803_rename_sms_reminder_failure_activities.rb
@@ -1,0 +1,9 @@
+class RenameSmsReminderFailureActivities < ActiveRecord::Migration[6.1]
+  def up
+    Activity.where(type: 'SmsReminderFailureActivity').update_all(type: 'SmsFailureActivity')
+  end
+
+  def down
+    Activity.where(type: 'SmsFailureActivity').update_all(type: 'SmsReminderFailureActivity')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_01_24_115245) do
+ActiveRecord::Schema.define(version: 2025_02_02_131803) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"

--- a/spec/jobs/sms_appointment_reminder_job_spec.rb
+++ b/spec/jobs/sms_appointment_reminder_job_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe SmsAppointmentReminderJob, '#perform' do
         allow(client).to receive(:send_sms)
           .and_raise(Notifications::Client::BadRequestError.new(double(code: 400, body: 'meh')))
 
-        described_class.new.perform(appointment)
+        described_class.perform_now(appointment)
 
         expect(appointment.activities.find_by(type: 'SmsFailureActivity')).to be
         expect(appointment.activities.find_by(type: 'SmsReminderActivity')).to be_nil

--- a/spec/jobs/sms_appointment_reminder_job_spec.rb
+++ b/spec/jobs/sms_appointment_reminder_job_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe SmsAppointmentReminderJob, '#perform' do
 
         described_class.new.perform(appointment)
 
-        expect(appointment.activities.find_by(type: 'SmsReminderFailureActivity')).to be
+        expect(appointment.activities.find_by(type: 'SmsFailureActivity')).to be
         expect(appointment.activities.find_by(type: 'SmsReminderActivity')).to be_nil
       end
     end

--- a/spec/jobs/sms_failure_notifications_job_spec.rb
+++ b/spec/jobs/sms_failure_notifications_job_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe SmsFailureNotificationsJob, '#perform' do
+  context 'for a regular appointment' do
+    it 'sends notifications to the associated resource managers' do
+      resource_manager = 'dave@example.com'
+      appointment = double(:appointment).as_null_object
+      allow(appointment).to receive_message_chain(:resource_managers, :pluck).and_return([resource_manager])
+
+      expect(AppointmentMailer).to receive(:resource_manager_sms_failure)
+        .with(appointment, 'supervisors@maps.org.uk')
+        .and_return(double(deliver_later: true))
+
+      subject.perform(appointment)
+    end
+  end
+end

--- a/spec/mailers/appointment_mailer_spec.rb
+++ b/spec/mailers/appointment_mailer_spec.rb
@@ -112,6 +112,31 @@ RSpec.describe AppointmentMailer, type: :mailer do
     end
   end
 
+  describe 'Resource Manager SMS Failure' do
+    let(:mailgun_headers) { JSON.parse(subject['X-Mailgun-Variables'].value) }
+    let(:appointment) { build_stubbed(:appointment) }
+    let(:body) { subject.body.encoded }
+
+    subject { described_class.resource_manager_sms_failure(appointment, 'dave@example.com') }
+
+    it 'renders the headers' do
+      expect(subject.to).to eq(['dave@example.com'])
+      expect(subject.subject).to eq('Pension Wise SMS Failure')
+    end
+
+    it 'renders the mailgun specific headers' do
+      expect(mailgun_headers).to include(
+        'message_type'   => 'resource_manager_sms_failure',
+        'appointment_id' => appointment.id
+      )
+    end
+
+    it 'includes the body specifics' do
+      expect(body).to include(appointment.canonical_sms_number)
+      expect(body).to match(%q(http://localhost:3001/appointments/\d+/edit))
+    end
+  end
+
   describe 'Resource Manager Email Failure' do
     let(:mailgun_headers) { JSON.parse(subject['X-Mailgun-Variables'].value) }
     let(:appointment) { build_stubbed(:appointment) }

--- a/spec/mailers/previews/appointment_mailer_preview.rb
+++ b/spec/mailers/previews/appointment_mailer_preview.rb
@@ -1,5 +1,14 @@
 # Preview all emails at http://localhost:3000/rails/mailers/appointment_mailer
 class AppointmentMailerPreview < ActionMailer::Preview
+  def resource_manager_sms_failure
+    appointment = random_appointment
+
+    AppointmentMailer.resource_manager_sms_failure(
+      appointment,
+      appointment.resource_managers.first.email
+    )
+  end
+
   def guider_summary_document_missing
     appointment = random_appointment
 


### PR DESCRIPTION
These jobs will also track SMS delivery failures and record an activity 
against the appointment in question. These failures will also be notifed to
owning resource managers via email.