### PR TITLE
Overlapping activity logic improvements

### DIFF
--- a/app/lib/genesys/models/activity.rb
+++ b/app/lib/genesys/models/activity.rb
@@ -32,6 +32,8 @@ module Genesys
       end
 
       def overlaps?(activity)
+        return false if start_date == activity.end_date
+
         date_range.overlap?(activity.date_range)
       end
 

--- a/spec/lib/genesys/models/activity_spec.rb
+++ b/spec/lib/genesys/models/activity_spec.rb
@@ -13,6 +13,19 @@ RSpec.describe Genesys::Models::Activity do # rubocop:disable Metrics/BlockLengt
 
   subject { described_class.new(activity_hash) }
 
+  describe '#overlaps?' do
+    context 'when the activity end matches the argument start' do
+      it 'is not overlapping' do
+        activity = described_class.new(
+          'startDate' => '2025-10-27T07:00:00Z',
+          'lengthMinutes' => 60
+        )
+
+        expect(subject.overlaps?(activity)).to be false
+      end
+    end
+  end
+
   it 'maps its basic attributes' do
     expect(subject).to have_attributes(
       start_date: Time.zone.parse('2025-10-27T08:00:00Z'),

--- a/spec/lib/genesys/models/shift_spec.rb
+++ b/spec/lib/genesys/models/shift_spec.rb
@@ -29,6 +29,100 @@ RSpec.describe Genesys::Models::Shift do
 
   subject { described_class.new(shift_hash) }
 
+  context 'when precisely matching end/start `overlaps`' do
+    let(:shift_hash) do
+      {
+        'id' => '0',
+        'startDate' => '2026-06-16T10:30:00Z',
+        'lengthMinutes' => 480,
+        'activities' => [
+          {
+            'startDate' => '2026-06-16T10:30:00Z',
+            'lengthMinutes' => 30,
+            'description' => 'oq-1',
+            'activityCodeId' => '0',
+            'paid' => true
+          },
+          {
+            'startDate' => '2026-06-16T11:00:00Z',
+            'lengthMinutes' => 70,
+            'description' => 'pw-1',
+            'activityCodeId' => 'pw-1',
+            'paid' => true
+          },
+          {
+            'startDate' => '2026-06-16T12:10:00Z',
+            'lengthMinutes' => 10,
+            'description' => 'oq-2',
+            'activityCodeId' => '0',
+            'paid' => true
+          },
+          {
+            'startDate' => '2026-06-16T12:20:00Z',
+            'lengthMinutes' => 70,
+            'description' => 'pw-2',
+            'activityCodeId' => 'pw-2',
+            'paid' => true
+          },
+          {
+            'startDate' => '2026-06-16T13:30:00Z',
+            'lengthMinutes' => 90,
+            'description' => 'oq-3',
+            'activityCodeId' => '0',
+            'paid' => true
+          },
+          {
+            'startDate' => '2026-06-16T15:00:00Z',
+            'lengthMinutes' => 60,
+            'description' => 'meeting',
+            'activityCodeId' => 'meeting',
+            'paid' => true
+          },
+          {
+            'startDate' => '2026-06-16T16:00:00Z',
+            'lengthMinutes' => 75,
+            'description' => 'oq-4',
+            'activityCodeId' => '0',
+            'paid' => true
+          },
+          {
+            'startDate' => '2026-06-16T17:15:00Z',
+            'lengthMinutes' => 15,
+            'description' => 'break',
+            'activityCodeId' => 'break',
+            'paid' => true
+          },
+          {
+            'startDate' => '2026-06-16T17:30:00Z',
+            'lengthMinutes' => 60,
+            'description' => 'oq-5',
+            'activityCodeId' => '0',
+            'paid' => true
+          }
+        ],
+        'manuallyEdited' => false
+      }
+    end
+
+    let(:activity) do
+      Genesys::Models::Activity.new(
+        'startDate' => '2026-06-16T13:50:00Z',
+        'lengthMinutes' => 70,
+        'description' => 'pw-3'
+      )
+    end
+
+    it 'does not overwrite the activity starting at the same time as the new one ends' do
+      # verify the right initial order
+      expect(subject.activities.map(&:description)).to eq(%w[oq-1 pw-1 oq-2 pw-2 oq-3 meeting oq-4 break oq-5])
+
+      subject.create_activity(activity)
+
+      # verify the right final order
+      expect(subject.activities.map(&:description)).to eq(%w[oq-1 pw-1 oq-2 pw-2 Filler pw-3 meeting oq-4 break oq-5])
+    end
+  end
+
   it 'maps its basic attributes' do
     expect(subject).to have_attributes(
       id: '0',


### PR DESCRIPTION
We had a case where an appointment activity was pushed that overwrote a reserved 'meeting' activity due to the new activity's end date/time matching precisely the existing activity's start date/time. The `overlaps?` logic on a date/time range would consider this `true`, which is technically correct, though in the case of agent shifts doesn't make sense. Instead if an end and start precisely match, we can be happy that they do not technically 'overlap' and instead can be considered contiguous.