### PR TITLE
Find appointments with normalised numbers

### DIFF
--- a/app/forms/sms_cancellation.rb
+++ b/app/forms/sms_cancellation.rb
@@ -39,10 +39,6 @@ class SmsCancellation
   end
 
   def appointment
-    @appointment ||= Appointment.for_sms_cancellation(normalised_source_number, schedule_type:)
-  end
-
-  def normalised_source_number
-    source_number.sub(/\A44/, '0').delete(' ')
+    @appointment ||= Appointment.for_sms_cancellation(source_number, schedule_type:)
   end
 end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
+NORMALISED_NUMBERS = %w[+447715930455 447715930455 07715930455 00447715930455].freeze
+
 # rubocop:disable Metrics/BlockLength
 RSpec.describe Appointment, type: :model do
   describe '.needing_status_reminder' do
@@ -305,6 +307,16 @@ RSpec.describe Appointment, type: :model do
   end
 
   describe '.for_sms_cancellation' do
+    context 'normalises client numbers into the various forms' do
+      NORMALISED_NUMBERS.each do |normalised_number|
+        it "returns the right appointment when number is in the form '#{normalised_number}'" do
+          @appointment = create(:appointment, mobile: NORMALISED_NUMBERS.sample)
+
+          expect(described_class.for_sms_cancellation(normalised_number)).to eq(@appointment)
+        end
+      end
+    end
+
     context 'when two appointment exist with the same number' do
       it 'returns the appointment created first' do
         @first = create(:appointment, mobile: '07715930455', created_at: '2018-04-28 13:00')


### PR DESCRIPTION
There have been incidents where customers replied to their reminder SMS
messages with the 'cancel' keyword but received a cancellation failure
SMS in response. These are due to normalisation issues occurring between
us and Notify. For example, when a customer's number is stored as
'+447...' the `source_number` we receive back from Notify is `447...'
thus the appointment for cancellation cannot be found. This change will
attempt to find the number by many sensible variants instead.