### PR TITLE
Hide holidays prefixed with `hide`

### DIFF
--- a/app/models/holiday.rb
+++ b/app/models/holiday.rb
@@ -31,6 +31,7 @@ class Holiday < ApplicationRecord
     includes(:user)
       .where(users: { organisation_content_id: [user.organisation_content_id, nil] })
       .where('(holidays.start_at, holidays.end_at) OVERLAPS (?, ?)', start_at, end_at)
+      .where.not("holidays.title ilike 'HIDE%'")
   end
 
   def holiday_ids

--- a/spec/models/holiday_spec.rb
+++ b/spec/models/holiday_spec.rb
@@ -146,6 +146,15 @@ RSpec.describe Holiday, type: :model do
       )
     end
 
+    let!(:hidden_holiday) do
+      create(
+        :bank_holiday,
+        title: 'HIDE - The Big Block',
+        start_at: start_at + 3.days,
+        end_at: end_at + 5.days
+      )
+    end
+
     let(:result) do
       described_class.overlapping_or_inside(start_at, end_at, resource_manager)
     end
@@ -171,6 +180,10 @@ RSpec.describe Holiday, type: :model do
 
       it 'lists holidays overlapping the range' do
         expect(result).to include holiday_overlapping_range
+      end
+
+      it 'excludes holidays named `hide*`' do
+        expect(result).to_not include(hidden_holiday)
       end
     end
   end


### PR DESCRIPTION
This is a temporary thing to allow holiday blocks to be effectively 'hidden' on the allocations calendar.