### PR TITLE
Bookings can specify PWD appointment attended

### DIFF
--- a/app/controllers/api/v1/appointments_controller.rb
+++ b/app/controllers/api/v1/appointments_controller.rb
@@ -48,7 +48,8 @@ module Api
           :lloyds_signposted,
           :referrer,
           :nudged,
-          :rebooked_from_id
+          :rebooked_from_id,
+          :attended_digital
         ).merge(
           agent: current_user,
           schedule_type:

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -239,6 +239,7 @@ class AppointmentsController < ApplicationController
       internal_availability
       welsh
       cancelled_via
+      attended_digital
     ]
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/forms/api/v1/appointment.rb
+++ b/app/forms/api/v1/appointment.rb
@@ -6,7 +6,7 @@ module Api
       attr_accessor :start_at, :first_name, :last_name, :email, :phone, :memorable_word, :date_of_birth,
                     :dc_pot_confirmed, :where_you_heard, :gdpr_consent, :accessibility_requirements,
                     :notes, :agent, :smarter_signposted, :lloyds_signposted, :schedule_type, :referrer,
-                    :rebooked_from_id
+                    :rebooked_from_id, :attended_digital
 
       attr_reader :model
 
@@ -57,7 +57,8 @@ module Api
           schedule_type:,
           referrer: referrer.to_s,
           nudged:,
-          rebooked_from_id:
+          rebooked_from_id:,
+          attended_digital:
         }
       end
     end

--- a/app/helpers/appointment_helper.rb
+++ b/app/helpers/appointment_helper.rb
@@ -40,7 +40,11 @@ module AppointmentHelper
   end
 
   def boolean_yes_no(value)
-    value ? 'Yes' : 'No'
+    case value
+    when true then 'Yes'
+    when false then 'No'
+    else 'Not sure'
+    end
   end
 
   def display_nudge_eligibility?(appointment)

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -15,7 +15,9 @@ class Appointment < ApplicationRecord
     CLIENT_RESCHEDULED = 'client_rescheduled'.freeze,
     OFFICE_RESCHEDULED = 'office_rescheduled'.freeze
   ].freeze
-  RESCHEDULING_ROUTES  = %w[phone email_or_crm].freeze
+  RESCHEDULING_ROUTES = %w[phone email_or_crm].freeze
+
+  ATTENDED_DIGITAL_OPTIONS = %w[yes no not-sure].freeze
 
   CANCELLED_STATUSES = %i[
     cancelled_by_customer
@@ -55,6 +57,7 @@ class Appointment < ApplicationRecord
     rescheduling_reason
     rescheduling_route
     cancelled_via
+    attended_digital
   ].freeze
 
   enum status: { pending: 0, complete: 1, no_show: 2, incomplete: 3, ineligible_age: 4,
@@ -167,6 +170,7 @@ class Appointment < ApplicationRecord
   validates :referrer, presence: true, if: :due_diligence?, on: :create
   validates :email, email: true, unless: :sms_confirmation?
   validates :cancelled_via, inclusion: %w[phone email], on: :update, if: :cancelled_prior_to_appointment?
+  validates :attended_digital, inclusion: ATTENDED_DIGITAL_OPTIONS, allow_blank: true, if: :pension_wise?
 
   validate :not_within_grace_period, unless: :agent_is_resource_manager?
   validate :valid_within_booking_window

--- a/app/views/appointments/_personal_details_form.html.erb
+++ b/app/views/appointments/_personal_details_form.html.erb
@@ -50,6 +50,14 @@
       <%= f.radio_button :gdpr_consent, '', label: 'No response', class: 't-gdpr-consent-no-response', disabled: true %>
       <% end %>
     </div>
+
+    <div class="form-group">
+      <p><strong>Have you completed an online Pension Wise appointment?</strong></p>
+      <span class="help-block text-left">This helps us understand how Pension Wise is used.</span>
+      <%= f.radio_button :attended_digital, 'yes', label: 'Yes', class: 't-attended-digital-yes' %>
+      <%= f.radio_button :attended_digital, 'no', label: 'No', class: 't-attended-digital-no' %>
+      <%= f.radio_button :attended_digital, 'not-sure', label: 'Not sure', class: 't-attended-digital-not-sure' %>
+    </div>
     <% end %>
   </div>
 

--- a/app/views/appointments/preview.html.erb
+++ b/app/views/appointments/preview.html.erb
@@ -49,6 +49,7 @@
   <%= f.hidden_field :referrer %>
   <%= f.hidden_field :small_pots %>
   <%= f.hidden_field :nudged %>
+  <%= f.hidden_field :attended_digital %>
 
   <%= f.hidden_field :data_subject_name %>
   <%= f.hidden_field :data_subject_date_of_birth %>
@@ -184,6 +185,10 @@
               <tr>
                 <td class="active"><b>Customer research consent</b></td>
                 <td><%= @appointment.customer_research_consent %></td>
+              </tr>
+              <tr>
+                <td class="active"><b>Completed an online Pension Wise appointment?</b></td>
+                <td><%= @appointment.attended_digital.to_s.humanize %></td>
               </tr>
               <tr>
                 <td class="active"><b>Type of appointment</b></td>

--- a/db/migrate/20250120124209_add_attended_digital_to_appointments.rb
+++ b/db/migrate/20250120124209_add_attended_digital_to_appointments.rb
@@ -1,5 +1,5 @@
 class AddAttendedDigitalToAppointments < ActiveRecord::Migration[6.1]
   def change
-    add_column :appointments, :attended_digital, :boolean
+    add_column :appointments, :attended_digital, :string
   end
 end

--- a/db/migrate/20250120124209_add_attended_digital_to_appointments.rb
+++ b/db/migrate/20250120124209_add_attended_digital_to_appointments.rb
@@ -1,0 +1,5 @@
+class AddAttendedDigitalToAppointments < ActiveRecord::Migration[6.1]
+  def change
+    add_column :appointments, :attended_digital, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -125,7 +125,7 @@ ActiveRecord::Schema.define(version: 2025_01_24_115245) do
     t.string "cancelled_via", default: "", null: false
     t.string "rescheduling_route", default: "", null: false
     t.string "other_reason", default: "", null: false
-    t.boolean "attended_digital"
+    t.string "attended_digital"
     t.index "guider_id, tsrange(start_at, end_at)", name: "index_appointments_guider_id_tsrange_start_at_end_at", using: :gist
     t.index "tsrange(start_at, end_at)", name: "index_appointments_tsrange_start_at_end_at", using: :gist
     t.index ["guider_id", "start_at"], name: "index_appointments_guider_start_schedule_status", where: "(((schedule_type)::text = 'pension_wise'::text) AND (status <> ALL ('{6,7,8,9}'::integer[])))"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -125,6 +125,7 @@ ActiveRecord::Schema.define(version: 2025_01_24_115245) do
     t.string "cancelled_via", default: "", null: false
     t.string "rescheduling_route", default: "", null: false
     t.string "other_reason", default: "", null: false
+    t.boolean "attended_digital"
     t.index "guider_id, tsrange(start_at, end_at)", name: "index_appointments_guider_id_tsrange_start_at_end_at", using: :gist
     t.index "tsrange(start_at, end_at)", name: "index_appointments_tsrange_start_at_end_at", using: :gist
     t.index ["guider_id", "start_at"], name: "index_appointments_guider_start_schedule_status", where: "(((schedule_type)::text = 'pension_wise'::text) AND (status <> ALL ('{6,7,8,9}'::integer[])))"

--- a/spec/features/agent_manages_appointments_spec.rb
+++ b/spec/features/agent_manages_appointments_spec.rb
@@ -225,10 +225,14 @@ RSpec.feature 'Agent manages appointments' do
     given_the_user_is_an_agent(organisation: :tpas) do
       and_there_is_a_guider_with_available_slots
       when_they_want_to_book_an_appointment
-      and_they_fill_in_their_appointment_details(smarter_signposted: true, bsl_video: true)
-      then_they_see_a_preview_of_the_appointment(smarter_signposted: true)
+      and_they_fill_in_their_appointment_details(
+        smarter_signposted: true,
+        bsl_video: true,
+        attended_digital: true
+      )
+      then_they_see_a_preview_of_the_appointment(smarter_signposted: true, attended_digital: true)
       when_they_accept_the_appointment_preview
-      then_that_appointment_is_created(smarter_signposted: true)
+      then_that_appointment_is_created(smarter_signposted: true, attended_digital: true)
     end
   end
 
@@ -531,6 +535,7 @@ RSpec.feature 'Agent manages appointments' do
     @page.smarter_signposted.set(options[:smarter_signposted]) if options[:smarter_signposted]
     @page.small_pots.set(options[:small_pots]) if options[:small_pots]
     @page.stronger_nudged.set(options[:stronger_nudge]) if options[:stronger_nudge]
+    @page.attended_digital_yes.set(true) if options[:attended_digital]
 
     expect(@page).to have_no_bsl_video if options[:bsl_video]
 
@@ -563,6 +568,7 @@ RSpec.feature 'Agent manages appointments' do
     expect(@page.preview).to have_content 'Small pots appointment? Yes' if options[:small_pots]
     expect(@page.preview).to have_content 'Stronger Nudge appointment? Yes' if options[:stronger_nudge]
     expect(@page.preview).to have_content 'Welsh language appointment? Yes' if options[:welsh]
+    expect(@page.preview).to have_content 'online Pension Wise appointment? Yes' if options[:attended_digital]
   end
 
   def and_they_fill_in_their_appointment_details_without_an_email
@@ -600,6 +606,7 @@ RSpec.feature 'Agent manages appointments' do
     expect(appointment).to be_small_pots if options[:small_pots]
     expect(appointment).to be_nudged if options[:stronger_nudge]
     expect(appointment).to be_welsh if options[:welsh]
+    expect(appointment).to be_attended_digital if options[:attended_digital]
   end
 
   def and_the_customer_gets_an_email_confirmation

--- a/spec/features/booking_due_diligence_appointments_spec.rb
+++ b/spec/features/booking_due_diligence_appointments_spec.rb
@@ -151,6 +151,9 @@ RSpec.feature 'Booking due diligence appointments', js: true do
     expect(@page).to have_no_gdpr_consent_no
     expect(@page).to have_no_gdpr_consent_no_response
     expect(@page).to have_no_small_pots
+    expect(@page).to have_no_attended_digital_yes
+    expect(@page).to have_no_attended_digital_no
+    expect(@page).to have_no_attended_digital_not_sure
     expect(@page).to have_text('Postal address')
     expect(@page).to_not have_text('Confirmation address')
 

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -473,6 +473,18 @@ RSpec.describe Appointment, type: :model do
       build_stubbed(:appointment)
     end
 
+    describe '#attended_digital' do
+      it 'permits any of the valid values' do
+        subject.attended_digital = 'meh'
+        expect(subject).to be_invalid
+
+        Appointment::ATTENDED_DIGITAL_OPTIONS.each do |option|
+          subject.attended_digital = option
+          expect(subject).to be_valid
+        end
+      end
+    end
+
     describe '#notes' do
       it 'has a maxlength of 1000 characters' do
         subject.notes = 'a' * 1001

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path('../../config/environment', __FILE__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
+require 'rspec/retry'
 require 'webmock/rspec'
 require 'capybara/rails'
 require 'capybara/rspec'
@@ -21,6 +22,9 @@ ActiveRecord::Migration.maintain_test_schema!
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
+  config.verbose_retry = true
+  config.display_try_failure_messages = true
+
   config.use_transactional_fixtures = false
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!

--- a/spec/requests/appointments_api_spec.rb
+++ b/spec/requests/appointments_api_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe 'POST /api/v1/appointments' do
       'notes' => 'I am hard of hearing',
       'lloyds_signposted' => true,
       'rebooked_from_id'  => '1234567',
-      'attended_digital'  => true
+      'attended_digital'  => 'yes'
     }
 
     post api_v1_appointments_path, params: @payload, as: :json
@@ -337,7 +337,7 @@ RSpec.describe 'POST /api/v1/appointments' do
         pension_provider: 'n/a',
         lloyds_signposted: true,
         rebooked_from_id: 1_234_567,
-        attended_digital: true
+        attended_digital: 'yes'
       )
 
       # defaults to pension wise when the schedule type is unspecified

--- a/spec/requests/appointments_api_spec.rb
+++ b/spec/requests/appointments_api_spec.rb
@@ -183,7 +183,8 @@ RSpec.describe 'POST /api/v1/appointments' do
   def and_the_due_diligence_appointment_is_created
     expect(Appointment.last).to have_attributes(
       schedule_type: 'due_diligence',
-      country_code: 'FR'
+      country_code: 'FR',
+      attended_digital: nil
     )
   end
 
@@ -248,7 +249,8 @@ RSpec.describe 'POST /api/v1/appointments' do
       'accessibility_requirements' => true,
       'notes' => 'I am hard of hearing',
       'lloyds_signposted' => true,
-      'rebooked_from_id'  => '1234567'
+      'rebooked_from_id'  => '1234567',
+      'attended_digital'  => true
     }
 
     post api_v1_appointments_path, params: @payload, as: :json
@@ -298,7 +300,10 @@ RSpec.describe 'POST /api/v1/appointments' do
   end
 
   def and_the_appointment_is_created_as_a_nudged_appointment
-    expect(Appointment.last).to be_nudged
+    expect(Appointment.last).to have_attributes(
+      nudged: true,
+      attended_digital: nil
+    )
   end
 
   def and_the_appointment_is_created_as_a_smarter_signposted_appointment
@@ -331,7 +336,8 @@ RSpec.describe 'POST /api/v1/appointments' do
         notes: 'I am hard of hearing',
         pension_provider: 'n/a',
         lloyds_signposted: true,
-        rebooked_from_id: 1_234_567
+        rebooked_from_id: 1_234_567,
+        attended_digital: true
       )
 
       # defaults to pension wise when the schedule type is unspecified

--- a/spec/support/pages/new_appointment.rb
+++ b/spec/support/pages/new_appointment.rb
@@ -47,6 +47,9 @@ module Pages
     element :internal_availability, '.t-internal-availability'
     element :small_pots, '.t-small-pots'
     element :stronger_nudged, '.t-nudge-flag'
+    element :attended_digital_yes, '.t-attended-digital-yes'
+    element :attended_digital_no, '.t-attended-digital-no'
+    element :attended_digital_not_sure, '.t-attended-digital-not-sure'
 
     element :availability_calendar_off, '.t-availability-calendar-off'
     element :availability_calendar_on, '.t-availability-calendar-on'


### PR DESCRIPTION
Similar to the API change, regular phone appointments will display an 
option for the customer to specify whether they have previously completed a
PWD appointment.