### PR TITLE
Pass `welsh` flag along to summary documents

### DIFF
--- a/app/lib/summary_document_link.rb
+++ b/app/lib/summary_document_link.rb
@@ -26,7 +26,8 @@ class SummaryDocumentLink
         country: 'United Kingdom',
         telephone_appointment: true,
         schedule_type: appointment.schedule_type,
-        unique_reference_number: appointment.unique_reference_number
+        unique_reference_number: appointment.unique_reference_number,
+        welsh: appointment.welsh?
       }.to_query(:appointment_summary)
     end
   end

--- a/spec/lib/summary_document_link_spec.rb
+++ b/spec/lib/summary_document_link_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe SummaryDocumentLink do
   subject { described_class.query(build(:appointment, :with_address)) }
 
+  it 'includes the Welsh language flag' do
+    expect(subject).to include('%5Bwelsh%5D=false')
+  end
+
   it 'includes the telephone appointment flag' do
     expect(subject).to include('%5Btelephone_appointment%5D=true')
   end


### PR DESCRIPTION
This will carry across and control whether the resultant summary
document is delivered in Welsh language variants.