### PR TITLE
Allow groups to be completely deleted

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -95,7 +95,7 @@ linters:
     max_depth: 4
 
   PlaceholderInExtend:
-    enabled: true
+    enabled: false
 
   PropertySortOrder:
     enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ source 'https://rubygems.org'
 
 gem 'active_link_to'
 gem 'active_model_serializers'
+gem 'alertifyjs-rails'
 gem 'audited'
 gem 'azure-storage-blob', '~> 2.0.3'
 gem 'bh'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ GEM
       uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    alertifyjs-rails (1.12.0)
     ast (2.4.2)
     audited (5.8.0)
       activerecord (>= 5.2, < 8.2)
@@ -649,6 +650,7 @@ PLATFORMS
 DEPENDENCIES
   active_link_to
   active_model_serializers
+  alertifyjs-rails
   audited
   aws-sdk-s3
   azure-storage-blob (~> 2.0.3)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,6 +23,7 @@
 //= require pusher
 //= require jquery.postcodes/dist/postcodes.js
 //= require govuk-admin-template/modules/checkbox_toggle
+//= require alertify
 
 //= require tap-base
 //= require modules/calendar

--- a/app/assets/javascripts/modules/group-deletion-confirmation.es6
+++ b/app/assets/javascripts/modules/group-deletion-confirmation.es6
@@ -1,0 +1,53 @@
+/* global TapBase, alertify */
+{
+  'use strict';
+
+  class GroupDeletionConfirmation extends TapBase {
+    start(el) {
+      super.start(el);
+
+      alertify.defaults.transition = 'fade'
+      alertify.defaults.theme.ok = 'btn btn-danger t-ok js-ok'
+      alertify.defaults.theme.cancel = 'btn btn-default'
+
+      this.$group = this.$el.data('group');
+
+      this.bindEvents();
+    }
+
+    bindEvents() {
+      this.$el.on('click', this.confirmGroupDeletion.bind(this));
+    }
+
+    confirmGroupDeletion(event) {
+      event.preventDefault();
+
+      alertify
+        .prompt(
+          `<strong class="text-danger">Delete group: ${this.$group}</strong>`,
+          `Type <strong>${this.$group}</strong> to confirm deletion of the group and guider assignments`,
+          '',
+          (jsEvent, value) => {
+            if (value === this.$group) {
+              this.$el.parent().submit();
+            }
+          },
+          () => { /* this handler has to be here otherwise alertify does not cancel */ }
+        );
+
+      this.$input = $('.ajs-input');
+      this.$input.on('keyup', this.inputKeyUp.bind(this));
+
+      this.$ok = $('.js-ok');
+      this.$ok.prop('disabled', true);
+    }
+
+    inputKeyUp() {
+      if (this.$input.val() === this.$group) {
+        this.$ok.prop('disabled', false);
+      }
+    }
+  }
+
+  window.GOVUKAdmin.Modules.GroupDeletionConfirmation = GroupDeletionConfirmation;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,4 +3,6 @@
 @import "components/*";
 @import "helper/*";
 
+@import "alertify";
+@import "alertify/bootstrap";
 @import "eonasdan-bootstrap-datetimepicker";

--- a/app/assets/stylesheets/components/_form-group.scss
+++ b/app/assets/stylesheets/components/_form-group.scss
@@ -1,3 +1,18 @@
 .form-group--email-validator {
   position: relative;
 }
+
+.form-group--delete-group {
+  @extend .form-group;
+  @extend .pull-left;
+
+  margin-bottom: 0;
+
+  .btn {
+    margin-right: 5px;
+
+    &:hover {
+      @extend .btn-danger;
+    }
+  }
+}

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -14,12 +14,12 @@ class GroupsController < ApplicationController
       current_user
     ).call
 
-    go_back_with_success('assigned to')
+    go_back_with_success('assigned')
   end
 
   def destroy
     DestroyGroupAssignments.new(user_ids, params[:id]).call
-    go_back_with_success('unassigned from')
+    go_back_with_success('unassigned')
   end
 
   private
@@ -27,7 +27,7 @@ class GroupsController < ApplicationController
   def go_back_with_success(action)
     redirect_back(
       fallback_location: users_path,
-      success: "The users were #{action} the specified groups"
+      success: "The users/groups were successfully #{action}"
     )
   end
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,4 +1,6 @@
 class Group < ApplicationRecord
+  audited on: :destroy
+
   default_scope { order(:name) }
 
   has_many :group_assignments, dependent: :destroy

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -40,7 +40,16 @@
             <td><span class="glyphicon glyphicon-user" aria-hidden="true"></span> <span class="name"><%= guider.name %><%= psg_banner(guider) %></span></td>
             <td>
               <% guider.groups.each do |group| %>
-                <span class="label label-info <%= dom_id(group) %> t-group"><%= group.name %></span>
+                  <%= button_to(
+                    group_path(group, user_ids: group.user_ids),
+                    method: :delete,
+                    data: { module: 'group-deletion-confirmation', group: group.name },
+                    class: 'btn btn-info btn-xs t-group',
+                    form_class: 'form-group--delete-group'
+                  ) do %>
+                    <strong class="<%= dom_id(group) %>"><%= group.name %></strong>
+                    <span class="sr-only">Delete <%= group.name %></span>
+                  <% end %>
               <% end %>
             </td>
             <td class="guider__active">

--- a/spec/features/resource_manager_manages_guiders_spec.rb
+++ b/spec/features/resource_manager_manages_guiders_spec.rb
@@ -52,6 +52,53 @@ RSpec.feature 'Resource manager manages guiders' do
     end
   end
 
+  scenario 'Deleting a group and all user assignments', js: true do
+    given_the_user_is_a_resource_manager do
+      and_multiple_guiders_are_assigned_to_a_group
+      when_they_visit_the_guiders_page
+      and_delete_the_group
+      then_the_group_and_assignments_are_deleted
+    end
+  end
+
+  scenario 'Failing confirmation and not deleting the group and user assignments', js: true do
+    given_the_user_is_a_resource_manager do
+      and_multiple_guiders_are_assigned_to_a_group
+      when_they_visit_the_guiders_page
+      and_they_attempt_to_delete_the_group
+      then_the_group_and_assignments_are_not_deleted
+    end
+  end
+
+  def and_multiple_guiders_are_assigned_to_a_group
+    @group  = create(:group, name: 'All Guiders')
+    @guider = create(:guider) { |g| g.groups << @group }
+    @other  = create(:guider) { |g| g.groups << @group }
+  end
+
+  def and_delete_the_group
+    @page.guiders.first.groups.first.click
+    @page.wait_until_delete_prompt_visible
+    @page.delete_prompt.group.set('All Guiders')
+    @page.delete_prompt.ok.click
+  end
+
+  def then_the_group_and_assignments_are_deleted
+    expect(@page).to have_flash_of_success
+    expect(Group.count).to be_zero
+    expect(GroupAssignment.count).to be_zero
+  end
+
+  def and_they_attempt_to_delete_the_group
+    @page.guiders.first.groups.first.click
+    @page.wait_until_delete_prompt_visible
+    @page.delete_prompt.group.set('Whoops Bad')
+  end
+
+  def then_the_group_and_assignments_are_not_deleted
+    expect { @page.delete_prompt.ok.click }.not_to(change { Group.count })
+  end
+
   def and_they_choose_to_remove_groups_from_multiple_guiders
     and_they_choose_to_add_groups_to_multiple_guiders
   end

--- a/spec/support/pages/manage_guiders.rb
+++ b/spec/support/pages/manage_guiders.rb
@@ -13,6 +13,11 @@ module Pages
       element :checkbox, '.t-checkbox'
     end
 
+    section :delete_prompt, '.alertify' do
+      element :group, '.ajs-input'
+      element :ok, '.t-ok'
+    end
+
     element :deactivate, '.t-deactivate'
     element :activate, '.t-activate'
 


### PR DESCRIPTION
Resource managers can completely delete groups and their assignments but have to go through a confirmation process first to ensure they do not do so accidentally as the consequences are dire.