### PR TITLE
Highlight block booked holidays

### DIFF
--- a/app/assets/javascripts/modules/calendars/holidays.es6
+++ b/app/assets/javascripts/modules/calendars/holidays.es6
@@ -32,6 +32,12 @@
 
       super.start(el);
     }
+
+    eventAfterRender(event, element) {
+      if(event.multipleGuiders === true) {
+        element.addClass('fc-event--multiple-guiders');
+      }
+    }
   }
 
   window.GOVUKAdmin.Modules.HolidaysCalendar = HolidaysCalendar;

--- a/app/assets/stylesheets/components/_calendars.scss
+++ b/app/assets/stylesheets/components/_calendars.scss
@@ -58,6 +58,12 @@ $guider-row-height: 120px;
       color: $calendar-holiday-anchor-visited;
     }
   }
+
+  .fc-event--multiple-guiders {
+    // scss-lint:disable ImportantRule
+    background: darken($calendar-holiday-background, 30%) !important;
+    // scss-lint:enable ImportantRule
+  }
 }
 
 .company-calendar {

--- a/app/models/holiday.rb
+++ b/app/models/holiday.rb
@@ -37,6 +37,7 @@ class Holiday < ApplicationRecord
   validates :end_at, presence: true
   validates :description, inclusion: { in: DESCRIPTION_OPTIONS.keys }
   validates :additional_information, length: { maximum: 300 }
+  validates :title, uniqueness: { scope: %i[user_id start_at end_at] }
 
   def self.merged_for_calendar_view(start_at, end_at, user) # rubocop:disable Metrics/MethodLength
     select(

--- a/app/serializers/holiday_serializer.rb
+++ b/app/serializers/holiday_serializer.rb
@@ -18,5 +18,13 @@ class HolidaySerializer < ActiveModel::Serializer
     edit_holiday_path(object.holiday_ids || object.id)
   end
 
+  attribute :multipleGuiders do
+    if object.holiday_ids
+      object.holiday_ids.split(',').size > 1
+    else
+      false
+    end
+  end
+
   delegate :bank_holiday?, to: :object
 end

--- a/db/migrate/20260603085938_add_uniqueness_to_holidays.rb
+++ b/db/migrate/20260603085938_add_uniqueness_to_holidays.rb
@@ -1,0 +1,15 @@
+class AddUniquenessToHolidays < ActiveRecord::Migration[8.1]
+  def up
+    execute <<-SQL
+      DROP INDEX IF EXISTS uniqueness_in_holidays;
+
+      CREATE UNIQUE INDEX uniqueness_in_holidays
+       ON holidays (title, start_at, end_at, user_id)
+       WHERE start_at > '2026-06-03 00:00';
+    SQL
+  end
+
+  def down
+    execute 'DROP INDEX IF EXISTS uniqueness_in_holidays;'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_11_102011) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_03_085938) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_catalog.plpgsql"
@@ -216,6 +216,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_11_102011) do
     t.index "user_id, tsrange(start_at, end_at)", name: "index_holidays_userid_tsrange", using: :gist
     t.index ["creator_id"], name: "index_holidays_on_creator_id"
     t.index ["start_at", "end_at"], name: "index_holidays_on_start_at_and_end_at"
+    t.index ["title", "start_at", "end_at", "user_id"], name: "uniqueness_in_holidays", unique: true, where: "(start_at > '2026-06-03 00:00:00'::timestamp without time zone)"
     t.index ["user_id"], name: "index_holidays_on_user_id"
   end
 

--- a/spec/models/holiday_spec.rb
+++ b/spec/models/holiday_spec.rb
@@ -3,6 +3,14 @@ require 'rails_helper'
 # rubocop:disable Metrics/BlockLength
 RSpec.describe Holiday, type: :model do
   describe 'validations' do
+    it 'validates uniqueness of title, user ID, start and end' do
+      guider    = create(:guider)
+      duplicate = build(:holiday, title: 'Whoops', user: guider)
+      create(:holiday, title: 'Whoops', user: guider)
+
+      expect(duplicate).to be_invalid
+    end
+
     it 'requires a description' do
       holiday = build_stubbed(:holiday, description: '')
       expect(holiday).to_not be_valid


### PR DESCRIPTION
Darken holiday entries in the calendar when they have multiple assignments so that they're easier to distinguish.