### PR TITLE
Ensure a Genesys push occurs upon creation

### DIFF
--- a/app/controllers/api/v1/appointments_controller.rb
+++ b/app/controllers/api/v1/appointments_controller.rb
@@ -34,6 +34,7 @@ module Api
         AppointmentMailer.potential_duplicates(appointment).deliver_later if appointment.potential_duplicates?
         CustomerUpdateJob.perform_later(appointment, CustomerUpdateActivity::CONFIRMED_MESSAGE)
         AppointmentCreatedNotificationsJob.perform_later(appointment)
+        PushGenesysAppointmentJob.perform_later(appointment)
       end
 
       def show_params

--- a/spec/requests/appointments_api_spec.rb
+++ b/spec/requests/appointments_api_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe 'POST /api/v1/appointments' do
       CustomerUpdateJob,
       SmsAppointmentConfirmationJob,
       AdjustmentNotificationsJob,
-      AppointmentCreatedNotificationsJob
+      AppointmentCreatedNotificationsJob,
+      PushGenesysAppointmentJob
     ].each do |job|
       allow(job).to receive(:perform_later)
     end
@@ -75,6 +76,7 @@ RSpec.describe 'POST /api/v1/appointments' do
         and_the_customer_receives_a_confirmation_sms
         and_the_resource_manager_receives_an_accessibility_notification
         and_the_resource_manager_receives_a_new_appointment_notification
+        and_a_genesys_push_is_enqueued
       end
     end
   end
@@ -382,6 +384,10 @@ RSpec.describe 'POST /api/v1/appointments' do
 
   def and_the_resource_manager_receives_a_new_appointment_notification
     expect(AppointmentCreatedNotificationsJob).to have_received(:perform_later)
+  end
+
+  def and_a_genesys_push_is_enqueued
+    expect(PushGenesysAppointmentJob).to have_received(:perform_later)
   end
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Appointments booked through the website should be pushed to Genesys when possible.