### PR TITLE
Improve reallocation calendar movements

### DIFF
--- a/app/assets/javascripts/modules/calendars/allocations.es6
+++ b/app/assets/javascripts/modules/calendars/allocations.es6
@@ -1,4 +1,4 @@
-/* global CompanyCalendar */
+/* global moment, CompanyCalendar */
 {
   'use strict';
 
@@ -23,7 +23,6 @@
 
       this.eventChanges = [];
       this.isFullscreen = false;
-      this.$actionPanel = $('.js-action-panel');
       this.$savedChanges = $('.js-saved-changes');
       this.$form = $('.js-changes-form');
       this.$holidayForm = $('.js-holiday-form');
@@ -36,7 +35,6 @@
       this.$rowHighlighterTime = $('<div class="calendar-row-highlighter-time"/>').insertAfter(this.$el);
 
       this.setCalendarToCorrectHeight();
-      this.setupUndo();
     }
 
     bindEvents() {
@@ -49,7 +47,6 @@
     afterChangesSaved() {
       this.eventChanges = [];
       this.clearUnloadEvent();
-      this.checkToShowActionPanel();
       this.$el.fullCalendar('refetchEvents');
       this.$savedChanges.show();
       this.showAlert('.alert-success');
@@ -110,10 +107,6 @@
         height -= 20;
       }
 
-      if (this.$actionPanel.is(':visible')) {
-        height -= this.$actionPanel.height();
-      }
-
       return height;
     }
 
@@ -127,7 +120,8 @@
 
     eventDrop(event, delta, revertFunc) {
       this.$modal = $('#rescheduling-reasons-modal');
-      this.$modal.find('.js-modal-title').text(`Reason for rescheduling ${event.title} #${event.id}`);
+      this.$modal.find('.js-modal-title').text(`Reschedule ${event.title} #${event.id}`);
+      this.bindReschedulingPanels(this.$modal, event);
       this.$modal.find('.js-save').one(
         'click',
         {event: event, revertFunc: revertFunc},
@@ -147,6 +141,19 @@
       $('#client-rescheduled-route,#office-rescheduled-route,#office-reallocated-route').hide();
 
       this.$modal.modal({keyboard: false});
+    }
+
+    bindReschedulingPanels(modal, event) {
+      this.bindReschedulingPanel(modal, 'before', event.originalStart, event.originalEnd, event.originalResourceId);
+      this.bindReschedulingPanel(modal, 'after', event.start, event.end, event.resourceId);
+    }
+
+    bindReschedulingPanel(modal, label, start, end, resourceId) {
+      const timeFormat = 'h:mma';
+
+      modal.find(`.js-${label}-start`).text(moment.utc(start).format(timeFormat));
+      modal.find(`.js-${label}-end`).text(moment.utc(end).format(timeFormat));
+      modal.find(`.js-${label}-guider`).text(this.$el.fullCalendar('getResourceById', resourceId).title);
     }
 
     assignReschedulingReason(e) {
@@ -173,6 +180,7 @@
 
           this.handleEventChange(e.data.event, e.data.revertFunc);
           this.$modal.modal('hide');
+          this.save();
         }
       }
 
@@ -245,12 +253,6 @@
       $(`tr[data-time]`).find('.fc-time').removeClass('active');
     }
 
-    setupUndo() {
-      this.$actionPanel.find('.js-action-panel-undo-all').on('click', this.undoAllChanges.bind(this));
-      this.$actionPanel.find('.js-action-panel-undo-one').on('click', this.undoOneChange.bind(this));
-      this.$actionPanel.find('.js-action-panel-save').on('click', this.save.bind(this));
-    }
-
     handleEventChange(event, revertFunc) {
       event.hasChanged = true;
 
@@ -260,8 +262,6 @@
       });
 
       this.$el.fullCalendar('rerenderEvents');
-
-      this.checkToShowActionPanel();
     }
 
     undoOneChange(evt) {
@@ -273,8 +273,6 @@
       event.eventObj.hasChanged = this.hasEventChanged(event.eventObj);
 
       this.rerenderEvents();
-
-      this.checkToShowActionPanel();
     }
 
     hasEventChanged(event) {
@@ -297,14 +295,11 @@
 
       this.eventChanges = [];
       this.rerenderEvents();
-
-      this.checkToShowActionPanel();
     }
 
-    save(evt) {
+    save() {
       const $hiddenInput = this.$form.find('#event-changes');
 
-      evt.preventDefault();
       this.$savedChanges.hide();
       $hiddenInput.val(this.getEventChangesForForm());
       this.$form.submit();
@@ -340,26 +335,6 @@
       // events who are left in red after event changes are undone
       this.$el.fullCalendar('rerenderEvents');
       this.$el.fullCalendar('rerenderEvents');
-    }
-
-    checkToShowActionPanel() {
-      const eventsChanged = this.uniqueEventsChanged();
-
-      let fadeAction = 'fadeIn';
-
-      if (eventsChanged > 0) {
-        this.$actionPanel.find('.js-action-panel-event-count').html(
-          `${eventsChanged} event${eventsChanged == 1 ? '':'s'}`
-        );
-        this.setUnloadEvent();
-      } else {
-        fadeAction = 'fadeOut';
-        this.clearUnloadEvent();
-      }
-
-      this.$actionPanel[fadeAction]({
-        complete: this.alterHeight.bind(this)
-      });
     }
 
     uniqueEventsChanged() {

--- a/app/serializers/appointment_serializer.rb
+++ b/app/serializers/appointment_serializer.rb
@@ -12,6 +12,9 @@ class AppointmentSerializer < ActiveModel::Serializer
   attribute :cancelled
   attribute :no_show?, key: :noShow
   attribute :guider_id, key: :resourceId
+  attribute :guider_id, key: :originalResourceId
+  attribute :start_at, key: :originalStart
+  attribute :end_at, key: :originalEnd
   attribute :pension_wise?, key: :pensionWise
   attribute :extended_duration?, key: :extendedDuration
   attribute :ms_teams_call?, key: :msTeamsCall

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -29,20 +29,6 @@
 
 <div class="action-panel t-action-panel js-action-panel">
   <%= form_tag batch_update_appointments_path, method: :patch, remote: true, class: 'js-changes-form' do %>
-    <button class="btn btn-primary t-save js-action-panel-save">
-      <span class="glyphicon glyphicon-save" aria-hidden="true"></span> Save changes to
-      <b>
-        <span class="js-action-panel-event-count">0 events</span>
-      </b>
-    </button>
-
-    <button class="btn btn-warning js-action-panel-undo-one">
-      <span class="glyphicon glyphicon-step-backward" aria-hidden="true"></span> Undo last change
-    </button>
-
-    <button class="btn btn-danger js-action-panel-undo-all">
-      <span class="glyphicon glyphicon-erase" aria-hidden="true"></span> Undo <b>all</b> changes
-    </button>
     <input type="hidden" name="changes" id="event-changes">
   <% end %>
 </div>
@@ -54,6 +40,27 @@
         <h4 class="modal-title js-modal-title" id="rescheduling-reasons-modal-label">Reason</h4>
       </div>
       <div class="modal-body" data-module="radio-toggle">
+        <div class="row">
+          <div class="col-md-6">
+            <div class="panel panel-default">
+              <div class="panel-heading"><h4 class="panel-title">Before</h4></div>
+              <div class="panel-body">
+                Time: <span class="js-before-start t-before-start"></span> - <span class="js-before-end"></span><br>
+                Guider: <span class="js-before-guider t-before-guider"></span>
+              </div>
+            </div>
+          </div>
+
+          <div class="col-md-6">
+            <div class="panel panel-default">
+              <div class="panel-heading"><h3 class="panel-title">After</h3></div>
+              <div class="panel-body">
+                Time: <span class="js-after-start t-after-start"></span> - <span class="js-after-end"></span><br>
+                Guider: <span class="js-after-guider t-after-guider"></span>
+              </div>
+            </div>
+          </div>
+        </div>
         <div class="radio">
           <div class="form-group">
             <div class="radio">

--- a/spec/features/guider_views_appointments_spec.rb
+++ b/spec/features/guider_views_appointments_spec.rb
@@ -104,10 +104,6 @@ RSpec.feature 'Guider views appointments' do
     @page.rescheduling_reason_modal.wait_until_via_unplanned_absence_visible
     @page.rescheduling_reason_modal.via_unplanned_absence.set(true)
     @page.rescheduling_reason_modal.save.click
-
-    @page.wait_until_action_panel_visible
-    @page.action_panel.save.click
-    @page.wait_until_saved_changes_message_visible
   end
 
   def then_they_are_notified_of_the_change

--- a/spec/features/resource_manager_modifies_appointments_spec.rb
+++ b/spec/features/resource_manager_modifies_appointments_spec.rb
@@ -39,7 +39,6 @@ RSpec.feature 'Resource manager modifies appointments' do
         when_they_view_the_appointments
         then_they_see_appointments_for_multiple_guiders
         when_they_change_the_guider
-        and_commit_their_modifications
         then_the_guider_is_modified
         and_no_customer_notifications_are_sent
       end
@@ -69,7 +68,6 @@ RSpec.feature 'Resource manager modifies appointments' do
         when_they_view_the_appointments
         then_they_see_appointments_for_multiple_guiders
         when_they_reschedule_an_appointment
-        and_commit_their_modifications
         then_the_appointment_is_modified
         and_the_customer_is_notified_of_the_appointment_change
       end
@@ -208,6 +206,12 @@ RSpec.feature 'Resource manager modifies appointments' do
 
     # this is being triggered for test purposes only
     @page.wait_until_rescheduling_reason_modal_visible
+
+    expect(@page.rescheduling_reason_modal.before_guider.text).to eq('Ben Lovell')
+    expect(@page.rescheduling_reason_modal.before_start.text).to eq('9:00am')
+    expect(@page.rescheduling_reason_modal.after_guider.text).to eq('Jan Schwifty')
+    expect(@page.rescheduling_reason_modal.after_start.text).to eq('9:00am')
+
     @page.rescheduling_reason_modal.pension_wise.set(true)
     @page.rescheduling_reason_modal.wait_until_via_unplanned_absence_visible
     @page.rescheduling_reason_modal.via_unplanned_absence.set(true)
@@ -215,6 +219,7 @@ RSpec.feature 'Resource manager modifies appointments' do
   end
 
   def then_the_guider_is_modified
+    @page.wait_until_saved_changes_message_visible
     expect(@appointment.reload.guider_id).to eq(@jan.id)
   end
 
@@ -258,6 +263,12 @@ RSpec.feature 'Resource manager modifies appointments' do
 
     wait_for_ajax_to_complete
     @page.wait_until_rescheduling_reason_modal_visible
+
+    expect(@page.rescheduling_reason_modal.before_guider.text).to eq('Ben Lovell')
+    expect(@page.rescheduling_reason_modal.before_start.text).to eq('9:00am')
+    expect(@page.rescheduling_reason_modal.after_guider.text).to eq('Ben Lovell')
+    expect(@page.rescheduling_reason_modal.after_start.text).to eq('1:30pm')
+
     @page.rescheduling_reason_modal.pension_wise.set(true)
     expect(@page.rescheduling_reason_modal).to have_no_via_phone
     @page.rescheduling_reason_modal.client.set(true)
@@ -266,13 +277,8 @@ RSpec.feature 'Resource manager modifies appointments' do
     @page.rescheduling_reason_modal.save.click
   end
 
-  def and_commit_their_modifications
-    @page.wait_until_action_panel_visible
-    @page.action_panel.save.click
-    @page.wait_until_saved_changes_message_visible
-  end
-
   def then_the_appointment_is_modified
+    @page.wait_until_saved_changes_message_visible
     @appointment.reload
 
     expect(@appointment.start_at.hour).to eq(13)

--- a/spec/support/pages/allocations.rb
+++ b/spec/support/pages/allocations.rb
@@ -10,11 +10,12 @@ module Pages
     element :saved_changes_message, '.t-saved-changes'
     element :due_diligence_grace_period, '.t-due-diligence-grace-period'
 
-    section :action_panel, '.t-action-panel' do
-      element :save, '.t-save'
-    end
-
     section :rescheduling_reason_modal, '.t-rescheduling-reason-modal' do
+      element :before_guider, '.t-before-guider'
+      element :before_start, '.t-before-start'
+      element :after_guider, '.t-after-guider'
+      element :after_start, '.t-after-start'
+
       element :pension_wise, '.t-pension-wise-rescheduled'
       element :client, '.t-client-rescheduled'
       element :via_phone, '.t-via-phone'


### PR DESCRIPTION
This negates the now unnecessary 'action panel' that was used for batches. We now move singular appointments and the modal displays the before/after details. Clicking 'save' will complete the full action rather than then also having to confirm the 'batch' using the 'action panel'.