### PR TITLE
Ensure the reference number job re-runs

### DIFF
--- a/app/jobs/due_diligence_reference_number_job.rb
+++ b/app/jobs/due_diligence_reference_number_job.rb
@@ -1,6 +1,8 @@
 class DueDiligenceReferenceNumberJob < ApplicationJob
   queue_as :default
 
+  retry_on ActiveRecord::RecordInvalid, wait: 1.second, attempts: 3
+
   def perform(appointment)
     generated_reference = DueDiligenceReferenceNumber.new(appointment).call
 


### PR DESCRIPTION
This wasn't configured correctly and so wasn't ensuring that the
reference number in rare cases when it generates a clash was not being
persisted.