### PR TITLE
Don't consider these as overlapping

### DIFF
--- a/app/lib/genesys/models/activity.rb
+++ b/app/lib/genesys/models/activity.rb
@@ -33,6 +33,7 @@ module Genesys
 
       def overlaps?(activity)
         return false if start_date == activity.end_date
+        return false if end_date == activity.start_date
 
         date_range.overlap?(activity.date_range)
       end

--- a/spec/lib/genesys/models/activity_spec.rb
+++ b/spec/lib/genesys/models/activity_spec.rb
@@ -14,10 +14,21 @@ RSpec.describe Genesys::Models::Activity do # rubocop:disable Metrics/BlockLengt
   subject { described_class.new(activity_hash) }
 
   describe '#overlaps?' do
-    context 'when the activity end matches the argument start' do
+    context 'when the activity start matches the argument end' do
       it 'is not overlapping' do
         activity = described_class.new(
           'startDate' => '2025-10-27T07:00:00Z',
+          'lengthMinutes' => 60
+        )
+
+        expect(subject.overlaps?(activity)).to be false
+      end
+    end
+
+    context 'when the activity end matches the argument start' do
+      it 'is not overlapping' do
+        activity = described_class.new(
+          'startDate' => '2025-10-27T10:00:00Z',
           'lengthMinutes' => 60
         )
 

--- a/spec/lib/genesys/models/shift_spec.rb
+++ b/spec/lib/genesys/models/shift_spec.rb
@@ -29,6 +29,58 @@ RSpec.describe Genesys::Models::Shift do
 
   subject { described_class.new(shift_hash) }
 
+  context 'when precisely matching start/end `overlaps`' do
+    let(:shift_hash) do
+      {
+        'id' => '0',
+        'startDate' => '2026-06-16T08:00:00Z',
+        'lengthMinutes' => 135,
+        'activities' => [
+          {
+            'startDate' => '2026-06-16T08:00:00Z',
+            'lengthMinutes' => 30,
+            'description' => 'huddle',
+            'activityCodeId' => 'huddle',
+            'paid' => true
+          },
+          {
+            'startDate' => '2026-06-16T08:30:00Z',
+            'lengthMinutes' => 90,
+            'description' => 'oq-1',
+            'activityCodeId' => 'oq-1',
+            'paid' => true
+          },
+          {
+            'startDate' => '2026-06-16T10:00:00Z',
+            'lengthMinutes' => 15,
+            'description' => 'break',
+            'activityCodeId' => 'break',
+            'paid' => true
+          }
+        ],
+        'manuallyEdited' => false
+      }
+    end
+
+    let(:activity) do
+      Genesys::Models::Activity.new(
+        'startDate' => '2026-06-16T08:30:00Z',
+        'lengthMinutes' => 70,
+        'description' => 'pw-1'
+      )
+    end
+
+    it 'does not overwrite the activity ending at the same time as the new one starts' do
+      # verify the right initial order
+      expect(subject.activities.map(&:description)).to eq(%w[huddle oq-1 break])
+
+      subject.create_activity(activity)
+
+      # verify the right final order
+      expect(subject.activities.map(&:description)).to eq(%w[huddle pw-1 Filler break])
+    end
+  end
+
   context 'when precisely matching end/start `overlaps`' do
     let(:shift_hash) do
       {


### PR DESCRIPTION
When a new activity start matches the prior activity end precisely, these are not to be considered overlaps. This means the prior activity remains on-shift and is not replaced by 'On Queue' filler.