### PR TITLE
Ensure guiders are not duplicated

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -579,7 +579,7 @@ class Appointment < ApplicationRecord
     self.start_at = start_at
     self.online_rescheduling_reason = reason
     self.rescheduled_at = Time.zone.now
-    self.previous_guider = guider.dup
+    self.previous_guider_id = guider.id
     self.rescheduling_reason = CLIENT_RESCHEDULED
     self.rescheduling_route = RESCHEDULED_ONLINE
 

--- a/spec/requests/reschedulings_api_spec.rb
+++ b/spec/requests/reschedulings_api_spec.rb
@@ -50,8 +50,9 @@ RSpec.describe 'POST /api/v1/appointments/{id}/reschedule' do # rubocop:disable 
   end
 
   def and_a_pending_appointment_exists
-    @appointment   = create(:appointment, date_of_birth: '1970-01-01')
-    @bookable_slot = create(:bookable_slot, :cas, start_at: Time.zone.parse('2025-07-10 13:00'))
+    @appointment     = create(:appointment, date_of_birth: '1970-01-01')
+    @previous_guider = @appointment.guider
+    @bookable_slot   = create(:bookable_slot, :cas, start_at: Time.zone.parse('2025-07-10 13:00'))
   end
 
   def when_the_client_posts_a_valid_reschedule_request
@@ -77,7 +78,7 @@ RSpec.describe 'POST /api/v1/appointments/{id}/reschedule' do # rubocop:disable 
       rescheduling_route: Appointment::RESCHEDULED_ONLINE
     )
 
-    expect(@appointment.previous_guider).to be
+    expect(@appointment.previous_guider_id).to eq(@previous_guider.id)
   end
 
   def and_the_rescheduling_reason_is_recorded


### PR DESCRIPTION
When customers were online rescheduling, a bug (calling `dup`) was cloning the original guider and creating a duplicate `User` record.