### PR TITLE
Reset `processed_at` when new guider is CAS

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -576,15 +576,15 @@ class Appointment < ApplicationRecord
   end
 
   def online_reschedule(start_at:, reason:) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    return unless (slot = BookableSlot.find_available_slot(start_at, nil))
+
     self.start_at = start_at
     self.online_rescheduling_reason = reason
     self.rescheduled_at = Time.zone.now
     self.previous_guider_id = guider.id
     self.rescheduling_reason = CLIENT_RESCHEDULED
     self.rescheduling_route = RESCHEDULED_ONLINE
-
-    return unless (slot = BookableSlot.find_available_slot(start_at, nil))
-
+    self.processed_at = nil if slot.guider.cas?
     self.guider = slot.guider
     self.end_at = slot.end_at
 

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -1185,6 +1185,30 @@ RSpec.describe Appointment, type: :model do
     end
   end
 
+  describe '#online_reschedule' do
+    context 'when the new guider is CAS' do
+      it 'marks the appointment as unprocessed' do
+        @bookable_slot = create(:bookable_slot, :cas)
+        @appointment = create(:appointment, :processed)
+
+        @appointment.online_reschedule(start_at: @bookable_slot.start_at, reason: '1')
+
+        expect(@appointment).to_not be_processed_at
+      end
+    end
+
+    context 'when the guider is another provider' do
+      it 'leaves the processed timestamp as-is' do
+        @bookable_slot = create(:bookable_slot)
+        @appointment = create(:appointment, :processed)
+
+        @appointment.online_reschedule(start_at: @bookable_slot.start_at, reason: '1')
+
+        expect(@appointment).to be_processed_at
+      end
+    end
+  end
+
   describe '#can_be_rescheduled_by?' do
     let(:result) do
       appointment.can_be_rescheduled_by?(user)


### PR DESCRIPTION
This fits CAS' internal processes and correctly marks newly assigned appointments as unprocessed for any online reschedules that switch ownership.