### PR TITLE
Show scheduling banners for guiders

### DIFF
--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -42,6 +42,18 @@
   <% end %>
 </h4>
 
+<% if current_user.guider? %>
+  <% if @appointment.start_at.today? %>
+    <div class="alert alert-success t-today" role="alert">
+      <p>This appointment is <strong>scheduled for today</strong></p>
+    </div>
+  <% else %>
+    <div class="alert alert-danger t-not-today" role="alert">
+      <p>This appointment is <strong>not scheduled for today</strong></p>
+    </div>
+  <% end %>
+<% end %>
+
 <% if @appointment.potential_duplicates?(only_pending: false) %>
   <div class="alert alert-warning" role="alert">
     <p>The customer’s details <strong><%= link_to 'match other appointment records', appointment_duplicates_path(@appointment) %></strong></p>

--- a/app/views/my_appointments/show.html.erb
+++ b/app/views/my_appointments/show.html.erb
@@ -4,7 +4,7 @@
 <h1>My appointments</h1>
 
 <div
-  class="js-calendar-reload-on-events t-calendar"
+  class="js-calendar-reload-on-events t-calendar my-appointments-calendar"
   data-module="my-appointments-calendar"
   data-default-date="<%= Time.zone.now %>"
   data-guider-id="<%= current_user.id %>"

--- a/spec/features/guider_edits_an_appointment_spec.rb
+++ b/spec/features/guider_edits_an_appointment_spec.rb
@@ -2,6 +2,16 @@ require 'rails_helper'
 
 # rubocop:disable Metrics/BlockLength
 RSpec.feature 'Guider edits an appointment' do
+  scenario 'Guider views appointments and schedule banners' do
+    given_the_user_is_a_guider do
+      and_an_appointment_exists_for_today
+      when_they_edit_the_appointment
+      then_they_see_the_scheduled_today_banner
+      when_they_edit_an_existing_appointment
+      then_they_see_the_scheduled_later_banner
+    end
+  end
+
   scenario 'Guider attempts to reschedule a PSG appointment' do
     given_the_user_is_a_guider(organisation: :tpas) do
       and_an_existing_psg_appointment_exists
@@ -45,6 +55,24 @@ RSpec.feature 'Guider edits an appointment' do
       and_the_customer_is_notified
       and_they_see_a_success_message
     end
+  end
+
+  def and_an_appointment_exists_for_today
+    @appointment = create(:appointment, start_at: Time.current.middle_of_day)
+  end
+
+  def when_they_edit_the_appointment
+    @page = Pages::EditAppointment.new
+    @page.load(id: @appointment.id)
+    expect(@page).to be_displayed
+  end
+
+  def then_they_see_the_scheduled_today_banner
+    expect(@page).to have_scheduled_today_banner
+  end
+
+  def then_they_see_the_scheduled_later_banner
+    expect(@page).to have_scheduled_another_day_banner
   end
 
   def when_the_guider_attempts_to_reschedule_an_appointment_directly

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -46,6 +46,8 @@ module Pages
     element :data_subject_date_of_birth_year,       '.t-data-subject-date-of-birth-year'
 
     element :permissions_warning, '.t-permissions'
+    element :scheduled_today_banner, '.t-today'
+    element :scheduled_another_day_banner, '.t-not-today'
 
     section :activity_feed, '.t-activity-feed' do
       elements :activities, '.t-activity'


### PR DESCRIPTION
Some guiders get confused when viewing appointments and make calls that are scheduled for other days. Adding prominent banners to appointments when they're viewed by guiders - denoting whether the appointment is scheduled for today or other days will be helpful.