### PR TITLE
Send reminders when appointments remain pending

### DIFF
--- a/app/jobs/appointment_status_reminder_job.rb
+++ b/app/jobs/appointment_status_reminder_job.rb
@@ -1,0 +1,13 @@
+class AppointmentStatusReminderJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Appointment.needing_status_reminder.each do |appointment|
+      AppointmentMailer.guider_status_reminder(appointment).deliver_later
+
+      appointment.without_auditing do
+        appointment.update_attribute(:status_reminder_sent, true) # rubocop:disable Rails/SkipsModelValidations
+      end
+    end
+  end
+end

--- a/app/mailers/appointment_mailer.rb
+++ b/app/mailers/appointment_mailer.rb
@@ -5,6 +5,12 @@ class AppointmentMailer < ApplicationMailer
 
   default subject: -> { @appointment.subject }, from: -> { @appointment.from }
 
+  def guider_status_reminder(appointment)
+    mailgun_headers('guider_status_reminder', appointment.id)
+    @appointment = decorate(appointment)
+    mail to: appointment.guider.email, subject: @appointment.subject('Appointment status not updated')
+  end
+
   def guider_summary_document_missing(appointment)
     mailgun_headers('guider_summary_document_missing', appointment.id)
     @appointment = decorate(appointment)

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -496,6 +496,13 @@ class Appointment < ApplicationRecord
     end
   end
 
+  def self.needing_status_reminder
+    pending
+      .for_pension_wise
+      .where("start_at < NOW() - INTERVAL '1 days' and start_at > NOW() - INTERVAL '14 days'")
+      .where(status_reminder_sent: nil)
+  end
+
   def self.needing_sms_reminder
     pending
       .not_booked_today

--- a/app/views/appointment_mailer/guider_status_reminder.html.erb
+++ b/app/views/appointment_mailer/guider_status_reminder.html.erb
@@ -1,0 +1,23 @@
+<h1 style="color: #0F19A0 !important;font-family: Calibri, Arial, sans-serif;margin: 15px 0;font-weight: 700;font-size: 20px;line-height: 1.111111111;padding: 15px 0;">
+  The status for this appointment has not been updated
+</h1>
+
+<%= p do %>
+  Reference number:
+  <br>
+  <strong class="emphasize">
+    <%= @appointment.id %>
+  </strong>
+<% end %>
+
+<%= p do %>
+  Date:
+  <br>
+  <strong class="emphasize">
+    <%= @appointment.start_at.to_date.to_s(:govuk_date) %>
+  </strong>
+<% end %>
+
+<%= p do %>
+  <%= link_to 'View the appointment', edit_appointment_url(@appointment) %>
+<% end %>

--- a/app/views/appointment_mailer/guider_status_reminder.text.erb
+++ b/app/views/appointment_mailer/guider_status_reminder.text.erb
@@ -1,0 +1,6 @@
+The status for this appointment has not been updated
+
+Reference number: <%= @appointment.id %>
+Date: <%= @appointment.start_at.to_date.to_s(:govuk_date) %>
+
+<%= edit_appointment_url(@appointment) %>

--- a/db/migrate/20250312153811_add_status_reminder_sent_to_appointments.rb
+++ b/db/migrate/20250312153811_add_status_reminder_sent_to_appointments.rb
@@ -1,0 +1,5 @@
+class AddStatusReminderSentToAppointments < ActiveRecord::Migration[6.1]
+  def change
+    add_column :appointments, :status_reminder_sent, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_02_27_135211) do
+ActiveRecord::Schema.define(version: 2025_03_12_153811) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -127,6 +127,7 @@ ActiveRecord::Schema.define(version: 2025_02_27_135211) do
     t.string "other_reason", default: "", null: false
     t.string "attended_digital"
     t.string "adjustments", default: "", null: false
+    t.boolean "status_reminder_sent"
     t.index "guider_id, tsrange(start_at, end_at)", name: "index_appointments_guider_id_tsrange_start_at_end_at", using: :gist
     t.index "tsrange(start_at, end_at)", name: "index_appointments_tsrange_start_at_end_at", using: :gist
     t.index ["guider_id", "start_at"], name: "index_appointments_guider_start_schedule_status", where: "(((schedule_type)::text = 'pension_wise'::text) AND (status <> ALL ('{6,7,8,9}'::integer[])))"

--- a/spec/jobs/appointment_status_reminder_job_spec.rb
+++ b/spec/jobs/appointment_status_reminder_job_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe AppointmentStatusReminderJob, '#perform' do
+  before do
+    allow(Appointment).to receive(:needing_status_reminder).and_return [appointment]
+    allow(AppointmentMailer).to receive(:guider_status_reminder).and_return(mailer_double)
+    allow(mailer_double).to receive(:deliver_later)
+  end
+
+  let(:mailer_double) { double(:mailer) }
+  let(:appointment) { create(:appointment) }
+
+  let(:subject) { described_class.perform_now }
+
+  it 'sends pending status reminder emails' do
+    subject
+
+    expect(AppointmentMailer).to have_received(:guider_status_reminder).with(appointment)
+    expect(mailer_double).to have_received(:deliver_later).once
+
+    expect(appointment.reload).to be_status_reminder_sent
+  end
+end

--- a/spec/mailers/appointment_mailer_spec.rb
+++ b/spec/mailers/appointment_mailer_spec.rb
@@ -112,6 +112,30 @@ RSpec.describe AppointmentMailer, type: :mailer do
     end
   end
 
+  describe 'Guider status reminder' do
+    let(:mailgun_headers) { JSON.parse(subject['X-Mailgun-Variables'].value) }
+    let(:appointment) { build_stubbed(:appointment) }
+    let(:body) { subject.body.encoded }
+
+    subject { described_class.guider_status_reminder(appointment) }
+
+    it 'renders the headers' do
+      expect(subject.to).to eq(['some-name@example.org'])
+      expect(subject.subject).to eq('Pension Wise Appointment status not updated')
+    end
+
+    it 'renders the mailgun specific headers' do
+      expect(mailgun_headers).to include(
+        'message_type'   => 'guider_status_reminder',
+        'appointment_id' => appointment.id
+      )
+    end
+
+    it 'includes the body specifics' do
+      expect(body).to match(/The status for this appointment has not been updated/)
+    end
+  end
+
   describe 'Resource Manager SMS Failure' do
     let(:mailgun_headers) { JSON.parse(subject['X-Mailgun-Variables'].value) }
     let(:appointment) { build_stubbed(:appointment) }

--- a/spec/mailers/previews/appointment_mailer_preview.rb
+++ b/spec/mailers/previews/appointment_mailer_preview.rb
@@ -9,6 +9,12 @@ class AppointmentMailerPreview < ActionMailer::Preview
     )
   end
 
+  def guider_status_reminder
+    appointment = random_appointment
+
+    AppointmentMailer.guider_status_reminder(appointment)
+  end
+
   def guider_summary_document_missing
     appointment = random_appointment
 

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -2,6 +2,21 @@ require 'rails_helper'
 
 # rubocop:disable Metrics/BlockLength
 RSpec.describe Appointment, type: :model do
+  describe '.needing_status_reminder' do
+    it 'returns appointments that are pending still at one day after the appointment' do
+      @included = create(:appointment, start_at: 2.days.ago)
+      @excluded = create(:appointment, start_at: 15.days.ago)
+      @other_exclusion   = create(:appointment, start_at: 2.hours.ago)
+      @another_exclusion = create(:appointment, start_at: 2.days.ago, status_reminder_sent: true)
+      @also_excluded     = create(:appointment, :due_diligence, start_at: 2.days.ago)
+
+      results = described_class.needing_status_reminder
+
+      expect(results.size).to eq(1)
+      expect(results).to include(@included)
+    end
+  end
+
   describe 'Booking an appointment within the schedule type window' do
     context 'when the appointment is PSG/DD' do
       it 'validates the end of the window correctly' do


### PR DESCRIPTION
Guiders will be reminded by email when the status remains pending after
24 hours since the appointment was delivered.