### PR TITLE
Disable headless backgrounding stuff

### DIFF
--- a/spec/support/chrome.rb
+++ b/spec/support/chrome.rb
@@ -3,7 +3,15 @@ require 'selenium/webdriver'
 
 Capybara.register_driver :chrome_headless do |app|
   options = Selenium::WebDriver::Chrome::Options.new(
-    args: %w[headless no-sandbox disable-gpu window-size=1500,2500]
+    args: %w[
+      headless
+      no-sandbox
+      disable-gpu
+      disable-background-timer-throttling
+      disable-renderer-backgrounding
+      disable-backgrounding-occluded-windows
+      window-size=1500,2500
+    ]
   )
 
   Capybara::Selenium::Driver.new(app, browser: :chrome, options:)


### PR DESCRIPTION
This nerfs a bunch of timing issues caused by changes in the most recent
chromedriver on macos.