### PR TITLE
Send a digest email with holiday blocks

### DIFF
--- a/app/lib/holiday_block_summary.rb
+++ b/app/lib/holiday_block_summary.rb
@@ -1,0 +1,7 @@
+class HolidayBlockSummary
+  def call
+    @holidays = Holiday.for_email_digest
+
+    HolidayMailer.block_digest(@holidays).deliver_now if @holidays.present?
+  end
+end

--- a/app/mailers/holiday_mailer.rb
+++ b/app/mailers/holiday_mailer.rb
@@ -1,0 +1,16 @@
+class HolidayMailer < ApplicationMailer
+  def block_digest(holidays)
+    @appointment = OpenStruct.new(logo_file: 'pw.jpg')
+    @holidays    = holidays
+
+    mail to: recipients,
+         from: 'Pension Wise Bookings <booking.pensionwise@moneyhelper.org.uk>',
+         subject: 'Holiday Block Digest'
+  end
+
+  private
+
+  def recipients
+    ENV.fetch('OPS_HOLIDAY_DIGEST_ALIASES') { ApplicationJob::OPS_SUPERVISOR }.split(',')
+  end
+end

--- a/app/models/holiday.rb
+++ b/app/models/holiday.rb
@@ -1,6 +1,8 @@
 class Holiday < ApplicationRecord
   acts_as_copy_target
 
+  BLOCK_DIGEST_RANGE_DAYS = 7
+
   DESCRIPTION_OPTIONS = {
     'annual_leave' => 'Annual Leave',
     'sick_leave' => 'Sick Leave',
@@ -41,15 +43,15 @@ class Holiday < ApplicationRecord
   def self.merged_for_calendar_view(start_at, end_at, user) # rubocop:disable Metrics/MethodLength
     select(
       <<-SQL
-        DISTINCT ON(holidays.bank_holiday, holidays.all_day, holidays.start_at, holidays.end_at, holidays.title)
-        holidays.bank_holiday, holidays.all_day, holidays.title, holidays.start_at, holidays.end_at,
+        DISTINCT ON(holidays.bank_holiday, holidays.all_day, holidays.start_at, holidays.end_at, holidays.title, holidays.description)
+        holidays.bank_holiday, holidays.all_day, holidays.title, holidays.start_at, holidays.end_at, holidays.description,
         string_agg(holidays.id::text, ',') as holiday_ids
       SQL
     )
       .joins('LEFT JOIN users ON users.id = holidays.user_id')
       .where(users: { organisation_content_id: [user.organisation_content_id, nil] })
       .where('(holidays.start_at, holidays.end_at) OVERLAPS (?, ?)', start_at, end_at)
-      .group(:bank_holiday, :all_day, :start_at, :end_at, :title)
+      .group(:bank_holiday, :all_day, :start_at, :end_at, :title, :description)
       .order(:start_at)
   end
 
@@ -62,6 +64,14 @@ class Holiday < ApplicationRecord
       .where(users: { organisation_content_id: [user.organisation_content_id, nil] })
       .where('(holidays.start_at, holidays.end_at) OVERLAPS (?, ?)', start_at, end_at)
       .where.not("holidays.title ilike 'HIDE%'")
+  end
+
+  def self.for_email_digest
+    merged_for_calendar_view(
+      Time.zone.now.beginning_of_day,
+      BLOCK_DIGEST_RANGE_DAYS.days.from_now.end_of_day,
+      OpenStruct.new(organisation_content_id: Provider::TPAS.id)
+    ).having('count(holidays.id) > 2').to_a
   end
 
   def holiday_ids

--- a/app/presenters/holiday_email_presenter.rb
+++ b/app/presenters/holiday_email_presenter.rb
@@ -1,0 +1,27 @@
+class HolidayEmailPresenter < SimpleDelegator
+  include Rails.application.routes.url_helpers
+
+  def from
+    if all_day
+      start_at.to_date.to_fs(:govuk_date)
+    else
+      start_at.to_fs(:govuk_date)
+    end
+  end
+
+  def to
+    if all_day
+      end_at.to_date.to_fs(:govuk_date)
+    else
+      end_at.to_fs(:govuk_date)
+    end
+  end
+
+  def all_day_label
+    '(all day)' if all_day
+  end
+
+  def full_description
+    Holiday::DESCRIPTION_OPTIONS[description]
+  end
+end

--- a/app/views/holiday_mailer/block_digest.html.erb
+++ b/app/views/holiday_mailer/block_digest.html.erb
@@ -1,0 +1,13 @@
+<h1 style="color: #0F19A0 !important;font-family: Calibri, Arial, sans-serif;margin: 15px 0;font-weight: 700;font-size: 20px;line-height: 1.111111111;padding: 15px 0;">
+  Holiday blocks for the next <%= Holiday::BLOCK_DIGEST_RANGE_DAYS %> days
+</h1>
+
+<% @holidays.each do |holiday| %>
+  <% @holiday = HolidayEmailPresenter.new(holiday) %>
+
+  <%= p do %>
+    <a href="<%= edit_holiday_url(@holiday.holiday_ids) %>"><strong><%= @holiday.title %></strong></a><br>
+    <%= @holiday.full_description %><br>
+    <%= @holiday.from %> - <%= @holiday.to %> <%= @holiday.all_day_label %><br>
+  <% end %>
+<% end %>

--- a/lib/tasks/holidays.rake
+++ b/lib/tasks/holidays.rake
@@ -1,4 +1,9 @@
 namespace :holidays do
+  desc 'Send 7 day digest email for holiday blocks'
+  task send_digest: :environment do
+    HolidayBlockSummary.new.call
+  end
+
   desc 'Allow CAS to receive bookings during given holidays'
   task exclude: :environment do
     BankHolidayExcluder.new.call

--- a/spec/lib/holiday_block_summary_spec.rb
+++ b/spec/lib/holiday_block_summary_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe HolidayBlockSummary, '#call' do
+  context 'when no holiday blocks are present' do
+    it 'does not send a digest' do
+      allow(Holiday).to receive(:for_email_digest).and_return([])
+
+      subject.call
+
+      expect(HolidayMailer).not_to receive(:block_digest)
+    end
+  end
+
+  context 'when holiday blocks are present' do
+    it 'sends the digest' do
+      message  = double(deliver_now: true)
+      holidays = [build(:holiday)]
+
+      allow(Holiday).to receive(:for_email_digest).and_return(holidays)
+      expect(HolidayMailer).to receive(:block_digest).with(holidays).and_return(message)
+
+      subject.call
+    end
+  end
+end

--- a/spec/mailers/holiday_mailer_spec.rb
+++ b/spec/mailers/holiday_mailer_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+# rubocop:disable Metrics/BlockLength
+RSpec.describe HolidayMailer, type: :mailer do
+  describe 'block_digest' do
+    before do
+      guiders = create_list(:guider, 3)
+      guiders.each do |guider|
+        create(
+          :holiday,
+          user: guider,
+          title: 'Block Booking',
+          start_at: Time.zone.parse('2026-06-12 12:00'),
+          end_at: Time.zone.parse('2026-06-12 13:00')
+        )
+      end
+    end
+
+    let(:mail) { HolidayMailer.block_digest(Holiday.for_email_digest) }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Holiday Block Digest')
+      expect(mail.to).to eq(['supervisors@maps.org.uk'])
+      expect(mail.from).to eq(['booking.pensionwise@moneyhelper.org.uk'])
+    end
+
+    it 'renders the body' do
+      travel_to '2026-06-12 07:00' do
+        body = mail.body.encoded
+        expect(body).to match('Holiday blocks for the next 7 days')
+        expect(body).to match('Block Booking')
+        expect(body).to match('12:00pm, 12 June 2026 - 1:00pm, 12 June 2026')
+      end
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/spec/mailers/previews/holiday_mailer_preview.rb
+++ b/spec/mailers/previews/holiday_mailer_preview.rb
@@ -1,0 +1,24 @@
+class HolidayMailerPreview < ActionMailer::Preview
+  def block_digest # rubocop:disable Metrics/MethodLength
+    HolidayMailer.block_digest(
+      [
+        OpenStruct.new(
+          all_day: false,
+          title: 'Tier 2 - Super Huddle',
+          start_at: Time.zone.parse('2026-06-10 15:30'),
+          end_at: Time.zone.parse('2026-06-10 16:30'),
+          description: 'training',
+          holiday_ids: '1,2,3'
+        ),
+        OpenStruct.new(
+          all_day: true,
+          title: 'Guider Conference',
+          start_at: Time.zone.parse('2026-06-14 00:00'),
+          end_at: Time.zone.parse('2026-06-15 23:59'),
+          description: 'team_meeting',
+          holiday_ids: '1,2,3'
+        )
+      ]
+    )
+  end
+end

--- a/spec/models/holiday_spec.rb
+++ b/spec/models/holiday_spec.rb
@@ -2,6 +2,20 @@ require 'rails_helper'
 
 # rubocop:disable Metrics/BlockLength
 RSpec.describe Holiday, type: :model do
+  describe '.for_email_digest' do
+    it 'returns 14 days of holidays assigned to more than 2 people' do
+      guiders = create_list(:guider, 3)
+      guiders.each { |guider| create(:holiday, user: guider, title: 'Block Booking') }
+
+      create(:holiday) # excluded from the results
+
+      results = Holiday.for_email_digest
+
+      expect(results.size).to eq(1)
+      expect(results.first.title).to eq('Block Booking')
+    end
+  end
+
   describe 'validations' do
     it 'requires a description' do
       holiday = build_stubbed(:holiday, description: '')


### PR DESCRIPTION
These are being missed sometimes and can lead to issues with availability and utilisation. Sending a daily digest should help to keep resource managers informed of upcoming blocks that are assigned to 3 or more guiders at a time.