### PR TITLE
Switch to a POST to permit complex holidays

### DIFF
--- a/app/views/holidays/_form.html.erb
+++ b/app/views/holidays/_form.html.erb
@@ -161,23 +161,6 @@
       <% if params[:id].present? %>
         <%=
           link_to(
-            'Duplicate holiday',
-            new_copy_holidays_path(
-              batch_upsert_holidays: {
-                holiday_ids: params[:id],
-                title: holiday.title,
-                users: holiday.users,
-                description: holiday.description,
-                additional_information: holiday.additional_information,
-                all_day: holiday.all_day,
-                start_at: holiday.start_at,
-                end_at: holiday.end_at
-            }),
-            class: 'btn btn-default t-duplicate'
-          )
-        %>
-        <%=
-          link_to(
             'Delete holiday',
             holidays_path(holiday_ids: params[:id]),
             method: :delete,

--- a/app/views/holidays/edit.html.erb
+++ b/app/views/holidays/edit.html.erb
@@ -10,3 +10,25 @@
 <%= form_for @holiday, url: batch_upsert_holidays_path(id: params[:id]), method: :patch, layout: :basic do |f| %>
   <%= render 'form', form: f, holiday: @holiday, guider_options: guider_options(current_user, include_reset: false), recurrence: false %>
 <% end %>
+
+<br>
+<%=
+  button_to(
+    'Duplicate holiday',
+    new_copy_holidays_path,
+    params: {
+      batch_upsert_holidays: {
+        holiday_ids: params[:id],
+        title: @holiday.title,
+        users: @holiday.users,
+        description: @holiday.description,
+        additional_information: @holiday.additional_information,
+        all_day: @holiday.all_day,
+        start_at: @holiday.start_at,
+        end_at: @holiday.end_at
+      }
+    },
+    class: 'btn btn-default t-duplicate',
+    method: :post
+  )
+%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,7 +76,7 @@ Rails.application.routes.draw do
     end
     delete '/', on: :collection, action: :destroy
     get 'merged', on: :collection
-    get 'new_copy', on: :collection
+    post 'new_copy', on: :collection
   end
   resources :bookable_slots, only: :index do
     collection do


### PR DESCRIPTION
As a link this was exceeding the maximum querystring length in some browsers for complex holidays.