### PR TITLE
Persist chosen filters via cookies

### DIFF
--- a/app/assets/javascripts/modules/calendar.es6
+++ b/app/assets/javascripts/modules/calendar.es6
@@ -128,7 +128,8 @@ class Calendar extends TapBase {
       this.config.cookieName,
       JSON.stringify({
         defaultView: view.name,
-        defaultDate: view.calendar.getDate()
+        defaultDate: view.calendar.getDate(),
+        filterList: this.config.filterList
       }),
       {
         days: 7

--- a/app/assets/javascripts/modules/calendars/company.es6
+++ b/app/assets/javascripts/modules/calendars/company.es6
@@ -59,9 +59,9 @@ class CompanyCalendar extends Calendar {
 
     super.start(el);
 
+    this.config.filterList = this.config.filterList || [];
     this.isFullscreen = false;
     this.hideCancelledAppointments = false;
-    this.filterList = [];
     this.$filterButton = $('.fc-filter-button');
     this.filterButtonLabel = this.$filterButton.text();
     this.$filterPanel = $('.resource-calendar-filter');
@@ -94,7 +94,7 @@ class CompanyCalendar extends Calendar {
   }
 
   filterResources(resource) {
-    return $.inArray(resource.id, this.filterList) > -1;
+    return $.inArray(resource.id, this.config.filterList) > -1;
   }
 
   bindEvents() {
@@ -104,6 +104,10 @@ class CompanyCalendar extends Calendar {
     this.$hideCancelledToggle.on('change', this.handleHideCancelledToggle.bind(this));
 
     $(document).click(this.hideFilterPanel.bind(this));
+
+    if (this.config.filterList.length) {
+      this.refreshFilterButtonLabel();
+    }
   }
 
   handleBookingSlotToggle(event) {
@@ -119,7 +123,7 @@ class CompanyCalendar extends Calendar {
   }
 
   setFilterList(event) {
-    this.filterList = $.map($(event.currentTarget).val(), (id) => {
+    this.config.filterList = $.map($(event.currentTarget).val(), (id) => {
       return parseInt(id);
     });
 
@@ -130,8 +134,8 @@ class CompanyCalendar extends Calendar {
   refreshFilterButtonLabel() {
     let filterButtonLabel = this.filterButtonLabel;
 
-    if (this.filterList.length) {
-      filterButtonLabel += ` (${this.filterList.length})`;
+    if (this.config.filterList.length) {
+      filterButtonLabel += ` (${this.config.filterList.length})`;
     }
 
     this.$filterButton.text(filterButtonLabel);

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -23,13 +23,23 @@ module UserHelper
     end
   end
 
-  def guider_options(user)
+  def guider_options(user, include_reset: true)
     groups = Group.for_user(user).includes(:users)
 
-    {
-      'Groups' => group_options(groups),
-      'Users'  => user_options(user)
-    }
+    options = include_reset ? { 'Reset' => reset_options } : {}
+    options['Groups'] = group_options(groups)
+    options['Users']  = user_options(user)
+    options
+  end
+
+  def reset_options
+    [
+      [
+        'Reset all filters',
+        'Reset all filters',
+        { data: { icon: 'glyphicon-remove', children_to_select: [] } }
+      ]
+    ]
   end
 
   def group_options(groups)

--- a/app/views/holidays/edit.html.erb
+++ b/app/views/holidays/edit.html.erb
@@ -8,5 +8,5 @@
 <h1>Edit holiday</h1>
 
 <%= form_for @holiday, url: batch_upsert_holidays_path(id: params[:id]), method: :patch, layout: :basic do |f| %>
-  <%= render 'form', form: f, holiday: @holiday, guider_options: guider_options(current_user), recurrence: false %>
+  <%= render 'form', form: f, holiday: @holiday, guider_options: guider_options(current_user, include_reset: false), recurrence: false %>
 <% end %>

--- a/app/views/holidays/new.html.erb
+++ b/app/views/holidays/new.html.erb
@@ -8,5 +8,5 @@
 <h1>Create a holiday</h1>
 
 <%= form_for @holiday, url: batch_create_holidays_path, layout: :basic do |f| %>
-  <%= render 'form', form: f, holiday: @holiday, guider_options: guider_options(current_user), recurrence: true %>
+  <%= render 'form', form: f, holiday: @holiday, guider_options: guider_options(current_user, include_reset: false), recurrence: true %>
 <% end %>


### PR DESCRIPTION
As with the current date and view configuration, we should also persist the chosen filters for 7 days via the config cookie. This will work on the company and allocations calendars.