### PR TITLE
Push appointments to Genesys when possible

### DIFF
--- a/app/lib/genesys/api.rb
+++ b/app/lib/genesys/api.rb
@@ -17,7 +17,7 @@ module Genesys
       Rails.logger.info(activity)
       Rails.logger.info(agent_schedule)
 
-      raise Genesys::ActivityUnassignableError unless agent_schedule.assign_activity(activity)
+      raise Genesys::ActivityUnassignableError, appointment.id unless agent_schedule.assign_activity(activity)
 
       schedule_payload = Genesys::Presenters::Schedule.new(schedule_version, agent_schedule).to_h
       Rails.logger.info('Genesys Schedule Payload')

--- a/app/lib/genesys/services/published_schedule_appointment_synchroniser.rb
+++ b/app/lib/genesys/services/published_schedule_appointment_synchroniser.rb
@@ -1,0 +1,21 @@
+module Genesys
+  module Services
+    class PublishedScheduleAppointmentSynchroniser
+      def initialize(appointments)
+        @appointments = appointments
+      end
+
+      def call
+        appointments.each do |appointment|
+          Genesys::Push.new(appointment).call
+        rescue Genesys::PublishedScheduleMissingError, Genesys::ActivityUnassignableError => e
+          Bugsnag.notify(e)
+        end
+      end
+
+      private
+
+      attr_reader :appointments
+    end
+  end
+end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -544,6 +544,14 @@ class Appointment < ApplicationRecord
     SECONDARY_STATUSES.values.reduce(&:merge)[key] || '-'
   end
 
+  def self.for_genesys_newly_published_schedule
+    pending
+      .where(genesys_operation_id: nil)
+      .where('start_at < ?', 5.weeks.from_now.end_of_week(:saturday))
+      .joins(:guider).where.not(users: { genesys_agent_id: nil })
+      .order(:start_at)
+  end
+
   def self.for_redaction
     where
       .not(first_name: 'redacted')

--- a/lib/tasks/genesys.rake
+++ b/lib/tasks/genesys.rake
@@ -1,7 +1,16 @@
 require 'faye/websocket'
 require 'eventmachine'
 
-namespace :genesys do
+namespace :genesys do # rubocop:disable Metrics/BlockLength
+  namespace :publisher do
+    desc 'Pushes appointments when they have newly published/available Genesys schedules'
+    task push: :environment do
+      appointments = Appointment.for_genesys_newly_published_schedule
+
+      Genesys::Services::PublishedScheduleAppointmentSynchroniser.new(appointments).call
+    end
+  end
+
   namespace :notifications do
     desc 'Subscribe and process messages for schedule updates'
     task subscribe: :environment do

--- a/spec/lib/genesys/services/published_schedule_appointment_synchroniser_spec.rb
+++ b/spec/lib/genesys/services/published_schedule_appointment_synchroniser_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Genesys::Services::PublishedScheduleAppointmentSynchroniser, '#call' do
+  it 'pushes each appointment in the list to Genesys' do
+    appointment = double(Appointment)
+    pusher = double(Genesys::Push, call: true)
+
+    allow(Genesys::Push).to receive(:new).with(appointment).and_return(pusher)
+
+    described_class.new(Array(appointment)).call
+
+    expect(pusher).to have_received(:call)
+  end
+
+  context 'when an appointment could not be published due to missing schedule' do
+    it 'reports the underlying error to bugsnag' do
+      appointment = double(Appointment)
+      pusher = double(Genesys::Push)
+
+      allow(Bugsnag).to receive(:notify)
+      allow(Genesys::Push).to receive(:new).with(appointment).and_return(pusher)
+      allow(pusher).to receive(:call).and_raise(Genesys::PublishedScheduleMissingError)
+
+      described_class.new(Array(appointment)).call
+
+      expect(Bugsnag).to have_received(:notify)
+    end
+  end
+end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -4,6 +4,20 @@ NORMALISED_NUMBERS = %w[+447715930455 447715930455 07715930455 00447715930455].f
 
 # rubocop:disable Metrics/BlockLength
 RSpec.describe Appointment, type: :model do
+  describe '.for_genesys_newly_published_schedule' do
+    it 'returns the appointments that are due to be pushed' do
+      @included       = create(:appointment, :genesys_guider)
+      @not_pending    = create(:appointment, :genesys_guider, status: :complete)
+      @already_pushed = create(:appointment, :genesys_guider, genesys_operation_id: 'deadbeef')
+      @beyond_date    = create(:appointment, :genesys_guider, start_at: 8.weeks.from_now)
+
+      results = Appointment.for_genesys_newly_published_schedule
+
+      expect(results.size).to eq(1)
+      expect(results).to include(@included)
+    end
+  end
+
   describe '.needing_status_reminder' do
     it 'returns appointments that are pending still at one day after the appointment' do
       @included = create(:appointment, start_at: 2.days.ago)


### PR DESCRIPTION
Sweeps up all the appointments that were not yet published to Genesys due to their date/time not being present within an existing published schedule. Genesys schedules are published up to 5 weeks ahead. When a new one is published we can try and retrieve all the appointments that have been yet to publish and push them all in turn.