### PR TITLE
Ensure prior appointment is cancelled too

### DIFF
--- a/app/jobs/reschedule_casebook_appointment_job.rb
+++ b/app/jobs/reschedule_casebook_appointment_job.rb
@@ -7,6 +7,7 @@ class RescheduleCasebookAppointmentJob < CasebookJob
     elsif pushed_casebook_appointment_reallocated_to_non_casebook_guider?(appointment)
       Casebook::Cancel.new(appointment).call
     else
+      Casebook::Cancel.new(appointment).call
       Casebook::Reschedule.new(appointment).call
     end
   end

--- a/spec/jobs/reschedule_casebook_appointment_job_spec.rb
+++ b/spec/jobs/reschedule_casebook_appointment_job_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe RescheduleCasebookAppointmentJob, '#perform' do
 
   context 'when the appointment is for a casebook-enlisted guider' do
     let(:reschedule) { instance_double(Casebook::Reschedule) }
+    let(:cancel) { instance_double(Casebook::Cancel) }
     let(:push) { instance_double(Casebook::Push) }
 
     before do
@@ -38,6 +39,9 @@ RSpec.describe RescheduleCasebookAppointmentJob, '#perform' do
 
       allow(Casebook::Push).to receive(:new).with(appointment).and_return(push)
       allow(push).to receive(:call)
+
+      allow(Casebook::Cancel).to receive(:new).with(appointment).and_return(cancel)
+      allow(cancel).to receive(:call)
     end
 
     context 'when the appointment was not yet pushed to casebook' do
@@ -53,9 +57,10 @@ RSpec.describe RescheduleCasebookAppointmentJob, '#perform' do
     context 'and the appointment was already pushed to casebook' do
       let(:appointment) { build_stubbed(:appointment, :casebook_guider, :casebook_pushed) }
 
-      it 'reschedules casebook appointment' do
+      it 'cancels and reschedules casebook appointment' do
         described_class.perform_now(appointment)
 
+        expect(cancel).to have_received(:call)
         expect(reschedule).to have_received(:call)
       end
     end


### PR DESCRIPTION
The prior appointment record needs to be cancelled in casebook whenever a rescheduling occurs to an existing appointment that would also be rescheduled in casebook, since casebook does not provide an API to do this atomically.