### PR TITLE
Revert "Ensure prior appointment is cancelled too"

### DIFF
--- a/app/jobs/reschedule_casebook_appointment_job.rb
+++ b/app/jobs/reschedule_casebook_appointment_job.rb
@@ -7,7 +7,6 @@ class RescheduleCasebookAppointmentJob < CasebookJob
     elsif pushed_casebook_appointment_reallocated_to_non_casebook_guider?(appointment)
       Casebook::Cancel.new(appointment).call
     else
-      Casebook::Cancel.new(appointment).call
       Casebook::Reschedule.new(appointment).call
     end
   end

--- a/spec/jobs/reschedule_casebook_appointment_job_spec.rb
+++ b/spec/jobs/reschedule_casebook_appointment_job_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe RescheduleCasebookAppointmentJob, '#perform' do
 
   context 'when the appointment is for a casebook-enlisted guider' do
     let(:reschedule) { instance_double(Casebook::Reschedule) }
-    let(:cancel) { instance_double(Casebook::Cancel) }
     let(:push) { instance_double(Casebook::Push) }
 
     before do
@@ -39,9 +38,6 @@ RSpec.describe RescheduleCasebookAppointmentJob, '#perform' do
 
       allow(Casebook::Push).to receive(:new).with(appointment).and_return(push)
       allow(push).to receive(:call)
-
-      allow(Casebook::Cancel).to receive(:new).with(appointment).and_return(cancel)
-      allow(cancel).to receive(:call)
     end
 
     context 'when the appointment was not yet pushed to casebook' do
@@ -57,10 +53,9 @@ RSpec.describe RescheduleCasebookAppointmentJob, '#perform' do
     context 'and the appointment was already pushed to casebook' do
       let(:appointment) { build_stubbed(:appointment, :casebook_guider, :casebook_pushed) }
 
-      it 'cancels and reschedules casebook appointment' do
+      it 'reschedules casebook appointment' do
         described_class.perform_now(appointment)
 
-        expect(cancel).to have_received(:call)
         expect(reschedule).to have_received(:call)
       end
     end


### PR DESCRIPTION
This reverts commit d2cd2d74e8e3fc075be3e6943306998f2cc24ac5.

We've had confirmation that the rescheduling API on the Casebook end does the necessary actions when an appointment crosses locations. This is no longer needed.