### PR TITLE
Alterations to assert on page output

### DIFF
--- a/spec/features/booking_due_diligence_appointments_spec.rb
+++ b/spec/features/booking_due_diligence_appointments_spec.rb
@@ -131,9 +131,12 @@ RSpec.feature 'Booking due diligence appointments', js: true do
   end
 
   def then_the_due_diligence_appointment_is_booked
-    @appointment = Appointment.last
-    expect(@appointment).to be_due_diligence
-    expect(@appointment.country_code).to eq('FR')
+    @page = Pages::EditAppointment.new
+    expect(@page).to be_displayed
+    expect(@page).to have_flash_of_success
+
+    expect(@page).to have_due_diligence_banner
+    expect(@page.country_code.value).to have_text('FR')
   end
 
   def and_they_accept_the_appointment_preview

--- a/spec/features/booking_due_diligence_appointments_spec.rb
+++ b/spec/features/booking_due_diligence_appointments_spec.rb
@@ -101,9 +101,9 @@ RSpec.feature 'Booking due diligence appointments', js: true do
   end
 
   def then_the_new_appointment_is_created
-    @rebooked_appointment = Appointment.last
-
-    expect(@rebooked_appointment.rebooked_from).to eq(@appointment)
+    @page = Pages::Search.new
+    expect(@page).to be_displayed
+    expect(@page).to have_flash_of_success
   end
 
   def and_an_due_diligence_appointment_exists

--- a/spec/features/booking_due_diligence_appointments_spec.rb
+++ b/spec/features/booking_due_diligence_appointments_spec.rb
@@ -124,7 +124,10 @@ RSpec.feature 'Booking due diligence appointments', js: true do
   end
 
   def then_the_original_appointment_is_rescheduled
-    expect(@appointment.reload.start_at).to eq(Time.zone.parse('2021-04-08 14:30'))
+    @page = Pages::EditAppointment.new
+    expect(@page).to be_displayed
+    expect(@page).to have_flash_of_success
+    expect(@page.date_time).to have_text('8 Apr 2021, 2:30pm - 3:30pm')
   end
 
   def then_the_due_diligence_appointment_is_booked

--- a/spec/features/guider_edits_an_appointment_spec.rb
+++ b/spec/features/guider_edits_an_appointment_spec.rb
@@ -157,10 +157,12 @@ RSpec.feature 'Guider edits an appointment' do
   end
 
   def then_the_appointment_is_changed
-    expect(@appointment.reload).to have_attributes(
-      first_name: 'Rick',
-      nudge_eligibility_reason: 'ill_health'
-    )
+    @page = Pages::EditAppointment.new
+    expect(@page).to be_displayed
+    expect(@page).to have_flash_of_success
+
+    expect(@page.first_name.value).to eq('Rick')
+    expect(@page).to have_text 'eligible due to Ill health'
   end
 
   def and_the_customer_is_notified

--- a/spec/features/resource_manager_manages_holidays_spec.rb
+++ b/spec/features/resource_manager_manages_holidays_spec.rb
@@ -397,7 +397,10 @@ RSpec.feature 'Resource manager manages holidays' do
   end
 
   def then_it_is_deleted
-    expect(Holiday.where.not(user: @guiders.last)).to be_empty
+    @page = Pages::Holidays.new
+    expect(@page).to be_displayed
+    expect(@page).to have_flash_of_success
+    expect(@page).to have_no_events
   end
 
   def expect_holidays_to_match(expected_holidays)

--- a/spec/features/resource_manager_modifies_appointments_spec.rb
+++ b/spec/features/resource_manager_modifies_appointments_spec.rb
@@ -256,6 +256,7 @@ RSpec.feature 'Resource manager modifies appointments' do
   def when_they_reschedule_an_appointment
     @page.reschedule(@page.appointments.first, hours: 13, minutes: 30)
 
+    wait_for_ajax_to_complete
     @page.wait_until_rescheduling_reason_modal_visible
     @page.rescheduling_reason_modal.pension_wise.set(true)
     expect(@page.rescheduling_reason_modal).to have_no_via_phone

--- a/spec/features/resource_manager_sorts_guiders_spec.rb
+++ b/spec/features/resource_manager_sorts_guiders_spec.rb
@@ -30,7 +30,10 @@ RSpec.feature 'Resource manager sorts guiders' do
   end
 
   def then_the_guiders_are_in_the_new_order
-    expect(@page.guiders.map(&:text)).to eq @guiders.reverse.map(&:name)
+    @page = Pages::SortGuiders.new
+    expect(@page).to be_displayed
+    expect(@page).to have_flash_of_success
+    expect(@page.guiders.map(&:text)).to eq %w[C B A]
   end
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -7,6 +7,7 @@ module Pages
     element :dc_pot_unsure_banner,                  '.t-dc-pot-unsure'
     element :appointment_was_imported_message,      '.t-appointment-was-imported-message'
     element :third_party_booked_banner,             '.t-third-party-booked'
+    element :due_diligence_banner,                  '.t-due-diligence-banner'
     element :guider,                                '.t-guider'
     element :date_time,                             '.t-appointment-date-time'
     element :date_of_birth_day,                     '.t-date-of-birth-day'
@@ -26,6 +27,7 @@ module Pages
     element :gdpr_consent_no_response,              '.t-gdpr-consent-no-response'
     element :cancelled_via_phone,                   '.t-cancelled-via-phone'
     element :cancelled_via_email,                   '.t-cancelled-via-email'
+    element :country_code,                          '.t-country-of-residence'
 
     element :status, '.t-status'
     element :secondary_status, '.t-secondary-status'

--- a/spec/support/pages/holidays.rb
+++ b/spec/support/pages/holidays.rb
@@ -2,6 +2,7 @@ module Pages
   class Holidays < Base
     set_url '/holidays'
 
+    element :flash_of_success, '.alert-success'
     element :next_week, '.fc-next-button'
     element :create_holiday, '.t-create-holiday'
     elements :delete_holidays, '.t-delete-holiday'

--- a/spec/support/pages/search.rb
+++ b/spec/support/pages/search.rb
@@ -2,6 +2,7 @@ module Pages
   class Search < Base
     set_url '/appointments/search'
 
+    element :flash_of_success, '.alert-success'
     element :q,          '.t-q'
     element :date_range, '.t-date-range'
     element :processed_no, '.t-processed-no'

--- a/spec/support/pages/sort_guiders.rb
+++ b/spec/support/pages/sort_guiders.rb
@@ -3,6 +3,7 @@ module Pages
     set_url '/users/sort'
 
     element :save, '.t-save'
+    element :flash_of_success, '.alert-success'
 
     elements :guiders, '.t-guider'
 


### PR DESCRIPTION
In many places we assert on model data instead of observable page elements.
This causes some subtle timing issues and should be avoided for simplicity.