### PR TITLE
Add cut-off for eligibility reasons pre 10/02/25

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -593,6 +593,7 @@ class Appointment < ApplicationRecord
   def require_eligibility_reason?
     return unless pension_wise?
     return if age_at_appointment.zero?
+    return if created_at && created_at < Time.zone.parse('2025-02-10 00:00')
 
     age_at_appointment < 50
   end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -921,12 +921,25 @@ RSpec.describe Appointment, type: :model do
     end
 
     context 'when the customer is under 50' do
-      it 'requires the eligibility reason' do
-        subject.date_of_birth = '1980-01-01'
-        expect(subject).to be_invalid
+      context 'when the appointment was created before the cut-off' do
+        it 'does not require the eligibility reason' do
+          subject.date_of_birth = '1980-01-01'
+          subject.nudge_eligibility_reason = ''
+          subject.created_at = '2024-01-01 00:00'
 
-        subject.nudge_eligibility_reason = 'ill_health'
-        expect(subject).to be_valid
+          expect(subject).to be_valid
+        end
+      end
+
+      context 'when the appointment was created after the cut-off' do
+        it 'requires the eligibility reason' do
+          subject.created_at = '2025-02-28 00:00'
+          subject.date_of_birth = '1980-01-01'
+          expect(subject).to be_invalid
+
+          subject.nudge_eligibility_reason = 'ill_health'
+          expect(subject).to be_valid
+        end
       end
 
       context 'when the appointment is not Pension Wise' do


### PR DESCRIPTION
This was affecting some older appointments created prior to the
introduction of this particular validation.