### PR TITLE
Remove 'TPAS' labelling

### DIFF
--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -142,7 +142,7 @@
       </thead>
       <tbody>
         <tr class="booking-details__row">
-          <td class="booking-details__item"><b class="visible-xs-block">Guider</b><span class="glyphicon glyphicon-user" aria-hidden="true"></span> <span class="t-guider"><%= @appointment.guider.name %> <small><%= @appointment.guider.organisation %></small></span> </td>
+          <td class="booking-details__item"><b class="visible-xs-block">Guider</b><span class="glyphicon glyphicon-user" aria-hidden="true"></span> <span class="t-guider"><%= @appointment.guider.name %></span> </td>
           <td class="booking-details__item"><b class="visible-xs-block">Appointment date/time</b><span class="glyphicon glyphicon-calendar" aria-hidden="true"></span> <span class="t-appointment-date-time"><%= @appointment.start_at.to_date.to_formatted_s(:govuk_date_short) %>, <%= @appointment.start_at.to_formatted_s(:govuk_time) %> - <%= @appointment.end_at.to_formatted_s(:govuk_time) %></span></td>
           <td class="booking-details__item"><b class="visible-xs-block">Appointment created</b><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span> <span class="t-created-date"><%= @appointment.created_at.in_time_zone('London').to_formatted_s(:govuk_date_short) %></span></td>
         </tr>

--- a/app/views/appointments/search.html.erb
+++ b/app/views/appointments/search.html.erb
@@ -69,7 +69,7 @@
       <tr class="appointment-search-results__row t-result">
         <td class="appointment-search-results__item"><b class="visible-xs-block">Reference</b><span class="id t-id"><%= link_to "##{result.id}", edit_appointment_path(result) %></span><% if result.due_diligence? %> <small>(PSG)</small><% end %></td>
         <td class="appointment-search-results__item"><b class="visible-xs-block">Customer</b><span class="js-allow-highlighting t-name"><%= result.name %></span></td>
-        <td class="appointment-search-results__item"><b class="visible-xs-block">Guider</b><span class="js-allow-highlighting"><%= result.guider_name %></span> <small>(<%= result.guider_organisation %>)</small></td>
+        <td class="appointment-search-results__item"><b class="visible-xs-block">Guider</b><span class="js-allow-highlighting"><%= result.guider_name %></span></td>
         <td class="appointment-search-results__item"><b class="visible-xs-block">Appointment Date/Time</b><%= result.date %></td>
         <td class="appointment-search-results__item"><b class="visible-xs-block">Created</b><%= result.created_at %></td>
         <td class="appointment-search-results__item"><b class="visible-xs-block">Status</b><%= result.status %> <%= processed_tick(result) %></td>

--- a/app/views/online_reschedulings/index.html.erb
+++ b/app/views/online_reschedulings/index.html.erb
@@ -64,7 +64,7 @@
       <tr class="appointment-search-results__row t-result">
         <td class="appointment-search-results__item"><b class="visible-xs-block">Reference</b><span class="id t-id"><%= link_to "##{result.reference}", edit_appointment_path(result.appointment), class: 't-edit-link' %></span></td>
         <td class="appointment-search-results__item"><b class="visible-xs-block">Customer</b><span class="js-allow-highlighting t-name"><%= result.customer_name %></span></td>
-        <td class="appointment-search-results__item"><b class="visible-xs-block">Guider</b><span class="js-allow-highlighting t-previous-guider-name"><%= result.previous_guider_name %></span> <small>(<%= result.previous_guider_organisation %>)</small></td>
+        <td class="appointment-search-results__item"><b class="visible-xs-block">Guider</b><span class="js-allow-highlighting t-previous-guider-name"><%= result.previous_guider_name %></span></td>
         <td class="appointment-search-results__item t-appointment-date-time"><b class="visible-xs-block">Original Date/Time</b><%= result.date %></td>
         <td class="appointment-search-results__item t-appointment-new-date-time"><b class="visible-xs-block">New Date/Time</b><%= result.new_date %></td>
         <td class="appointment-search-results__item t-rescheduled-date-time"><b class="visible-xs-block">Rescheduled At</b><%= result.rescheduled_at %></td>

--- a/spec/features/resource_manager_reschedules_an_appointment_spec.rb
+++ b/spec/features/resource_manager_reschedules_an_appointment_spec.rb
@@ -105,8 +105,6 @@ RSpec.feature 'Resource manager reschedules an appointment', js: true do
 
     @page = Pages::EditAppointment.new
     expect(@page).to be_displayed
-
-    expect(@page.guider).to have_text('CAS')
   end
 
   def when_they_choose_an_internal_slot
@@ -140,8 +138,6 @@ RSpec.feature 'Resource manager reschedules an appointment', js: true do
 
     @page = Pages::EditAppointment.new
     expect(@page).to be_displayed
-
-    expect(@page.guider).to have_text('TPAS')
   end
 
   def and_there_are_matching_available_slots_across_multiple_organisations


### PR DESCRIPTION
This is no longer needed as all guiders belong to MaPS ops.