### PR TITLE
Do not retry Genesys failures for specific errors

### DIFF
--- a/app/jobs/genesys_notification_job.rb
+++ b/app/jobs/genesys_notification_job.rb
@@ -1,6 +1,4 @@
-class GenesysNotificationJob < ApplicationJob
-  queue_as :single
-
+class GenesysNotificationJob < GenesysJob
   def perform(event_data)
     event = JSON.parse(event_data)
 


### PR DESCRIPTION
When the schedule is not yet published or the activity could not be pushed, do not bother retrying the job as it's not recoverable automatically.